### PR TITLE
Erik(table): border class update

### DIFF
--- a/components/table/src/table.styles.scss
+++ b/components/table/src/table.styles.scss
@@ -33,7 +33,7 @@
       @apply w-0;
     }
     & .gui-table__header-wrapper {
-      @apply border-t-1 border-l-0 border-everBlue-100;
+      @apply border-t border-l-0 border-everBlue-100;
     }
     & .gui-table__header {
       @apply relative;

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -331,7 +331,6 @@ module.exports = {
         "3xl": "1900px",
       },
       borderWidth: {
-        1: "1px",
         3: "3px",
       },
       boxShadow: {


### PR DESCRIPTION
Se elimina la variable `border-1` de la propiedad `borderWeight` del tema de Tailwind en el proyecto y se reemplaza esta variable por la variable por defecto de Tailwind para indicar bordes de 1px (`border`, en lugar de `border-1`) en el estilo del componente Table.