### PR TITLE
feat(checkbox): add new style with borders

### DIFF
--- a/components/checkbox/src/checkbox-group.ts
+++ b/components/checkbox/src/checkbox-group.ts
@@ -1,10 +1,18 @@
-import { UPDATE_MODEL_EVENT, useAriaProps } from 'element-plus'
-import { buildProps, definePropType, isArray } from 'element-plus/es/utils/index.mjs'
+import { UPDATE_MODEL_EVENT, useAriaProps } from "element-plus";
+import {
+  buildProps,
+  definePropType,
+  isArray,
+} from "element-plus/es/utils/index.mjs";
 
-import type { ExtractPropTypes, PropType } from 'vue'
-import type checkboxGroup from './checkbox-group.vue'
-import type { CheckboxValueType } from './checkbox'
-import { CheckboxGroupValueType, layoutType, Option } from './checkbox-group.types'
+import type { ExtractPropTypes, PropType } from "vue";
+import type checkboxGroup from "./checkbox-group.vue";
+import type { CheckboxValueType } from "./checkbox";
+import {
+  CheckboxGroupValueType,
+  layoutType,
+  Option,
+} from "./checkbox-group.types";
 
 export const checkboxGroupProps = buildProps({
   /**
@@ -12,14 +20,14 @@ export const checkboxGroupProps = buildProps({
    */
   modelValue: {
     type: definePropType<CheckboxGroupValueType>(Array),
-    default: () => []
+    default: () => [],
   },
   /**
    * @description options for building checkboxes
    */
   options: {
     type: Array as PropType<Option[]>,
-    default: () => []
+    default: () => [],
   },
   /**
    * @description whether the nesting checkboxes are disabled
@@ -38,30 +46,46 @@ export const checkboxGroupProps = buildProps({
    */
   layout: {
     type: String as PropType<layoutType>,
-    default: 'horizontal'
+    default: "horizontal",
   },
   /**
    * @description element tag of the checkbox group
    */
   tag: {
     type: String,
-    default: 'div'
+    default: "div",
   },
   /**
    * @description whether to trigger form validation
    */
   validateEvent: {
     type: Boolean,
-    default: true
+    default: true,
   },
-  ...useAriaProps(['ariaLabel'])
-} as const)
+  /**
+   * @description show the checkbox with bordered style
+   */
+  border: {
+    type: Boolean,
+    default: false,
+  },
+  /**
+   * @description show the checkbox with inverted order of label and check input
+   */
+  invert: {
+    type: Boolean,
+    default: false,
+  },
+  ...useAriaProps(["ariaLabel"]),
+} as const);
 
 export const checkboxGroupEmits = {
-  [UPDATE_MODEL_EVENT]: (val: CheckboxGroupValueType | CheckboxGroupValueType[]) => isArray(val),
-  change: (val: CheckboxValueType[] | CheckboxGroupValueType[]) => isArray(val)
-}
+  [UPDATE_MODEL_EVENT]: (
+    val: CheckboxGroupValueType | CheckboxGroupValueType[]
+  ) => isArray(val),
+  change: (val: CheckboxValueType[] | CheckboxGroupValueType[]) => isArray(val),
+};
 
-export type CheckboxGroupProps = ExtractPropTypes<typeof checkboxGroupProps>
-export type CheckboxGroupEmits = typeof checkboxGroupEmits
-export type CheckboxGroupInstance = InstanceType<typeof checkboxGroup>
+export type CheckboxGroupProps = ExtractPropTypes<typeof checkboxGroupProps>;
+export type CheckboxGroupEmits = typeof checkboxGroupEmits;
+export type CheckboxGroupInstance = InstanceType<typeof checkboxGroup>;

--- a/components/checkbox/src/checkbox-group.vue
+++ b/components/checkbox/src/checkbox-group.vue
@@ -4,7 +4,9 @@
     :id="groupId"
     :class="compKls"
     role="group"
-    :aria-label="!isLabeledByFormItem ? ariaLabel || 'checkbox-group' : undefined"
+    :aria-label="
+      !isLabeledByFormItem ? ariaLabel || 'checkbox-group' : undefined
+    "
     :aria-labelledby="isLabeledByFormItem ? formItem?.labelId : undefined"
   >
     <g-checkbox
@@ -15,82 +17,86 @@
       :label="item?.label ?? item.value"
       :disabled="item?.disabled"
       :checked="item?.checked"
+      :border="props.border"
+      :invert="props.invert"
     />
     <slot v-else />
   </component>
 </template>
 
 <script lang="ts" setup>
-import { computed, nextTick, onMounted, provide, toRefs, watch } from 'vue'
-import { pick } from 'lodash-unified'
-import { GCheckbox } from '../index'
-import { UPDATE_MODEL_EVENT, useNamespace } from 'element-plus'
-import { debugWarn } from 'element-plus/es/utils/index.mjs'
-import { useFormItem, useFormItemInputId } from '@flash-global66/g-form'
+import { computed, nextTick, onMounted, provide, toRefs, watch } from "vue";
+import { pick } from "lodash-unified";
+import { GCheckbox } from "../index";
+import { UPDATE_MODEL_EVENT, useNamespace } from "element-plus";
+import { debugWarn } from "element-plus/es/utils/index.mjs";
+import { useFormItem, useFormItemInputId } from "@flash-global66/g-form";
 
-import { checkboxGroupEmits, checkboxGroupProps } from './checkbox-group'
-import { checkboxGroupContextKey } from './constants'
-import type { CheckboxGroupValueType, klsByType } from './checkbox-group.types'
+import { checkboxGroupEmits, checkboxGroupProps } from "./checkbox-group";
+import { checkboxGroupContextKey } from "./constants";
+import type { CheckboxGroupValueType, klsByType } from "./checkbox-group.types";
 
 defineOptions({
-  name: 'GuiCheckboxGroup'
-})
+  name: "GuiCheckboxGroup",
+});
 
-const props = defineProps(checkboxGroupProps)
-const emit = defineEmits(checkboxGroupEmits)
-const ns = useNamespace('checkbox')
+const props = defineProps(checkboxGroupProps);
+const emit = defineEmits(checkboxGroupEmits);
+const ns = useNamespace("checkbox");
 
