### PR TITLE
style(GIconButton): fox wrong border style declaration

### DIFF
--- a/components/icon-button/package.json
+++ b/components/icon-button/package.json
@@ -20,7 +20,7 @@
     "url": "https://github.com/Flash-Global66/global-design-system.git"
   },
   "peerDependencies": {
-    "@flash-global66/g-icon-font": "^0.0.8",
+    "@flash-global66/g-icon-font": "^0.9.0",
     "element-plus": "^2.9.0",
     "vue": "^3.2.0"
   },

--- a/components/icon-button/src/icon-button.styles.scss
+++ b/components/icon-button/src/icon-button.styles.scss
@@ -84,7 +84,7 @@
   }
 
   @include m("border") {
-    @apply rounded-sm border-1;
+    @apply rounded-sm border;
 
     &.is-disabled {
       --color-border-disabled: theme(colors.grey.300);

--- a/components/icon-font/src/icon-sets.ts
+++ b/components/icon-font/src/icon-sets.ts
@@ -174,6 +174,7 @@ export const ICON_SETS = {
     "webhook",
     "tag",
     "sliders",
+    "sliders-simple",
     "ballot-check",
     "ballot",
     "bell",

--- a/components/icon-font/src/lib/far-regular-pro.ts
+++ b/components/icon-font/src/lib/far-regular-pro.ts
@@ -75,6 +75,7 @@ export {
   faWebhook,
   faTag,
   faSliders,
+  faSlidersSimple,
   faBallotCheck,
   faBallot,
   faBell,


### PR DESCRIPTION
Este PR realiza las siguientes tareas:
- Componente `GIConButton`:
  - Chore: actualiza dependencia de `GIconFont` a su última versión.
  - Fix: se modifica el estilo `border-1` a `border`, ya que `border-1` no es una clase de Tailwind y generar error al implementar

- Componente `GIconFont`: 
  - Feat: agrega un nuevo ícono, necesario para `GIconButton`