### PR TITLE
feat(select): add data-test selector to option item

### DIFF
--- a/components/select/src/option-item.vue
+++ b/components/select/src/option-item.vue
@@ -1,13 +1,14 @@
 <template>
   <li
     :aria-selected="selected"
+    :data-test="`item:${getTitle(item)}`"
     :style="style"
     :class="[
       ns.be('dropdown', 'item'),
       ns.is('selected', selected),
       ns.is('disabled', disabled),
       ns.is('created', created),
-      ns.is('hovering', hovering)
+      ns.is('hovering', hovering),
     ]"
     @mousemove="hoverItem"
     @click.stop="selectOptionClick"
@@ -19,7 +20,9 @@
         :class="ns.bem('dropdown', 'item', 'icon')"
       />
       <div :class="ns.bem('dropdown', 'item', 'content')">
-        <span :class="ns.bem('dropdown', 'item', 'title')">{{ getTitle(item) }}</span>
+        <span :class="ns.bem('dropdown', 'item', 'title')">{{
+          getTitle(item)
+        }}</span>
         <span
           v-if="Boolean(getDescription(item))"
           :class="ns.bem('dropdown', 'item', 'description')"
@@ -32,23 +35,23 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, inject } from 'vue'
-import { useNamespace } from 'element-plus'
-import { useOption } from './hooks/use-option'
-import { useProps } from './hooks/use-props'
-import { OptionProps, optionEmits } from './defaults'
-import { selectV2InjectionKey } from './types/token'
-import { GIconFont } from '@flash-global66/g-icon-font'
+import { defineComponent, inject } from "vue";
+import { useNamespace } from "element-plus";
+import { useOption } from "./hooks/use-option";
+import { useProps } from "./hooks/use-props";
+import { OptionProps, optionEmits } from "./defaults";
+import { selectV2InjectionKey } from "./types/token";
+import { GIconFont } from "@flash-global66/g-icon-font";
 
 export default defineComponent({
   props: OptionProps,
   emits: optionEmits,
   components: { GIconFont },
   setup(props, { emit }) {
-    const select = inject(selectV2InjectionKey)!
-    const ns = useNamespace('select')
-    const { hoverItem, selectOptionClick } = useOption(props, { emit })
-    const { getIcon, getTitle, getDescription } = useProps(select.props)
+    const select = inject(selectV2InjectionKey)!;
+    const ns = useNamespace("select");
+    const { hoverItem, selectOptionClick } = useOption(props, { emit });
+    const { getIcon, getTitle, getDescription } = useProps(select.props);
 
     return {
       ns,
@@ -56,8 +59,8 @@ export default defineComponent({
       selectOptionClick,
       getTitle,
       getDescription,
-      getIcon
-    }
-  }
-})
+      getIcon,
+    };
+  },
+});
 </script>


### PR DESCRIPTION
Este desarrollo agrega un selector data-test en el mapeo de las option items del componente Select.
El objetivo de esto es que las opciones del Select se puedan identificar para interactuar desde la plataforma que se encarga de los tests E2E.