-const { formItem } = useFormItem()
+const { formItem } = useFormItem();
 const { inputId: groupId, isLabeledByFormItem } = useFormItemInputId(props, {
-  formItemContext: formItem
-})
+  formItemContext: formItem,
+});
 
-const changeEvent = async (value: CheckboxGroupValueType | CheckboxGroupValueType[]) => {
-  emit(UPDATE_MODEL_EVENT, value)
-  await nextTick()
-  emit('change', value)
-}
+const changeEvent = async (
+  value: CheckboxGroupValueType | CheckboxGroupValueType[]
+) => {
+  emit(UPDATE_MODEL_EVENT, value);
+  await nextTick();
+  emit("change", value);
+};
 
 const modelValue = computed({
   get() {
-    return props.modelValue
+    return props.modelValue;
   },
   set(val: CheckboxGroupValueType | CheckboxGroupValueType[]) {
-    changeEvent(val)
-  }
-})
+    changeEvent(val);
+  },
+});
 
 const klsByLayout: klsByType = {
-  horizontal: 'flex flex-row gap-4',
-  vertical: 'flex flex-col gap-4'
-}
+  horizontal: "flex flex-row gap-4",
+  vertical: "flex flex-col gap-4",
+};
 
 const compKls = computed(() => {
-  return [ns.b('group'), klsByLayout[props.layout]]
-})
+  return [ns.b("group"), klsByLayout[props.layout]];
+});
 
 provide(checkboxGroupContextKey, {
-  ...pick(toRefs(props), ['min', 'max', 'disabled', 'validateEvent']),
+  ...pick(toRefs(props), ["min", "max", "disabled", "validateEvent"]),
   modelValue,
-  changeEvent
-})
+  changeEvent,
+});
 
 onMounted(() => {
   const checkedValues = props.options
     .filter((item) => item.checked)
-    .map((item) => item.value)
-  
+    .map((item) => item.value);
+
   if (checkedValues.length > 0) {
-    modelValue.value = checkedValues as CheckboxGroupValueType
+    modelValue.value = checkedValues as CheckboxGroupValueType;
   }
-})
+});
 
 watch(
   () => props.modelValue,
   () => {
     if (props.validateEvent) {
-      formItem?.validate?.('change').catch((err) => debugWarn(err))
+      formItem?.validate?.("change").catch((err) => debugWarn(err));
     }
   }
-)
+);
 </script>

--- a/components/checkbox/src/checkbox.styles.scss
+++ b/components/checkbox/src/checkbox.styles.scss
@@ -33,12 +33,23 @@
     }
   }
 
+  @include when(border) {
+    @apply justify-between p-xs border border-disab-lt-bd rounded-md h-12;
+  }
+
+  @include when(invert) {
+    @apply flex flex-row-reverse gap-xxs;
+    @include e(inner) {
+      @apply ml-xs
+    }
+  }
+
   @include e(label) {
     @apply p-0 text-secondary-txt text-pretty leading-snug;
   }
 
   @include e(input) {
-    @apply self-start;
+    @apply self-center;
 
     @include when(indeterminate) {
       @include e(inner) {
@@ -74,7 +85,7 @@
   }
 
   @include e(inner) {
-    @apply w-[18px] h-[18px] border-disabled-bd border rounded mr-[7px] bg-transparent;
+    @apply w-[18px] h-[18px] border-disabled-bd border rounded mr-xs bg-transparent;
 
     &::after {
       @apply w-[3px] h-2 top-0.5 left-1.5 absolute;

--- a/components/checkbox/src/checkbox.ts
+++ b/components/checkbox/src/checkbox.ts
@@ -1,10 +1,10 @@
-import { UPDATE_MODEL_EVENT, useAriaProps } from 'element-plus'
-import { isBoolean, isNumber, isString } from 'element-plus/es/utils/index.mjs'
+import { UPDATE_MODEL_EVENT, useAriaProps } from "element-plus";
+import { isBoolean, isNumber, isString } from "element-plus/es/utils/index.mjs";
 
-import type { ExtractPropTypes } from 'vue'
-import Checkbox from './checkbox.vue'
+import type { ExtractPropTypes } from "vue";
+import Checkbox from "./checkbox.vue";
 
-export type CheckboxValueType = string | number | boolean
+export type CheckboxValueType = string | number | boolean;
 
 export const checkboxProps = {
   /**
@@ -12,21 +12,21 @@ export const checkboxProps = {
    */
   modelValue: {
     type: [Number, String, Boolean],
-    default: undefined
+    default: undefined,
   },
   /**
    * @description label of the Checkbox when used inside a `checkbox-group`
    */
   label: {
     type: [String, Boolean, Number, Object],
-    default: undefined
+    default: undefined,
   },
   /**
    * @description value of the Checkbox when used inside a `checkbox-group`
    */
   value: {
     type: [String, Boolean, Number, Object],
-    default: undefined
+    default: undefined,
   },
   /**
    * @description Set indeterminate state, only responsible for style control
@@ -45,28 +45,28 @@ export const checkboxProps = {
    */
   name: {
     type: String,
-    default: undefined
+    default: undefined,
   },
   /**
    * @description value of the Checkbox if it's checked
    */
   trueValue: {
     type: [String, Number],
-    default: undefined
+    default: undefined,
   },
   /**
    * @description value of the Checkbox if it's not checked
    */
   falseValue: {
     type: [String, Number],
-    default: undefined
+    default: undefined,
   },
   /**
    * @description input id
    */
   id: {
     type: String,
-    default: undefined
+    default: undefined,
   },
   /**
    * @description input tabindex
@@ -77,17 +77,32 @@ export const checkboxProps = {
    */
   validateEvent: {
     type: Boolean,
-    default: true
+    default: true,
   },
-  ...useAriaProps(['ariaControls'])
-}
+  /**
+   * @description show the checkbox with bordered style
+   */
+  border: {
+    type: Boolean,
+    default: false,
+  },
+  /**
+   * @description show the checkbox with inverted order of label and check input
+   */
+  invert: {
+    type: Boolean,
+    default: false,
+  },
+  ...useAriaProps(["ariaControls"]),
+};
 
 export const checkboxEmits = {
   [UPDATE_MODEL_EVENT]: (val: CheckboxValueType) =>
     isString(val) || isNumber(val) || isBoolean(val),
-  change: (val: CheckboxValueType) => isString(val) || isNumber(val) || isBoolean(val)
-}
+  change: (val: CheckboxValueType) =>
+    isString(val) || isNumber(val) || isBoolean(val),
+};
 
-export type CheckboxProps = ExtractPropTypes<typeof checkboxProps>
-export type CheckboxEmits = typeof checkboxEmits
-export type CheckboxInstance = InstanceType<typeof Checkbox>
+export type CheckboxProps = ExtractPropTypes<typeof checkboxProps>;
+export type CheckboxEmits = typeof checkboxEmits;
+export type CheckboxInstance = InstanceType<typeof Checkbox>;

--- a/components/checkbox/src/checkbox.vue
+++ b/components/checkbox/src/checkbox.vue
@@ -1,6 +1,6 @@
 <template>
   <component
-    :is="!hasOwnLabel && isLabeledByFormItem ? 'span' : 'label'"
+    :is="baseComponent"
     :class="compKls"
     :aria-controls="indeterminate ? ariaControls : null"
     @click="onClickRoot"
@@ -30,10 +30,10 @@
         :class="ns.e('original')"
         type="checkbox"
         :indeterminate="indeterminate"
-        :disabled="isDisabled"
-        :value="actualValue"
         :name="name"
         :tabindex="tabindex"
+        :disabled="isDisabled"
+        :value="actualValue"
         @change="handleChange"
         @focus="isFocused = true"
         @blur="isFocused = false"
@@ -55,18 +55,18 @@
 </template>
 
 <script lang="ts" setup>
-import { computed, useSlots } from 'vue'
-import { useNamespace } from 'element-plus'
-import { checkboxEmits, checkboxProps } from './checkbox'
-import { useCheckbox } from './composables'
+import { computed, useSlots } from "vue";
+import { useNamespace } from "element-plus";
+import { checkboxEmits, checkboxProps } from "./checkbox";
+import { useCheckbox } from "./composables";
 
 defineOptions({
-  name: 'GuiCheckbox'
-})
+  name: "GuiCheckbox",
+});
 
