### PR TITLE
feat: add duotone icons and update icon sets

### DIFF
--- a/components/icon-font/src/Icon.vue
+++ b/components/icon-font/src/Icon.vue
@@ -17,16 +17,16 @@
 </template>
 
 <script lang="ts" setup>
-import { computed, PropType } from 'vue';
-import { debugWarn, isString } from "element-plus/es/utils/index.mjs";;
+import { computed } from 'vue';
+import { debugWarn, isString } from "element-plus/es/utils/index.mjs";
 
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 import { library } from '@fortawesome/fontawesome-svg-core';
-import type { IconString } from './types';
 import * as SolidPro from './lib/fas-solid-pro';
 import * as RegularPro from './lib/far-regular-pro';
 import * as LightPro from './lib/fal-light-pro';
 import * as BrandsFree from './lib/fab-free';
+import * as DuotonePro from './lib/fad-duotone-pro';
 import { iconProps } from './icon';
 
 // Registro de iconos
@@ -34,7 +34,8 @@ library.add(
   SolidPro,
   RegularPro,
   LightPro,
-  BrandsFree
+  BrandsFree,
+  DuotonePro
 );
 
 const props = defineProps(iconProps);

--- a/components/icon-font/src/icon-sets.ts
+++ b/components/icon-font/src/icon-sets.ts
@@ -232,6 +232,7 @@ export const ICON_SETS = {
     'star',
     'flag',
     'heart-pulse',
+    'ticket-perforated'
   ] as const,
 
   light: [
@@ -288,5 +289,6 @@ export const ICON_SETS = {
     "university",
     "arrow-to-bottom",
     "store",
+    "arrows-repeat",
   ] as const,
 } as const;

--- a/components/icon-font/src/icon-sets.ts
+++ b/components/icon-font/src/icon-sets.ts
@@ -232,7 +232,7 @@ export const ICON_SETS = {
     'star',
     'flag',
     'heart-pulse',
-    'ticket-perforated'
+    'ticket-perforated',
   ] as const,
 
   light: [

--- a/components/icon-font/src/lib/fad-duotone-pro.ts
+++ b/components/icon-font/src/lib/fad-duotone-pro.ts
@@ -12,5 +12,6 @@ export {
   faSparkles,
   faUniversity,
   faArrowToBottom,
-  faStore
+  faStore,
+  faArrowsRepeat
 } from '@fortawesome/pro-duotone-svg-icons';

--- a/components/icon-font/src/lib/far-regular-pro.ts
+++ b/components/icon-font/src/lib/far-regular-pro.ts
@@ -119,4 +119,5 @@ export {
   faStar,
   faFlag,
   faHeartPulse,
+  faTicketPerforated
 } from '@fortawesome/pro-regular-svg-icons';


### PR DESCRIPTION
## Cambios realizados

- **Registra iconos duotone en la librería**: `DuotonePro` no estaba incluido en `library.add()`, por lo que todos los iconos `duotone` no se renderizaban.
- **Nuevo icono duotone**: `arrows-repeat` — usado en el botón de swap del componente `g-quote`.
- **Nuevo icono regular**: `ticket-perforated` — agrega soporte para iconos de tickets perforados.
- **Fix**: doble `;` en el import de `element-plus` en `Icon.vue`.