-const props = defineProps(checkboxProps)
-defineEmits(checkboxEmits)
-const slots = useSlots()
+const props = defineProps(checkboxProps);
+defineEmits(checkboxEmits);
+const slots = useSlots();
 
 const {
   actualValue,
@@ -79,26 +79,32 @@ const {
   isFocused,
   isLabeledByFormItem,
   model,
-  onClickRoot
-} = useCheckbox(props, slots)
+  onClickRoot,
+} = useCheckbox(props, slots);
 
-const ns = useNamespace('checkbox')
+const ns = useNamespace("checkbox");
+
+const baseComponent = computed(() => {
+  return !hasOwnLabel.value && isLabeledByFormItem ? "span" : "label";
+});
 
 const compKls = computed(() => {
   return [
     ns.b(),
-    ns.is('disabled', isDisabled.value),
-    ns.is('checked', isChecked.value),
-  ]
-})
+    ns.is("disabled", isDisabled.value),
+    ns.is("checked", isChecked.value),
+    ns.is("border", props.border),
+    ns.is("invert", props.invert),
+  ];
+});
 
 const spanKls = computed(() => {
   return [
-    ns.e('input'),
-    ns.is('disabled', isDisabled.value),
-    ns.is('checked', isChecked.value),
-    ns.is('indeterminate', props.indeterminate),
-    ns.is('focus', isFocused.value),
-  ]
-})
+    ns.e("input"),
+    ns.is("disabled", isDisabled.value),
+    ns.is("checked", isChecked.value),
+    ns.is("indeterminate", props.indeterminate),
+    ns.is("focus", isFocused.value),
+  ];
+});
 </script>

--- a/stories/checkbox-group.stories.ts
+++ b/stories/checkbox-group.stories.ts
@@ -1,31 +1,84 @@
-import type { Meta, StoryObj } from '@storybook/vue3'
-import { ref } from 'vue'
-import { GCheckbox, GCheckboxGroup, CheckboxGroupProps } from '@flash-global66/g-checkbox/index.ts'
-import { GConfigProvider } from '../components/config-provider'
+import type { Meta, StoryObj } from "@storybook/vue3";
+import { ref } from "vue";
+
+// COMPONENTS
+import {
+  GCheckbox,
+  GCheckboxGroup,
+  CheckboxGroupProps,
+} from "@flash-global66/g-checkbox/index.ts";
+
+// CONFIG
+import { GConfigProvider } from "../components/config-provider";
+
+// VERSION
+import {
+  version,
+  peerDependencies,
+} from "@flash-global66/g-checkbox/package.json";
+
+// HELPERS
+import {
+  generatePeerDepsList,
+  generatePeerDepsInstalls,
+} from "../helper/documentation-stories";
 
 const meta: Meta<typeof GCheckboxGroup> = {
-  title: 'Form/Checkbox/Group',
+  title: "Form/Checkbox/Group",
   component: GCheckboxGroup,
   parameters: {
     docs: {
       description: {
         component: `
-El componente \`GCheckboxGroup\` es un grupo de checkboxes que permite selección múltiple con validación y configuración visual. Existen dos maneras
-de construir el grupo: mediante la propiedad \`options\` o con los slots predeterminados.
+El componente GCheckboxGroup es un grupo de checkboxes que permite selección múltiple con validación y configuración visual. 
 
-### Instalación
+> Versión actual: ${version}
+
+## Características
+
+La función principal del componente es la de agrupar un conjunto de Checkboxes y vincularlos a un mismo estado de referencia, y es por este motivo que el componente hereda todas las características del componente Checkbox, pudiendo personalizarse en mayor o menor medida de acuerdo a como se declaren las opciones del grupo.
+
+Todas las propiedades que se declaran en el componente aplican a todos los checkboxes incluidos en el grupo. Si se desea utilizar un estado por defecto en un elemento del grupo en particular, se puede realizar de las dos maneras en las que se pueden declarar los elementos del mismo:
+
+- Si el componente toma las opciones a través de la propiedad \`options\`, estas se deben declarar como un array de objetos con -como mínimo-, los atributos \`value\` y \`label\`. También se pueden agregar props que indiquen un estado por defecto para uno o mas elementos, simplemente agregando un atributo de tipo booleano, con el nombre de la prop que queremos declarar para ese elemento (por ejemplo: \`checked\`, \`disabled\` o \`indeterminate\`).
+- Si el componente toma las opciones a partir de slots con checkboxes individuales, se deben declarar al menos las propiedades de label y value de cada checkbox, y se pueden indicar estados y caracteristicas individuales a través de las props, tal como se indica en la documentación de estos componentes.
+
+> Se puede encontrar un ejemplo práctico en la sección de <a href="#uso-basico">Uso Básico</a>
+
+## Instalación
+
 \`\`\`bash
 yarn add @flash-global66/g-checkbox
 \`\`\`
 
-### Importación
+## Importación del componente
 
 \`\`\`typescript
+# importar donde se va a utilizar
 import { GCheckboxGroup } from '@flash-global66/g-checkbox'
-import '@flash-global66/g-checkbox/checkbox.styles.scss'
+
+# recomendado importar en los estilos globales
+@use '@flash-global66/g-checkbox/styles.scss' as *;
 \`\`\`
 
-### Ejemplo con slots personalizados:
+## Dependencias
+
+Este componente requiere:
+
+${generatePeerDepsList(peerDependencies)}
+
+\`\`\`bash
+# Dependencias global66
+yarn add ${generatePeerDepsInstalls(peerDependencies)}
+
+# Dependencias externas
+yarn add ${generatePeerDepsInstalls(peerDependencies, true)}
+\`\`\`
+
+<h2 id="uso-basico">Uso básico</h2>
+
+**Ejemplo con slots personalizados:**
+
 \`\`\`html
 <g-checkbox-group 
   v-bind="args"
@@ -36,37 +89,55 @@ import '@flash-global66/g-checkbox/checkbox.styles.scss'
 </g-checkbox-group>
 \`\`\`
 
-### Ejemplo con opciones predefinidas:
+**Ejemplo con opciones predefinidas:**
+
+\`\`\`javascript
+const selectedValues = ref([]);
+const options = [
+  { value: "Value A", label: "Importaciones" },
+  { value: "Value B", label: "Inversiones" },
+  { value: "Value C", label: "Exportaciones", checked: true },
+  { value: "Value D", label: "Transferencias", disabled: true },
+  { value: "Value E", label: "Otros", indeterminate: true },
+];
+
+const checkboxGroupProps = {
+    disabled: false,
+    layout: "horizontal",
+    ariaLabel: "Grupo de opciones",
+}
+\`\`\`
+
 \`\`\`html
 <g-checkbox-group
-  v-bind="args"
+  v-bind="checkboxGroupProps"
   v-model="selectedValues"
   :options="options"
 />
 \`\`\`
-        `
-      }
-    }
+        `,
+      },
+    },
   },
   argTypes: {
     // Estados
     disabled: {
-      description: 'Deshabilita todo el grupo',
-      control: 'boolean',
+      description: "Deshabilita todo el grupo",
+      control: "boolean",
       table: {
-        type: { summary: 'boolean' },
-        defaultValue: { summary: 'false' },
-        category: 'Estados'
-      }
+        type: { summary: "boolean" },
+        defaultValue: { summary: "false" },
+        category: "Estados",
+      },
     },
 
     // Principales
     options: {
-      description: 'Array de opciones para construir el grupo de checkboxes',
-      control: 'object',
+      description: "Array de opciones para construir el grupo de checkboxes",
+      control: "object",
       table: {
         type: {
-          summary: 'Option[]',
+          summary: "Option[]",
           detail: `
             type Option = {
   value: CheckboxGroupValueType
@@ -74,148 +145,165 @@ import '@flash-global66/g-checkbox/checkbox.styles.scss'
   disabled?: boolean
   checked?: boolean
 }
-          `
+          `,
         },
-        defaultValue: { summary: '[]' },
-        category: 'Principales'
-      }
+        defaultValue: { summary: "[]" },
+        category: "Principales",
+      },
     },
     modelValue: {
-      description: 'Valores seleccionados (v-model)',
-      control: 'object',
+      description: "Valores seleccionados (v-model)",
+      control: "object",
       table: {
         type: {
-          summary: 'CheckboxGroupValueType',
-          detail: 'Array<string | number | boolean>'
+          summary: "CheckboxGroupValueType",
+          detail: "Array<string | number | boolean>",
         },
-        defaultValue: { summary: '[]' },
-        category: 'Principales'
-      }
+        defaultValue: { summary: "[]" },
+        category: "Principales",
+      },
     },
 
     // Validación
     min: {
-      description: 'Mínimo de checkboxes seleccionados',
-      control: { type: 'number', min: 0 },
+      description: "Mínimo de checkboxes seleccionados",
+      control: { type: "number", min: 0 },
       table: {
-        type: { summary: 'number' },
-        category: 'Validación'
-      }
+        type: { summary: "number" },
+        category: "Validación",
+      },
     },
     max: {
-      description: 'Máximo de checkboxes seleccionados',
-      control: { type: 'number', min: 1 },
+      description: "Máximo de checkboxes seleccionados",
+      control: { type: "number", min: 1 },
       table: {
-        type: { summary: 'number' },
-        category: 'Validación'
-      }
+        type: { summary: "number" },
+        category: "Validación",
+      },
     },
     validateEvent: {
-      description: 'Activa validación de formulario',
-      control: 'boolean',
+      description: "Activa validación de formulario",
+      control: "boolean",
       table: {
-        type: { summary: 'boolean' },
-        defaultValue: { summary: 'true' },
-        category: 'Validación'
-      }
+        type: { summary: "boolean" },
+        defaultValue: { summary: "true" },
+        category: "Validación",
+      },
     },
 
     // Apariencia
     layout: {
-      description: 'Diseño del grupo',
-      control: 'select',
-      options: ['horizontal', 'vertical'],
+      description: "Diseño del grupo",
+      control: "select",
+      options: ["horizontal", "vertical"],
       table: {
-        type: { summary: 'layoutType', detail: "'horizontal' | 'vertical'" },
-        defaultValue: { summary: 'horizontal' },
-        category: 'Apariencia'
-      }
+        type: { summary: "layoutType", detail: "'horizontal' | 'vertical'" },
+        defaultValue: { summary: "horizontal" },
+        category: "Apariencia",
+      },
+    },
+    border: {
+      description: "Indica si debe mostrarse el checkbox con borde",
+      control: "boolean",
+      table: {
+        category: "Apariencia",
+        type: { summary: "boolean" },
+      },
+    },
+    invert: {
+      description:
+        "Indica si debe mostrarse el checkbox con el label y el check input invertidos",
+      control: "boolean",
+      table: {
+        category: "Apariencia",
+        type: { summary: "boolean" },
+      },
     },
 
     // Configuración avanzada
     tag: {
-      description: 'Elemento HTML contenedor',
-      control: 'select',
-      options: ['div', 'span', 'fieldset'],
+      description: "Elemento HTML contenedor",
+      control: "select",
+      options: ["div", "span", "fieldset"],
       table: {
-        type: { summary: 'string' },
-        defaultValue: { summary: 'div' },
-        category: 'Apariencia'
-      }
+        type: { summary: "string" },
+        defaultValue: { summary: "div" },
+        category: "Apariencia",
+      },
     },
 
     // Accesibilidad
     ariaLabel: {
-      description: 'Etiqueta ARIA para el grupo',
-      control: 'text',
+      description: "Etiqueta ARIA para el grupo",
+      control: "text",
       table: {
-        type: { summary: 'string' },
-        category: 'Accesibilidad'
-      }
+        type: { summary: "string" },
+        category: "Accesibilidad",
+      },
     },
 
     // Eventos
-    'onUpdate:modelValue': {
-      description: 'Se emite al actualizar los valores',
+    "onUpdate:modelValue": {
+      description: "Se emite al actualizar los valores",
       table: {
-        category: 'Eventos',
+        category: "Eventos",
         type: {
-          summary: 'CheckboxGroupValueType',
-          detail: 'Array<string | number>'
-        }
-      }
+          summary: "CheckboxGroupValueType",
+          detail: "Array<string | number>",
+        },
+      },
     },
     onChange: {
-      description: 'Se emite al cambiar la selección',
+      description: "Se emite al cambiar la selección",
       table: {
-        category: 'Eventos',
+        category: "Eventos",
         type: {
-          summary: 'CheckboxGroupValueType',
-          detail: 'Array<string | number>'
-        }
-      }
+          summary: "CheckboxGroupValueType",
+          detail: "Array<string | number>",
+        },
+      },
     },
 
     // Slots
     default: {
-      description: 'Slot para contenido personalizado de cada checkbox',
+      description: "Slot para contenido personalizado de cada checkbox",
       table: {
-        category: 'Slots',
+        category: "Slots",
         type: {
-          summary: 'slot',
-        }
-      }
-    }
+          summary: "slot",
+        },
+      },
+    },
   },
   args: {
     options: [],
     modelValue: [],
     disabled: false,
-    layout: 'horizontal',
-    tag: 'div',
+    layout: "horizontal",
+    tag: "div",
     min: undefined,
     max: undefined,
     validateEvent: true,
-    ariaLabel: 'Grupo de opciones'
-  } as Partial<CheckboxGroupProps>
-}
-export default meta
+    ariaLabel: "Grupo de opciones",
+  } as Partial<CheckboxGroupProps>,
+};
+export default meta;
 
-type Story = StoryObj<typeof GCheckboxGroup>
+type Story = StoryObj<typeof GCheckboxGroup>;
 
 const Template: Story = {
   render: (args) => ({
     components: { GCheckboxGroup, GCheckbox, GConfigProvider },
     setup() {
-      const selectedValues = ref([])
+      const selectedValues = ref([]);
       const options = [
-        { value: 'Value A', label: 'Importaciones' },
-        { value: 'Value B', label: 'Inversiones'},
-        { value: 'Value C', label: 'Exportaciones', checked: true },
-        { value: 'Value D', label: 'Transferencias', disabled: true },
-        { value: 'Value E', label: 'Otros' }
-      ]
-      return { args, selectedValues, options }
+        { value: "Value A", label: "Importaciones" },
+        { value: "Value B", label: "Inversiones" },
+        { value: "Value C", label: "Exportaciones", checked: true },
+        { value: "Value D", label: "Transferencias", disabled: true },
+        { value: "Value E", label: "Otros" },
+      ];
+      return { args, selectedValues, options };
     },
     template: `
     <g-config-provider>
@@ -228,9 +316,9 @@ const Template: Story = {
         Valores seleccionados: {{ selectedValues }}
       </div>
     </g-config-provider>
-    `
-  })
-}
+    `,
+  }),
+};
 
 export const Basic: Story = {
   ...Template,
@@ -239,55 +327,103 @@ export const Basic: Story = {
     docs: {
       description: {
         story:
-          'Grupo de checkboxes básico. Muestra la funcionalidad principal de selección múltiple con valores en array. Los checkboxes se muestran en línea por defecto.'
-      }
-    }
-  }
-}
+          "Grupo de checkboxes básico. Muestra la funcionalidad principal de selección múltiple con valores en array. Los checkboxes se muestran en línea por defecto.",
+      },
+    },
+  },
+};
 
 export const Disabled: Story = {
   ...Template,
   args: {
     disabled: true,
-    modelValue: ['Value A']
+    modelValue: ["Value A"],
   },
   parameters: {
     docs: {
       description: {
         story:
-          'Grupo completo deshabilitado. Todos los checkboxes están no interactivos. Útil para estados donde la selección no está disponible temporalmente.'
-      }
-    }
-  }
-}
+          "Grupo completo deshabilitado. Todos los checkboxes están no interactivos. Útil para estados donde la selección no está disponible temporalmente.",
+      },
+    },
+  },
+};
 
 export const WithLimits: Story = {
   ...Template,
   args: {
     min: 1,
-    max: 2
+    max: 2,
   },
   parameters: {
     docs: {
       description: {
         story:
-          'Grupo con restricciones de selección. Permite definir mínimo (1) y máximo (2) de opciones seleccionables. Muestra validación automática al exceder los límites.'
-      }
-    }
-  }
-}
+          "Grupo con restricciones de selección. Permite definir mínimo (1) y máximo (2) de opciones seleccionables. Muestra validación automática al exceder los límites.",
+      },
+    },
+  },
+};
 
 export const VerticalLayout: Story = {
   ...Template,
   args: {
-    layout: 'vertical'
+    layout: "vertical",
   },
   parameters: {
     docs: {
       description: {
         story:
-          'Checkboxes apilados verticalmente. Controlado mediante la propiedad `layout: vertical`. Ideal para formularios con espacio vertical limitado.'
-      }
-    }
-  }
-}
+          "Checkboxes apilados verticalmente. Controlado mediante la propiedad `layout: vertical`. Ideal para formularios con espacio vertical limitado.",
+      },
+    },
+  },
+};
+
+export const InvertedStyle: Story = {
+  ...Template,
+  args: {
+    layout: "vertical",
+    invert: true,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Ejemplo del componente con checkboxes con elementos invertidos, controlados mediante la propiedad `invert: true`.",
+      },
+    },
+  },
+};
+
+export const BorderedStyle: Story = {
+  ...Template,
+  args: {
+    layout: "vertical",
+    border: true,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: "Ejemplo del componente con checkboxes con bordes, controlados mediante la propiedad `border: true`.",
+      },
+    },
+  },
+};
+
+export const InvertedBorderedStyle: Story = {
+  ...Template,
+  args: {
+    layout: "vertical",
+    border: true,
+    invert: true,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Ejemplo del componente con checkboxes con borde y elementos invertidos para mostrar la interacción de las propiedades `border` e `invert`.",
+      },
+    },
+  },
+};

--- a/stories/checkbox.stories.ts
+++ b/stories/checkbox.stories.ts
@@ -1,207 +1,283 @@
-import { Meta, StoryFn, StoryObj } from '@storybook/vue3'
-import { ref } from 'vue';
+import { Meta, StoryFn, StoryObj } from "@storybook/vue3";
+import { ref } from "vue";
 
 // COMPONENTS
-import { GCheckbox, CheckboxProps } from '@flash-global66/g-checkbox/index.ts'
+import { GCheckbox, CheckboxProps } from "@flash-global66/g-checkbox/index.ts";
 
 // CONFIG
-import { GConfigProvider } from '../components/config-provider'
+import { GConfigProvider } from "../components/config-provider";
+
+// VERSION
+import {
+  version,
+  peerDependencies,
+} from "@flash-global66/g-checkbox/package.json";
+
+// HELPERS
+import {
+  generatePeerDepsList,
+  generatePeerDepsInstalls,
+} from "../helper/documentation-stories";
 
 const meta: Meta<typeof GCheckbox> = {
-  title: 'Form/Checkbox/Single',
+  title: "Form/Checkbox/Single",
   component: GCheckbox,
   parameters: {
     docs: {
       description: {
         component: `
-El componente \`GCheckbox\` es un elemento de selección que permite activar o desactivar una opción.
+El componente Checkbox es un elemento de selección que permite activar o desactivar una opción.
 
-### Instalación
+> Versión actual: ${version}
+
+## Características
+
+El componente consta de dos elementos base (input check + label), cuya disposición y apariencia puede variar
+
+Posee tres opciones de estilo, de acuerdo a si se le envían o no ciertas props:
+- Por defecto: el componente aparecerá con el formato input check + label
+- \`invert\`: invierte los elementos del componente para dejarlo con el formato label + input check. Es importante destacar que esta configuración alinea los elementos a la derecha, por lo cual se utiliza sobre todo con el border y en casos donde una serie de checks deban alinearse hacia la derecha y su tamaño dependerá del contenedor padre del checkbox.
+- \`border\`: agrega un borde al componente, envolviendo tanto el label como el input check, sea cual sea su orden.
+
+Mas allá del estilo seleccionado para el componente, este cuenta con 4 estados:
+- Sin checkear: el valor se encuentra deseleccionado.
+- Checked: el valor se ha seleccionado.
+- Indeterminate: el valor se encuentra en un punto medio (generalmente utilizado cuando existe un check 'padre' que cuenta con checks 'hijos' cuya selección no es completa.)
+- Disabled: el valor no se puede seleccionar.
+
+## Instalación
+
 \`\`\`bash
 yarn add @flash-global66/g-checkbox
 \`\`\`
 
-### Importación
+## Importación del componente
 
 \`\`\`typescript
+# importar donde se va a utilizar
 import { GCheckbox } from '@flash-global66/g-checkbox'
-import '@flash-global66/g-checkbox/checkbox.styles.scss'
+
+# recomendado importar en los estilos globales
+@use '@flash-global66/g-checkbox/styles.scss' as *;
 \`\`\`
 
-### Ejemplo básico:
-\`\`\`html
-<g-checkbox v-model="checked" label="Acepto los términos" />
+## Dependencias
+
+Este componente requiere:
+
+${generatePeerDepsList(peerDependencies)}
+
+\`\`\`bash
+# Dependencias global66
+yarn add ${generatePeerDepsInstalls(peerDependencies)}
+
+# Dependencias externas
+yarn add ${generatePeerDepsInstalls(peerDependencies, true)}
 \`\`\`
-        `
-      }
-    }
+
+## Uso básico
+\`\`\`html
+<!--- Componente básico --->
+<g-checkbox v-model="checked" label="Acepto los términos" />
+
+<!--- Componente con borde --->
+<g-checkbox v-model="checked" label="Acepto los términos" border />
+
+<!--- Componente invertido con borde --->
+<g-checkbox v-model="checked" label="Acepto los términos" border invert />
+\`\`\`
+        `,
+      },
+    },
   },
   argTypes: {
     // Principales
     modelValue: {
-      description: 'Valor del modelo (v-model)',
+      description: "Valor del modelo (v-model)",
       table: {
-        type: { summary: 'number | string | boolean' },
-        category: 'Principales'
-      }
+        type: { summary: "number | string | boolean" },
+        category: "Principales",
+      },
     },
     label: {
-      description: 'Etiqueta del checkbox cuando se usa dentro de un grupo',
-      control: 'text',
+      description: "Etiqueta del checkbox cuando se usa dentro de un grupo",
+      control: "text",
       table: {
-        category: 'Principales',
-        type: { summary: 'string | boolean | number | object' }
-      }
+        category: "Principales",
+        type: { summary: "string | boolean | number | object" },
+      },
     },
     value: {
-      description: 'Valor del checkbox cuando se usa dentro de un grupo',
-      control: 'object',
+      description: "Valor del checkbox cuando se usa dentro de un grupo",
+      control: "object",
       table: {
-        category: 'Principales',
-        type: { summary: 'string | boolean | number | object' }
-      }
+        category: "Principales",
+        type: { summary: "string | boolean | number | object" },
+      },
+    },
+
+    // Apariencia
+    border: {
+      description: "Indica si debe mostrarse el checkbox con borde",
+      control: "boolean",
+      table: {
+        category: "Apariencia",
+        type: { summary: "boolean" },
+      },
+    },
+    invert: {
+      description:
+        "Indica si debe mostrarse el checkbox con el label y el check input invertidos",
+      control: "boolean",
+      table: {
+        category: "Apariencia",
+        type: { summary: "boolean" },
+      },
     },
 
     // Valores
     trueValue: {
-      description: 'Valor cuando está activado',
-      control: 'text',
+      description: "Valor cuando está activado",
+      control: "text",
       table: {
-        category: 'Valores',
-        type: { summary: 'string | number' }
-      }
+        category: "Valores",
+        type: { summary: "string | number" },
+      },
     },
     falseValue: {
-      description: 'Valor cuando está desactivado',
-      control: 'text',
+      description: "Valor cuando está desactivado",
+      control: "text",
       table: {
-        category: 'Valores',
-        type: { summary: 'string | number' }
-      }
+        category: "Valores",
+        type: { summary: "string | number" },
+      },
     },
 
     // Estados
     indeterminate: {
-      description: 'Estado visual indeterminado',
-      control: 'boolean',
+      description: "Estado visual indeterminado",
+      control: "boolean",
       table: {
-        category: 'Estados',
-        type: { summary: 'boolean' },
-        defaultValue: { summary: 'false' }
-      }
+        category: "Estados",
+        type: { summary: "boolean" },
+        defaultValue: { summary: "false" },
+      },
     },
     checked: {
-      description: 'Indica si el checkbox está activado',
-      control: 'boolean',
+      description: "Indica si el checkbox está activado",
+      control: "boolean",
       table: {
-        category: 'Estados',
-        type: { summary: 'boolean' },
-        defaultValue: { summary: 'false' }
-      }
+        category: "Estados",
+        type: { summary: "boolean" },
+        defaultValue: { summary: "false" },
+      },
     },
     disabled: {
-      description: 'Deshabilita el componente',
-      control: 'boolean',
+      description: "Deshabilita el componente",
+      control: "boolean",
       table: {
-        category: 'Estados',
-        type: { summary: 'boolean' },
-        defaultValue: { summary: 'false' }
-      }
+        category: "Estados",
+        type: { summary: "boolean" },
+        defaultValue: { summary: "false" },
+      },
     },
 
     // Atributos HTML
     name: {
-      description: 'Atributo name nativo',
-      control: 'text',
+      description: "Atributo name nativo",
+      control: "text",
       table: {
-        category: 'Atributos HTML',
-        type: { summary: 'string' }
-      }
+        category: "Atributos HTML",
+        type: { summary: "string" },
+      },
     },
     id: {
-      description: 'ID nativo del input',
-      control: 'text',
+      description: "ID nativo del input",
+      control: "text",
       table: {
-        category: 'Atributos HTML',
-        type: { summary: 'string' }
-      }
+        category: "Atributos HTML",
+        type: { summary: "string" },
+      },
     },
     tabindex: {
-      description: 'Orden de tabulación',
-      control: 'number',
+      description: "Orden de tabulación",
+      control: "number",
       table: {
-        category: 'Atributos HTML',
-        type: { summary: 'string | number' }
-      }
+        category: "Atributos HTML",
+        type: { summary: "string | number" },
+      },
     },
 
     // Validación
     validateEvent: {
-      description: 'Activa la validación del formulario',
-      control: 'boolean',
+      description: "Activa la validación del formulario",
+      control: "boolean",
       table: {
-        category: 'Validación',
-        type: { summary: 'boolean' },
-        defaultValue: { summary: 'true' }
-      }
+        category: "Validación",
+        type: { summary: "boolean" },
+        defaultValue: { summary: "true" },
+      },
     },
 
     // Accesibilidad
     ariaControls: {
-      description: 'ID de los elementos controlados (ARIA)',
-      control: 'text',
+      description: "ID de los elementos controlados (ARIA)",
+      control: "text",
       table: {
-        category: 'Accesibilidad',
-        type: { summary: 'string' }
-      }
+        category: "Accesibilidad",
+        type: { summary: "string" },
+      },
     },
 
     // Eventos
-    'onUpdate:modelValue': {
-      description: 'Se emite al actualizar el valor',
+    "onUpdate:modelValue": {
+      description: "Se emite al actualizar el valor",
       table: {
-        category: 'Eventos',
-        type: { summary: 'number | string | boolean' }
-      }
+        category: "Eventos",
+        type: { summary: "number | string | boolean" },
+      },
     },
     onChange: {
-      description: 'Se emite al cambiar el estado',
+      description: "Se emite al cambiar el estado",
       table: {
-        category: 'Eventos',
-        type: { summary: 'number | string | boolean' }
-      }
+        category: "Eventos",
+        type: { summary: "number | string | boolean" },
+      },
     },
 
     // Slots
     default: {
-      description: 'Slot personalizado para el contenido del checkbox',
+      description: "Slot personalizado para el contenido del checkbox",
       table: {
-        category: 'Slots',
-        type: { summary: 'slot' }
-      }
-    }
+        category: "Slots",
+        type: { summary: "slot" },
+      },
+    },
   },
   args: {
     disabled: false,
     indeterminate: false,
     checked: false,
     validateEvent: true,
-    label: 'Etiqueta del checkbox',
-    value: 'Valor del checkbox',
-    name: 'checkbox-name',
-    id: 'checkbox-id',
-  } as Partial<CheckboxProps>
-}
+    label: "Etiqueta del checkbox",
+    value: "Valor del checkbox",
+    name: "checkbox-name",
+    id: "checkbox-id",
+  } as Partial<CheckboxProps>,
+};
 
-export default meta
-type Story = StoryObj<typeof GCheckbox>
+export default meta;
+type Story = StoryObj<typeof GCheckbox>;
 
-const Template: StoryFn<CheckboxProps> = (args: CheckboxProps, { argTypes }) => ({
+const Template: StoryFn<CheckboxProps> = (
+  args: CheckboxProps,
+  { argTypes }
+) => ({
   props: Object.keys(argTypes),
   components: { GCheckbox, GConfigProvider },
   setup() {
-    const value = ref(args.modelValue)
-    return { args, value }
+    const value = ref(args.modelValue);
+    return { args, value };
   },
   template: `
     <g-config-provider>
@@ -210,63 +286,135 @@ const Template: StoryFn<CheckboxProps> = (args: CheckboxProps, { argTypes }) => 
         v-model="value"
       />
     </g-config-provider>
-  `
-})
+  `,
+});
 
-export const Default: Story = Template.bind({})
-Default.args = {
-  label: 'Default Checkbox',
+export const Basic: Story = Template.bind({});
+Basic.args = {
+  label: "Básico",
   disabled: false,
   indeterminate: false,
-  modelValue: false
-} as CheckboxProps
-Default.parameters = {
+  modelValue: false,
+} as CheckboxProps;
+Basic.parameters = {
   docs: {
     description: {
       story:
-        'Checkbox básico en su estado inicial no seleccionado. Muestra la funcionalidad principal con una etiqueta estándar.'
-    }
-  }
-}
+        "Checkbox básico en su estado inicial no seleccionado. Muestra la funcionalidad principal con una etiqueta estándar.",
+    },
+  },
+};
 
-export const Checked: Story = Template.bind({})
+export const Checked: Story = Template.bind({});
 Checked.args = {
-  ...Default.args,
-  checked: true
-} as CheckboxProps
+  ...Basic.args,
+  checked: true,
+} as CheckboxProps;
 Checked.parameters = {
   docs: {
     description: {
       story:
-        'Checkbox en estado seleccionado. Ejemplo de uso con `v-model` vinculado a un valor verdadero. Ideal para mostrar opciones activadas por defecto.'
-    }
-  }
-}
+        "Checkbox en estado seleccionado. Ejemplo de uso con `v-model` vinculado a un valor verdadero. Ideal para mostrar opciones activadas por defecto.",
+    },
+  },
+};
 
-export const Disabled: Story = Template.bind({})
+export const Disabled: Story = Template.bind({});
 Disabled.args = {
-  ...Default.args,
-  disabled: true
-} as CheckboxProps
+  ...Basic.args,
+  disabled: true,
+} as CheckboxProps;
 Disabled.parameters = {
   docs: {
     description: {
       story:
-        'Checkbox deshabilitado no interactivo. Útil para estados donde la acción no está disponible temporalmente. Se combina con otros estados como checked o indeterminate.'
-    }
-  }
-}
+        "Checkbox deshabilitado no interactivo. Útil para estados donde la acción no está disponible temporalmente. Se combina con otros estados como checked o indeterminate.",
+    },
+  },
+};
 
-export const Indeterminate: Story = Template.bind({})
+export const Indeterminate: Story = Template.bind({});
 Indeterminate.args = {
-  ...Default.args,
-  indeterminate: true
-} as CheckboxProps
+  ...Basic.args,
+  indeterminate: true,
+} as CheckboxProps;
 Indeterminate.parameters = {
   docs: {
     description: {
       story:
-        'Estado visual indeterminado (ni chequeado ni deschequeado). Usado comúnmente en selecciones parciales o grupos con múltiples opciones. Requiere control programático.'
-    }
-  }
-}
+        "Estado visual indeterminado (ni chequeado ni deschequeado). Usado comúnmente en selecciones parciales o grupos con múltiples opciones. Requiere control programático.",
+    },
+  },
+};
+
+export const Styles: Story = {
+  name: "Style options",
+  parameters: {
+    docs: {
+      description: {
+        story: "Ejemplo del componente con diferentes estilos controlados por las propiedades `border` e `invert`.",
+      },
+      source: {
+        code: `
+<template>
+  <!-- Basic -->
+  <p class="ml-md font-semibold">Basic</p>
+  <div class="flex p-md items-center">
+    <g-checkbox label="Etiqueta del checkbox" value="Valor del checkbox" />
+  </div>
+
+  <!-- With border -->
+  <p class="ml-md font-semibold">With border</p>
+  <div class="p-md">
+    <g-checkbox label="Etiqueta del checkbox" value="Valor del checkbox" border />
+  </div>
+
+  <!-- Inverted -->
+  <p class="ml-md font-semibold">Inverted</p>
+  <div class='flex flex-col gap-xs p-md w-fit justify-start'>
+    <g-checkbox label="Etiqueta del checkbox" value="Valor del checkbox" invert />
+    <g-checkbox label="Etiqueta de Checkbox larga" value="Check-2" invert />
+  </div>
+
+  <!-- Border + invert -->
+  <p class="ml-md font-semibold">Border + invert</p>
+  <div class="p-md">
+    <g-checkbox label="Etiqueta del checkbox" value="Valor del checkbox" border invert />
+  </div>
+</template>
+        `,
+        language: "html",
+      },
+    },
+  },
+  render: (args) => ({
+    components: { GCheckbox, GConfigProvider },
+    setup() {
+      return { args };
+    },
+    template: `
+    <g-config-provider>
+      <p class="ml-md font-semibold">Basic</p>
+      <div class="flex p-md items-center">
+        <g-checkbox v-bind="args" />
+      </div>
+
+      <p class="ml-md font-semibold">With border</p>
+      <div class="p-md">
+        <g-checkbox v-bind="args" border />
+      </div>
+
+      <p class="ml-md font-semibold">Inverted</p>
+      <div class='flex flex-col gap-xs p-md w-fit justify-start'>
+        <g-checkbox v-bind="args" invert />
+        <g-checkbox label="Etiqueta de Checkbox larga" value="Check-2" invert />
+      </div>
+
+      <p class="ml-md font-semibold">Border + invert</p>
+      <div class="p-md">
+        <g-checkbox v-bind="args" border invert />
+      </div>
+    </g-config-provider>
+    `,
+  }),
+};


### PR DESCRIPTION
Este PR agrega dos aspectos de estilo al checkbox:
- Permite agregar bordes alrededor del checkbox (`border`)
- Permite invertir los elementos que componen el checkbox (`invert`)

Este cambio aplica tanto a Checkbox individual como a CheckboxGroup. 
Ambas propiedades nuevas actúan de manera independiente, pudiendo solo invertir los valores, solo agregar el borde o ambas.