### PR TITLE
feat: add quote component with currency input and styling

### DIFF
--- a/assets/scss/index.scss
+++ b/assets/scss/index.scss
@@ -41,6 +41,7 @@
 @use "@flash-global66/g-collapse/styles.scss" as *;
 @use "@flash-global66/g-chip/styles.scss" as *;
 @use "@flash-global66/g-country-flag/styles.scss" as *;
+@use "@flash-global66/g-quote/styles.scss" as *;
 
 * {
   @apply font-montserrat;

--- a/components/quote/index.ts
+++ b/components/quote/index.ts
@@ -1,0 +1,13 @@
+import Quote from './src/quote.vue'
+import { withInstall, SFCWithInstall } from 'element-plus/es/utils/index.mjs'
+
+export const GQuote: SFCWithInstall<typeof Quote> & {
+  Quote: typeof Quote
+} = withInstall(Quote, { Quote })
+
+export default GQuote
+
+export * from './src/quote.type'
+export * from './src/quote'
+
+export type QuoteInstance = InstanceType<typeof Quote>

--- a/components/quote/package.json
+++ b/components/quote/package.json
@@ -10,7 +10,8 @@
       "require": "./dist/index.js",
       "types": "./dist/types/index.d.ts"
     },
-    "./styles.scss": "./src/quote.styles.scss"
+    "./styles.scss": "./src/quote.styles.scss",
+    "./*": "./*"
   },
   "files": [
     "dist",

--- a/components/quote/package.json
+++ b/components/quote/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "@flash-global66/g-quote",
+  "author": "Global66",
+  "version": "0.0.1",
+  "license": "MIT",
+  "buildable": true,
+  "exports": {
+    ".": {
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.js",
+      "types": "./dist/types/index.d.ts"
+    },
+    "./styles.scss": "./src/quote.styles.scss"
+  },
+  "files": [
+    "dist",
+    "src",
+    "index.ts"
+  ],
+  "scripts": {
+    "build": "vite build",
+    "build:types": "vue-tsc --project tsconfig.json"
+  },
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com"
+  },
+  "repository": {
+    "url": "https://github.com/Flash-Global66/global-design-system.git"
+  },
+  "peerDependencies": {
+    "@flash-global66/g-country-flag": "^0.0.2",
+    "@flash-global66/g-dropdown": "^0.1.4",
+    "@flash-global66/g-icon-font": "^0.20.0",
+    "vue": "^3.2.0",
+    "vue-currency-input": "^3.2.0"
+  }
+}

--- a/components/quote/src/components/quote-input.ts
+++ b/components/quote/src/components/quote-input.ts
@@ -1,0 +1,30 @@
+import type { ExtractPropTypes } from 'vue'
+import { buildProps, definePropType } from 'element-plus/es/utils/index.mjs'
+import type { FlagCode } from '@flash-global66/g-country-flag'
+import type { Currency } from '../quote.type'
+
+export const quoteInputProps = buildProps({
+  currencies: { type: definePropType<Currency[]>(Array), default: () => [] },
+  label: { type: String, required: true },
+  value: { type: String, default: '' },
+  currencyCode: { type: String, default: '' },
+  flagCode: { type: definePropType<FlagCode>(String), default: undefined },
+  showArrow: { type: Boolean, default: true },
+  isDisabled: { type: Boolean, default: false },
+  hasError: { type: Boolean, default: false },
+  isEmptyValue: { type: Boolean, default: false },
+  isResult: { type: Boolean, default: false },
+  quoteDone: { type: Boolean, default: false },
+  isFading: { type: Boolean, default: false },
+  placeholder: { type: String, default: '0,00' },
+  emptyResultsText: { type: String, default: 'Sin resultados' },
+} as const)
+
+export type QuoteInputProps = ExtractPropTypes<typeof quoteInputProps>
+
+export const quoteInputEmits = {
+  input: (value: string) => typeof value === 'string',
+  blur: (value: string) => typeof value === 'string',
+  focus: () => true,
+  'currency-change': (currency: Currency) => !!currency,
+}

--- a/components/quote/src/components/quote-input.vue
+++ b/components/quote/src/components/quote-input.vue
@@ -1,0 +1,160 @@
+<template>
+  <div
+    :class="[
+      ns.b(),
+      ns.is('disabled', isDisabled),
+      ns.is('error', hasError),
+    ]"
+  >
+    <label :for="inputId" :class="ns.e('label')">{{ label }}</label>
+
+    <div :class="[ns.e('row'), ns.is('fading', isFading)]">
+      <div :class="ns.e('amount-wrapper')">
+        <input
+          :id="inputId"
+          ref="inputRef"
+          :class="[
+            ns.e('amount'),
+            ns.is('empty', isEmptyValue && numberValue === null),
+            ns.is('big', isBig),
+            ns.is('error', hasError),
+            ns.is('disabled', isDisabled),
+          ]"
+          type="text"
+          inputmode="decimal"
+          :placeholder="placeholder"
+          :disabled="isDisabled"
+          :aria-invalid="hasError"
+          autocomplete="off"
+          @blur="handleBlur"
+          @focus="handleFocus"
+        />
+      </div>
+      <g-dropdown
+        ref="dropdownRef"
+        trigger="click"
+        placement="bottom-end"
+        :popper-class="`${ns.e('dropdown-popper')} ${dropdownPopperId}`"
+        :disabled="isDisabled || !hasCurrencyOptions"
+        @command="handleCurrencySelect"
+        @visible-change="onDropdownVisibleChange"
+      >
+        <div
+          :class="[
+            ns.e('currency'),
+            ns.is('open', isDropdownOpen),
+            ns.is('disabled', isDisabled),
+          ]"
+          :aria-label="`Seleccionar moneda ${currencyCode}`"
+        >
+          <span :class="ns.e('flag-group')">
+            <span :class="ns.e('flag')">
+              <slot name="flag">
+                <g-country-flag
+                  v-if="flagCode || selectedCurrency?.flagCountryCode"
+                  :name="(flagCode || selectedCurrency?.flagCountryCode)!"
+                  size="xs"
+                  aria-hidden="true"
+                />
+                <span v-else :class="ns.e('flag-fallback')" aria-hidden="true">🏳</span>
+              </slot>
+            </span>
+
+            <input
+              ref="searchInputRef"
+              v-model="searchQuery"
+              :class="[
+                ns.e('currency-code'),
+                ns.is('disabled', isDisabled),
+              ]"
+              :aria-label="`Buscar moneda, seleccionada: ${currencyCode}`"
+              :placeholder="currencyCode"
+              :size="((searchQuery || currencyCode).length || 3) + 1"
+              :disabled="isDisabled || !hasCurrencyOptions"
+              autocomplete="off"
+              @click="handleInputClick"
+              @input="handleSearchInput"
+            />
+          </span>
+
+          <span
+            v-if="showArrow && hasCurrencyOptions"
+            :class="[
+              ns.e('arrow'),
+              ns.is('disabled', isDisabled),
+              ns.is('open', isDropdownOpen),
+            ]"
+            aria-hidden="true"
+          >
+            <g-icon-font name="regular chevron-down" />
+          </span>
+        </div>
+
+        <template #dropdown>
+          <g-dropdown-menu :class="ns.e('dropdown')">
+            <g-dropdown-item
+              v-for="currency in filteredCurrencies"
+              :key="`${currency.code}-${currency.name}`"
+              :command="currency"
+              :title="currency.name"
+              :class="{ [ns.is('active')]: currency.code === currencyCode }"
+            >
+              <span :class="ns.e('dropdown-item')">
+                <g-country-flag
+                  v-if="currency.flagCountryCode"
+                  :name="currency.flagCountryCode"
+                  size="md"
+                  aria-hidden="true"
+                />
+                <span v-else :class="ns.e('dropdown-flag-fallback')" aria-hidden="true">🏳</span>
+                <span :class="ns.e('dropdown-label')">
+                  <span :class="ns.e('dropdown-code')">({{ currency.code }})</span>
+                  {{ currency.name }}
+                </span>
+              </span>
+            </g-dropdown-item>
+            <div v-if="filteredCurrencies.length === 0" :class="ns.e('dropdown-empty')">
+              {{ emptyResultsText }}
+            </div>
+          </g-dropdown-menu>
+        </template>
+      </g-dropdown>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { useNamespace } from 'element-plus'
+import { GIconFont } from '@flash-global66/g-icon-font'
+import { GDropdown, GDropdownMenu, GDropdownItem } from '@flash-global66/g-dropdown'
+import { GCountryFlag } from '@flash-global66/g-country-flag'
+import { quoteInputProps, quoteInputEmits } from './quote-input'
+import { useQuoteInput } from './use-quote-input'
+
+defineOptions({ name: 'GQuoteInput' })
+
+const ns = useNamespace('quote-input')
+const props = defineProps(quoteInputProps)
+const emit = defineEmits(quoteInputEmits)
+
+const {
+  inputRef,
+  searchInputRef,
+  searchQuery,
+  isDropdownOpen,
+  filteredCurrencies,
+  hasCurrencyOptions,
+  isBig,
+  numberValue,
+  selectedCurrency,
+  inputId,
+  dropdownPopperId,
+  dropdownRef,
+  handleFocus,
+  handleBlur,
+  handleCurrencySelect,
+  onDropdownVisibleChange,
+  handleInputClick,
+  handleSearchInput,
+} = useQuoteInput(props, emit)
+</script>

--- a/components/quote/src/components/use-quote-input.ts
+++ b/components/quote/src/components/use-quote-input.ts
@@ -28,7 +28,7 @@ export function useQuoteInput(props: QuoteInputProps, emit: QuoteInputEmit) {
   })
 
   const isFocused = ref(false)
-  const isBig = computed(() => isFocused.value && !props.quoteDone && !props.isResult)
+  const isBig = computed(() => isFocused.value && !props.quoteDone)
 
   const selectedCurrency = computed<Currency | null>(
     () => props.currencies?.find((c: Currency) => c.code === props.currencyCode) ?? null

--- a/components/quote/src/components/use-quote-input.ts
+++ b/components/quote/src/components/use-quote-input.ts
@@ -1,0 +1,139 @@
+import { ref, watch, computed, nextTick } from 'vue'
+import type { SetupContext } from 'vue'
+import { useCurrencyInput, CurrencyDisplay } from 'vue-currency-input'
+import type { CurrencyInputOptions } from 'vue-currency-input'
+import { quoteInputEmits } from './quote-input'
+import type { QuoteInputProps } from './quote-input'
+import type { Currency } from '../quote.type'
+
+type QuoteInputEmit = SetupContext<typeof quoteInputEmits>['emit']
+
+export function useQuoteInput(props: QuoteInputProps, emit: QuoteInputEmit) {
+  const dropdownPopperId = `g-qip-${crypto.randomUUID().slice(0, 8)}`
+  const inputId = `g-qi-${crypto.randomUUID().slice(0, 8)}`
+
+  const hasCurrencyOptions = computed(() => (props.currencies?.length ?? 0) > 1)
+
+  const dropdownRef = ref<{ handleOpen: () => void } | null>(null)
+  const searchInputRef = ref<HTMLInputElement | null>(null)
+  const searchQuery = ref('')
+  const isDropdownOpen = ref(false)
+
+  const filteredCurrencies = computed(() => {
+    if (!searchQuery.value) return props.currencies ?? []
+    const q = searchQuery.value.toLowerCase()
+    return (props.currencies ?? []).filter(
+      (c) => c.alwaysVisible || c.code.toLowerCase().includes(q) || c.name.toLowerCase().includes(q)
+    )
+  })
+
+  const isFocused = ref(false)
+  const isBig = computed(() => isFocused.value && !props.quoteDone && !props.isResult)
+
+  const selectedCurrency = computed<Currency | null>(
+    () => props.currencies?.find((c: Currency) => c.code === props.currencyCode) ?? null
+  )
+
+  const currencyOptions = computed<CurrencyInputOptions>(() => ({
+    currency: 'USD',
+    currencyDisplay: CurrencyDisplay.hidden,
+    precision: selectedCurrency.value?.decimalPlaces ?? 2,
+    locale: selectedCurrency.value?.locale,
+    valueRange: { min: 0 },
+    useGrouping: true,
+    hideGroupingSeparatorOnFocus: false,
+    hideCurrencySymbolOnFocus: false,
+    hideNegligibleDecimalDigitsOnFocus: false,
+  }))
+
+  const { inputRef, numberValue, setValue, setOptions } = useCurrencyInput(
+    currencyOptions.value,
+    false
+  )
+
+  let isExternalUpdate = false
+
+  watch(
+    () => props.value,
+    (val) => {
+      const parsed = val && !isNaN(parseFloat(val)) ? parseFloat(val) : null
+      if (parsed !== numberValue.value) {
+        isExternalUpdate = true
+        setValue(parsed)
+      }
+    },
+    { immediate: true }
+  )
+
+  watch(currencyOptions, async (opts) => {
+    isExternalUpdate = true
+    setOptions(opts)
+    await nextTick()
+    isExternalUpdate = false
+  })
+
+  watch(numberValue, (num) => {
+    if (isExternalUpdate) {
+      isExternalUpdate = false
+      return
+    }
+    emit('input', num !== null ? String(num) : '')
+  })
+
+  function handleFocus() {
+    isFocused.value = true
+    emit('focus')
+  }
+
+  function handleBlur() {
+    isFocused.value = false
+    emit('blur', numberValue.value !== null ? String(numberValue.value) : '')
+  }
+
+  function handleCurrencySelect(currency: Currency) {
+    emit('currency-change', currency)
+  }
+
+  async function onDropdownVisibleChange(visible: boolean) {
+    isDropdownOpen.value = visible
+    if (visible) {
+      await nextTick()
+      searchInputRef.value?.select()
+    } else {
+      searchQuery.value = ''
+    }
+  }
+
+  function handleInputClick(e: MouseEvent) {
+    if (isDropdownOpen.value) {
+      e.stopPropagation()
+    }
+  }
+
+  function handleSearchInput() {
+    if (!isDropdownOpen.value && searchQuery.value) {
+      dropdownRef.value?.handleOpen()
+    }
+  }
+
+  return {
+    inputRef,
+    searchInputRef,
+    searchQuery,
+    isDropdownOpen,
+    filteredCurrencies,
+    hasCurrencyOptions,
+    isBig,
+    numberValue,
+    selectedCurrency,
+    inputId,
+    dropdownPopperId,
+    dropdownRef,
+    handleFocus,
+    handleBlur,
+    handleCurrencySelect,
+    onDropdownVisibleChange,
+    handleInputClick,
+    handleSearchInput,
+  }
+}

--- a/components/quote/src/quote.styles.scss
+++ b/components/quote/src/quote.styles.scss
@@ -1,0 +1,268 @@
+@use "element-plus/theme-chalk/src/mixins/mixins" as *;
+
+// ─── Quote Container ────────────────────────────────────────────────────────
+
+@include b("quote") {
+  @apply flex flex-col gap-xs;
+
+  @include e("available") {
+    @apply flex items-center gap-xxs px-xxs;
+    @apply text-2 font-medium text-terciary-txt;
+  }
+
+  @include e("available-value") {
+    @apply font-semibold text-secondary-txt;
+  }
+
+  @include e("card") {
+    @apply relative bg-white rounded-lg shadow-sm overflow-hidden;
+
+    @include when(error) {
+      @apply rounded-b-none border-l border-r border-t border-error-bd shadow-none;
+    }
+  }
+
+  @include e("card-group") {
+    @apply flex flex-col;
+  }
+
+  @include e("action") {
+    @apply flex justify-center items-center px-md py-md;
+    @apply bg-everBlue-50 rounded-b-md;
+    @apply border-l border-r border-b border-error-bd;
+  }
+
+  @include e("action-link") {
+    @apply flex items-center gap-xxs
+      text-4 font-semibold text-primary-def
+      bg-transparent border-none cursor-pointer p-0;
+
+    svg {
+      @apply text-3;
+    }
+
+    &:hover {
+      @apply underline;
+    }
+  }
+
+  @include e("error-message") {
+    @apply text-2 text-error-txt px-xxs;
+  }
+
+  @include e("input-from") {
+    @apply relative;
+  }
+
+  @include e("input-to") {
+    @apply relative;
+  }
+
+  @include e("divider") {
+    @apply relative h-px w-full bg-blue-50;
+  }
+
+  @include e("swap-icon") {
+    @apply flex items-center justify-center text-6;
+    transition: transform 0.4s ease;
+  }
+
+  @include e("swap-btn") {
+    @apply absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2
+      z-10 flex items-center justify-center
+      w-xl h-xl rounded-xl bg-everBlue-50
+      cursor-pointer border-none
+      transition-colors duration-200;
+
+    &:hover:not(:disabled) {
+      @apply bg-everBlue-100;
+    }
+
+    &:active:not(:disabled) {
+      @apply bg-everBlue-200;
+    }
+
+    &:disabled {
+      @apply cursor-not-allowed opacity-50;
+    }
+  }
+}
+
+// ─── Quote Input ────────────────────────────────────────────────────────────
+
+@include b("quote-input") {
+  @apply flex flex-col gap-xxs justify-center px-md overflow-hidden;
+  height: 112px;
+  padding-top: 24px;
+  padding-bottom: 24px;
+
+  @include e("label") {
+    @apply text-4 font-medium text-secondary-txt;
+  }
+
+  @include e("row") {
+    @apply flex items-center gap-xs;
+    min-height: 36px;
+    transition: opacity 0.2s ease;
+
+    @include when(fading) {
+      opacity: 0;
+    }
+  }
+
+  @include e("amount-wrapper") {
+    @apply flex-1 min-w-0;
+  }
+
+  @include e("amount") {
+    @apply w-full text-9 font-bold text-primary-txt
+      appearance-none outline-none bg-transparent;
+    transition: font-size 0.15s ease;
+
+    @media (max-width: theme('screens.sm')) {
+      @apply text-7;
+    }
+
+    &::placeholder {
+      @apply text-terciary-txt font-bold;
+    }
+
+    @include when(big) {
+      @apply text-11;
+
+      @media (max-width: theme('screens.sm')) {
+        @apply text-9;
+      }
+    }
+
+    @include when(empty) {
+      @apply text-terciary-txt;
+    }
+
+    @include when(error) {
+      @apply text-error-txt;
+    }
+
+    @include when(disabled) {
+      @apply text-disabled-txt cursor-not-allowed;
+
+      &::placeholder {
+        @apply text-disabled-txt;
+      }
+    }
+  }
+
+  @include e("currency") {
+    @apply flex items-center gap-xxs bg-transparent border-none
+      cursor-pointer p-0 shrink-0 outline-none;
+
+    &:focus-visible {
+      @apply outline-none;
+    }
+
+    @include when(disabled) {
+      @apply cursor-not-allowed;
+    }
+
+    @include when(open) {
+      @apply px-md py-xs rounded-md;
+      outline: 1px solid var(--color-border-primary);
+      outline-offset: -1px;
+    }
+  }
+
+  @include e("flag-group") {
+    @apply flex items-center gap-xs;
+  }
+
+  @include e("flag") {
+    @apply flex items-center justify-center shrink-0;
+  }
+
+  @include e("flag-img") {
+    @apply w-4 h-4 rounded-full object-cover;
+  }
+
+  @include e("flag-fallback") {
+    @apply text-4;
+  }
+
+  @include e("currency-code") {
+    @apply text-4 font-semibold text-primary-txt
+           bg-transparent border-none outline-none p-0;
+
+    &::placeholder {
+      @apply text-primary-txt font-semibold;
+    }
+
+    @include when(disabled) {
+      @apply text-disabled-txt cursor-not-allowed;
+
+      &::placeholder {
+        @apply text-disabled-txt;
+      }
+    }
+  }
+
+  @include e("arrow") {
+    @apply flex items-center text-secondary-txt;
+    transition: transform 0.2s ease;
+
+    svg {
+      @apply text-4;
+    }
+
+    @include when(disabled) {
+      @apply text-disabled-txt;
+    }
+
+    @include when(open) {
+      transform: rotate(180deg);
+    }
+  }
+
+  @include e("dropdown") {
+    @apply max-h-60 overflow-y-auto;
+
+    .gui-dropdown-menu__item {
+      @apply p-2;
+      min-height: unset;
+    }
+
+    .gui-dropdown-menu__item.is-active {
+      @apply bg-everBlue-50;
+    }
+  }
+
+  @include e("dropdown-popper") {
+    @apply w-72 rounded-lg shadow-md;
+
+    .gui-scrollbar__wrap {
+      @apply rounded-lg;
+    }
+  }
+
+  @include e("dropdown-item") {
+    @apply flex items-center gap-xs;
+  }
+
+  @include e("dropdown-empty") {
+    @apply px-md py-xs text-3 text-terciary-txt text-center;
+  }
+
+  @include e("dropdown-flag") {
+    @apply w-5 h-5 rounded-full object-cover shrink-0;
+  }
+
+  @include e("dropdown-flag-fallback") {
+    @apply text-4;
+  }
+
+  @include e("dropdown-label") {
+    @apply flex items-center gap-xxs;
+  }
+
+  @include e("dropdown-code") {
+    @apply text-secondary-txt;
+  }
+}

--- a/components/quote/src/quote.ts
+++ b/components/quote/src/quote.ts
@@ -37,7 +37,7 @@ export const quoteEmits = {
   'from-currency-change': (currency: Currency) => !!currency,
   'to-currency-change': (currency: Currency) => !!currency,
   swap: (payload: { from: string; to: string; fromAmount: string; toAmount: string; fromFlagCode?: FlagCode; toFlagCode?: FlagCode }) =>
-    typeof payload.from === 'string' && typeof payload.to === 'string' && typeof payload.fromAmount === 'string',
+    typeof payload.from === 'string' && typeof payload.to === 'string' && typeof payload.fromAmount === 'string' && typeof payload.toAmount === 'string',
   'from-focus': () => true,
   'to-focus': () => true,
   'action-click': () => true,

--- a/components/quote/src/quote.ts
+++ b/components/quote/src/quote.ts
@@ -1,0 +1,44 @@
+import type { ExtractPropTypes } from 'vue'
+import { buildProps, definePropType } from 'element-plus/es/utils/index.mjs'
+import type { FlagCode } from '@flash-global66/g-country-flag'
+import type { Currency, QuoteAction } from './quote.type'
+
+export const quoteProps = buildProps({
+  fromCurrency: { type: String, required: true },
+  toCurrency: { type: String, required: true },
+  fromCurrencies: { type: definePropType<Currency[]>(Array), default: () => [] },
+  toCurrencies: { type: definePropType<Currency[]>(Array), default: () => [] },
+  fromAmount: { type: String, default: '' },
+  toAmount: { type: String, default: '' },
+  action: { type: definePropType<QuoteAction>(String), default: 'Default' },
+  isLoading: { type: Boolean, default: false },
+  errorMessage: { type: String, default: '' },
+  availableBalance: { type: String, default: '' },
+  singleInput: { type: Boolean, default: false },
+  fromLabel: { type: String, default: 'Tú envías' },
+  toLabel: { type: String, default: 'Tu contacto recibe' },
+  isDisabled: { type: Boolean, default: false },
+  showSwap: { type: Boolean, default: true },
+  availableLabel: { type: String, default: 'Disponible' },
+  swapAriaLabel: { type: String, default: 'Intercambiar monedas' },
+  emptyResultsText: { type: String, default: 'Sin resultados' },
+  actionText: { type: String, default: 'Cargar dinero' },
+  fromFlagCode: { type: definePropType<FlagCode>(String), default: undefined },
+  toFlagCode: { type: definePropType<FlagCode>(String), default: undefined },
+} as const)
+
+export type QuoteProps = ExtractPropTypes<typeof quoteProps>
+
+export const quoteEmits = {
+  'from-input': (value: string) => typeof value === 'string',
+  'to-input': (value: string) => typeof value === 'string',
+  'from-blur': (value: string) => typeof value === 'string',
+  'to-blur': (value: string) => typeof value === 'string',
+  'from-currency-change': (currency: Currency) => !!currency,
+  'to-currency-change': (currency: Currency) => !!currency,
+  swap: (payload: { from: string; to: string; fromAmount: string; toAmount: string; fromFlagCode?: FlagCode; toFlagCode?: FlagCode }) =>
+    typeof payload.from === 'string' && typeof payload.to === 'string' && typeof payload.fromAmount === 'string',
+  'from-focus': () => true,
+  'to-focus': () => true,
+  'action-click': () => true,
+}

--- a/components/quote/src/quote.type.ts
+++ b/components/quote/src/quote.type.ts
@@ -1,0 +1,20 @@
+import type { FlagCode } from '@flash-global66/g-country-flag'
+
+export interface Currency {
+  code: string
+  name: string
+  flagCountryCode: FlagCode
+  symbol: string
+  decimalPlaces: number
+  thousandSeparator: string
+  decimalSeparator: string
+  locale?: string
+  alwaysVisible?: boolean
+}
+
+export type QuoteAction =
+  | 'Default'
+  | 'NoValue'
+  | 'FromError'
+  | 'ToError'
+  | 'Error'

--- a/components/quote/src/quote.vue
+++ b/components/quote/src/quote.vue
@@ -1,0 +1,119 @@
+<template>
+  <div :class="ns.b()">
+    <p v-if="availableBalance" :class="ns.e('available')">
+      {{ availableLabel }}
+      <span :class="ns.e('available-value')">{{ availableBalance }}</span>
+    </p>
+
+    <div :class="ns.e('card-group')">
+    <div :class="[ns.e('card'), ns.is('error', hasCardError)]">
+      <div
+        v-if="!singleInput"
+        :class="ns.e('input-from')"
+      >
+        <quote-input
+          :label="fromLabel"
+          :value="fromAmount"
+          :currency-code="fromCurrency"
+          :currencies="fromCurrencies"
+          :flag-code="props.fromFlagCode ?? fromCurrencyObj?.flagCountryCode"
+          :is-fading="isSwapFading"
+          :is-disabled="isDisabled"
+          :has-error="action === 'FromError' || action === 'Error'"
+          :is-empty-value="action === 'NoValue'"
+          :quote-done="isFromQuoteDone"
+          :placeholder="fromPlaceholder"
+          :empty-results-text="emptyResultsText"
+          @input="onFromInput"
+          @blur="$emit('from-blur', $event)"
+          @focus="onFromFocus"
+          @currency-change="$emit('from-currency-change', $event)"
+        />
+      </div>
+
+      <div v-if="!singleInput && showSwap" :class="ns.e('divider')">
+        <button
+          type="button"
+          :class="ns.e('swap-btn')"
+          :disabled="isDisabled"
+          :aria-label="swapAriaLabel"
+          @click="onSwap"
+        >
+          <span :class="ns.e('swap-icon')" :style="{ transform: swapTransform }">
+            <g-icon-font name="duotone arrows-repeat" />
+          </span>
+        </button>
+      </div>
+
+      <div :class="ns.e('input-to')">
+        <quote-input
+          :label="toLabel"
+          :value="toAmount"
+          :currency-code="toCurrency"
+          :currencies="toCurrencies"
+          :flag-code="props.toFlagCode ?? toCurrencyObj?.flagCountryCode"
+          :is-fading="isSwapFading"
+          :is-disabled="isDisabled"
+          :has-error="action === 'ToError'"
+          :is-empty-value="action === 'NoValue'"
+          :is-result="true"
+          :quote-done="isToQuoteDone"
+          :placeholder="toPlaceholder"
+          :empty-results-text="emptyResultsText"
+          @input="onToInput"
+          @blur="$emit('to-blur', $event)"
+          @focus="onToFocus"
+          @currency-change="$emit('to-currency-change', $event)"
+        />
+      </div>
+
+    </div>
+
+    <div v-if="hasCardError" :class="ns.e('action')">
+      <slot name="action">
+        <button
+          type="button"
+          :class="ns.e('action-link')"
+          @click="emit('action-click')"
+        >
+          {{ actionText }}
+          <g-icon-font name="regular chevron-right" />
+        </button>
+      </slot>
+    </div>
+
+    <p v-if="errorMessage" :class="ns.e('error-message')">{{ errorMessage }}</p>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { useNamespace } from 'element-plus'
+import { GIconFont } from '@flash-global66/g-icon-font'
+import QuoteInput from './components/quote-input.vue'
+import { quoteProps, quoteEmits } from './quote'
+import { useQuote } from './use-quote'
+
+defineOptions({ name: 'GQuote' })
+
+const ns = useNamespace('quote')
+const props = defineProps(quoteProps)
+const emit = defineEmits(quoteEmits)
+
+const {
+  hasCardError,
+  fromCurrencyObj,
+  toCurrencyObj,
+  isFromQuoteDone,
+  isToQuoteDone,
+  fromPlaceholder,
+  toPlaceholder,
+  swapTransform,
+  isSwapFading,
+  onFromInput,
+  onToInput,
+  onFromFocus,
+  onToFocus,
+  onSwap,
+} = useQuote(props, emit)
+</script>

--- a/components/quote/src/quote.vue
+++ b/components/quote/src/quote.vue
@@ -25,9 +25,9 @@
           :placeholder="fromPlaceholder"
           :empty-results-text="emptyResultsText"
           @input="onFromInput"
-          @blur="$emit('from-blur', $event)"
+          @blur="emit('from-blur', $event)"
           @focus="onFromFocus"
-          @currency-change="$emit('from-currency-change', $event)"
+          @currency-change="emit('from-currency-change', $event)"
         />
       </div>
 
@@ -61,9 +61,9 @@
           :placeholder="toPlaceholder"
           :empty-results-text="emptyResultsText"
           @input="onToInput"
-          @blur="$emit('to-blur', $event)"
+          @blur="emit('to-blur', $event)"
           @focus="onToFocus"
-          @currency-change="$emit('to-currency-change', $event)"
+          @currency-change="emit('to-currency-change', $event)"
         />
       </div>
 

--- a/components/quote/src/use-quote.ts
+++ b/components/quote/src/use-quote.ts
@@ -79,19 +79,23 @@ export function useQuote(props: QuoteProps, emit: QuoteEmit) {
   }
 
   async function onSwap() {
+    if (isSwapFading.value) return
     isSwapFading.value = true
-    await delay(SWAP_FADE_MS)
-    emit('swap', {
-      from: props.toCurrency,
-      to: props.fromCurrency,
-      fromAmount: props.toAmount || '',
-      toAmount: props.fromAmount || '',
-      fromFlagCode: props.toFlagCode,
-      toFlagCode: props.fromFlagCode,
-    })
-    await nextTick()
-    isSwapFading.value = false
-    swapRotation.value = (swapRotation.value + 180) % 360
+    try {
+      await delay(SWAP_FADE_MS)
+      emit('swap', {
+        from: props.toCurrency,
+        to: props.fromCurrency,
+        fromAmount: props.toAmount || '',
+        toAmount: props.fromAmount || '',
+        fromFlagCode: props.toFlagCode,
+        toFlagCode: props.fromFlagCode,
+      })
+      await nextTick()
+      swapRotation.value = (swapRotation.value + 180) % 360
+    } finally {
+      isSwapFading.value = false
+    }
   }
 
   return {

--- a/components/quote/src/use-quote.ts
+++ b/components/quote/src/use-quote.ts
@@ -1,0 +1,113 @@
+import { computed, nextTick, ref, watch } from 'vue'
+import type { SetupContext } from 'vue'
+import type { QuoteProps } from './quote'
+import { quoteEmits } from './quote'
+import type { Currency } from './quote.type'
+
+type QuoteEmit = SetupContext<typeof quoteEmits>['emit']
+
+const SWAP_FADE_MS = 200
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+export function useQuote(props: QuoteProps, emit: QuoteEmit) {
+  const isFromQuoteDone = ref(false)
+  const isToQuoteDone = ref(false)
+
+  const fromCurrencyObj = computed(() =>
+    props.fromCurrencies?.find((c: Currency) => c.code === props.fromCurrency) ?? null
+  )
+
+  const toCurrencyObj = computed(() =>
+    props.toCurrencies?.find((c: Currency) => c.code === props.toCurrency) ?? null
+  )
+
+  const hasCardError = computed(
+    () => props.action === 'FromError' || props.action === 'ToError' || props.action === 'Error'
+  )
+
+  const fromPlaceholder = computed(() => {
+    const decimals = fromCurrencyObj.value?.decimalPlaces ?? 2
+    return decimals > 0
+      ? `0${fromCurrencyObj.value?.decimalSeparator ?? ','}${'0'.repeat(decimals)}`
+      : '0'
+  })
+
+  const toPlaceholder = computed(() => {
+    const decimals = toCurrencyObj.value?.decimalPlaces ?? 2
+    return decimals > 0
+      ? `0${toCurrencyObj.value?.decimalSeparator ?? ','}${'0'.repeat(decimals)}`
+      : '0'
+  })
+
+  const swapRotation = ref(90)
+  const swapTransform = computed(() => `rotate(${swapRotation.value}deg)`)
+  const isSwapFading = ref(false)
+
+  watch(
+    () => props.isLoading,
+    (isLoading, wasLoading) => {
+      if (wasLoading && !isLoading) {
+        isFromQuoteDone.value = true
+        isToQuoteDone.value = true
+      }
+    }
+  )
+
+  function onFromInput(value: string) {
+    isFromQuoteDone.value = false
+    isToQuoteDone.value = false
+    emit('from-input', value)
+  }
+
+  function onToInput(value: string) {
+    isFromQuoteDone.value = false
+    isToQuoteDone.value = false
+    emit('to-input', value)
+  }
+
+  function onFromFocus() {
+    isFromQuoteDone.value = false
+    emit('from-focus')
+  }
+
+  function onToFocus() {
+    isToQuoteDone.value = false
+    emit('to-focus')
+  }
+
+  async function onSwap() {
+    isSwapFading.value = true
+    await delay(SWAP_FADE_MS)
+    emit('swap', {
+      from: props.toCurrency,
+      to: props.fromCurrency,
+      fromAmount: props.toAmount || '',
+      toAmount: props.fromAmount || '',
+      fromFlagCode: props.toFlagCode,
+      toFlagCode: props.fromFlagCode,
+    })
+    await nextTick()
+    isSwapFading.value = false
+    swapRotation.value = (swapRotation.value + 180) % 360
+  }
+
+  return {
+    isFromQuoteDone,
+    isToQuoteDone,
+    fromCurrencyObj,
+    toCurrencyObj,
+    hasCardError,
+    fromPlaceholder,
+    toPlaceholder,
+    swapTransform,
+    isSwapFading,
+    onFromInput,
+    onToInput,
+    onFromFocus,
+    onToFocus,
+    onSwap,
+  }
+}

--- a/components/quote/tsconfig.json
+++ b/components/quote/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "declarationDir": "./dist/types",
+    "outDir": "./dist",
+    "rootDir": "./"
+  },
+  "include": [
+    "./**/*.ts",
+    "./**/*.d.ts",
+    "./**/*.tsx",
+    "./**/*.vue",
+    "../shims-vue.d.ts"
+  ],
+  "exclude": ["dist", "vite.config.ts"]
+}

--- a/components/quote/vite.config.ts
+++ b/components/quote/vite.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig, mergeConfig } from 'vite';
+import baseConfig from '../../vite.config.base';
+import { resolve } from 'path';
+
+export default mergeConfig(baseConfig, defineConfig({
+  build: {
+    lib: {
+      entry: resolve(__dirname, 'index.ts'),
+      name: 'GQuote',
+    }
+  }
+}));

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "vite": "5.2.11",
     "vite-dts": "1.0.4",
     "vue": "3.5.18",
+    "vue-currency-input": "3.2.2",
     "vue-loader": "16.8.3",
     "vue-tsc": "2.2.12"
   },

--- a/stories/quote.stories.ts
+++ b/stories/quote.stories.ts
@@ -173,7 +173,7 @@ function useQuoteSimulator(initialFrom = 'CLP', initialTo = 'USD') {
 // ─── Meta ─────────────────────────────────────────────────────────────────────
 
 const meta: Meta<QuoteInstance> = {
-  title: 'Forms/Quote',
+  title: 'Form/Quote',
   component: GQuote,
   parameters: {
     layout: 'centered',

--- a/stories/quote.stories.ts
+++ b/stories/quote.stories.ts
@@ -1,0 +1,576 @@
+import { ref } from 'vue'
+import type { Meta, StoryObj } from '@storybook/vue3'
+import { GQuote, type QuoteInstance } from '../components/quote'
+import { GConfigProvider } from '../components/config-provider'
+import type { Currency } from '../components/quote'
+import { generatePeerDepsList, generatePeerDepsInstalls } from '../helper/documentation-stories'
+import { version, peerDependencies } from '../components/quote/package.json'
+
+// ─── Fixtures ────────────────────────────────────────────────────────────────
+
+const CLP: Currency = {
+  code: 'CLP',
+  name: 'Peso chileno',
+  flagCountryCode: 'CL',
+  symbol: '$',
+  decimalPlaces: 0,
+  thousandSeparator: '.',
+  decimalSeparator: ',',
+  locale: 'es-CL',
+}
+
+const COP: Currency = {
+  code: 'COP',
+  name: 'Peso colombiano',
+  flagCountryCode: 'CO',
+  symbol: '$',
+  decimalPlaces: 2,
+  thousandSeparator: '.',
+  decimalSeparator: ',',
+  locale: 'es-CO',
+}
+
+const USD: Currency = {
+  code: 'USD',
+  name: 'Dólar estadounidense',
+  flagCountryCode: 'US',
+  symbol: '$',
+  decimalPlaces: 2,
+  thousandSeparator: ',',
+  decimalSeparator: '.',
+  locale: 'en-US',
+}
+
+const PEN: Currency = {
+  code: 'PEN',
+  name: 'Sol peruano',
+  flagCountryCode: 'PE',
+  symbol: 'S/',
+  decimalPlaces: 2,
+  thousandSeparator: ',',
+  decimalSeparator: '.',
+  locale: 'es-PE',
+}
+
+const BRL: Currency = {
+  code: 'BRL',
+  name: 'Real brasileño',
+  flagCountryCode: 'BR',
+  symbol: 'R$',
+  decimalPlaces: 2,
+  thousandSeparator: '.',
+  decimalSeparator: ',',
+  locale: 'pt-BR',
+}
+
+const CURRENCIES: Currency[] = [CLP, COP, USD, PEN, BRL]
+
+const RATES: Record<string, number> = {
+  CLP_USD: 0.001075,
+  CLP_COP: 3.97,
+  CLP_PEN: 0.004,
+  CLP_BRL: 0.0055,
+  COP_USD: 0.00024,
+  COP_CLP: 0.252,
+  COP_PEN: 0.00096,
+  COP_BRL: 0.00138,
+  USD_CLP: 930,
+  USD_COP: 4150,
+  USD_PEN: 3.72,
+  USD_BRL: 5.05,
+  PEN_USD: 0.2688,
+  PEN_CLP: 248,
+  PEN_COP: 1080,
+  PEN_BRL: 1.36,
+  BRL_USD: 0.198,
+  BRL_CLP: 182,
+  BRL_COP: 800,
+  BRL_PEN: 0.735,
+}
+
+// ─── Composable reutilizable para la lógica de simulación ────────────────────
+
+function useQuoteSimulator(initialFrom = 'CLP', initialTo = 'USD') {
+  const fromCurrency = ref(initialFrom)
+  const toCurrency = ref(initialTo)
+  const fromAmount = ref('')
+  const toAmount = ref('')
+  const isLoading = ref(false)
+  const lastDirection = ref<'from' | 'to'>('from')
+  let debounceTimer: ReturnType<typeof setTimeout> | null = null
+
+  async function fetchQuote(amount: string, direction: 'from' | 'to') {
+    if (!amount || isNaN(parseFloat(amount))) {
+      direction === 'from' ? (toAmount.value = '') : (fromAmount.value = '')
+      return
+    }
+    isLoading.value = true
+    direction === 'from' ? (toAmount.value = '') : (fromAmount.value = '')
+
+    await new Promise((r) => setTimeout(r, 800))
+
+    const from = direction === 'from' ? fromCurrency.value : toCurrency.value
+    const to = direction === 'from' ? toCurrency.value : fromCurrency.value
+    const rate = RATES[`${from}_${to}`] ?? 1
+    const decimals = CURRENCIES.find((c) => c.code === to)?.decimalPlaces ?? 2
+    const result = parseFloat((parseFloat(amount) * rate).toFixed(decimals))
+
+    direction === 'from' ? (toAmount.value = String(result)) : (fromAmount.value = String(result))
+    isLoading.value = false
+  }
+
+  function scheduleQuote(amount: string, direction: 'from' | 'to') {
+    if (debounceTimer) clearTimeout(debounceTimer)
+    debounceTimer = setTimeout(() => fetchQuote(amount, direction), 600)
+  }
+
+  function handleFromInput(val: string) {
+    lastDirection.value = 'from'
+    fromAmount.value = val
+    scheduleQuote(val, 'from')
+  }
+
+  function handleToInput(val: string) {
+    lastDirection.value = 'to'
+    toAmount.value = val
+    scheduleQuote(val, 'to')
+  }
+
+  function handleFromCurrencyChange(currency: Currency) {
+    fromCurrency.value = currency.code
+    const amount = lastDirection.value === 'from' ? fromAmount.value : toAmount.value
+    if (amount) scheduleQuote(amount, lastDirection.value)
+  }
+
+  function handleToCurrencyChange(currency: Currency) {
+    toCurrency.value = currency.code
+    const amount = lastDirection.value === 'from' ? fromAmount.value : toAmount.value
+    if (amount) scheduleQuote(amount, lastDirection.value)
+  }
+
+  function handleSwap(payload: { from: string; to: string; fromAmount: string }) {
+    fromCurrency.value = payload.from
+    toCurrency.value = payload.to
+    fromAmount.value = payload.fromAmount
+    toAmount.value = ''
+    if (payload.fromAmount) scheduleQuote(payload.fromAmount, 'from')
+  }
+
+  return {
+    fromCurrency,
+    toCurrency,
+    fromAmount,
+    toAmount,
+    isLoading,
+    handleFromInput,
+    handleToInput,
+    handleFromCurrencyChange,
+    handleToCurrencyChange,
+    handleSwap,
+  }
+}
+
+// ─── Meta ─────────────────────────────────────────────────────────────────────
+
+const meta: Meta<QuoteInstance> = {
+  title: 'Forms/Quote',
+  component: GQuote,
+  parameters: {
+    layout: 'centered',
+    docs: {
+      description: {
+        component: `
+El componente Quote permite al usuario ingresar montos y seleccionar monedas para simular una cotización de cambio de divisas. Soporta entrada bidireccional, swap de monedas, estados de error y saldo disponible.
+
+> La versión de este componente es \`${version}\`.
+
+### Características principales
+
+- Entrada bidireccional: cotiza desde el origen o desde el destino
+- Selector de moneda con búsqueda por código o nombre
+- Botón de swap para intercambiar monedas
+- Estado de saldo disponible
+- Mensaje de error personalizable
+- Modo de entrada única (singleInput) para transferencias nacionales
+- Estado deshabilitado
+
+### Instalación
+
+\`\`\`bash
+yarn add @flash-global66/g-quote
+\`\`\`
+
+### Dependencias internas
+
+\`\`\`bash
+yarn add ${generatePeerDepsInstalls(peerDependencies)}
+\`\`\`
+
+### Dependencias externas
+
+\`\`\`bash
+yarn add ${generatePeerDepsInstalls(peerDependencies, true)}
+\`\`\`
+
+### Peer dependencies
+
+${generatePeerDepsList(peerDependencies)}
+
+### Importación
+
+\`\`\`typescript
+import { GQuote } from '@flash-global66/g-quote'
+import '@flash-global66/g-quote/styles.scss'
+\`\`\`
+
+### Tipo Currency
+
+\`\`\`typescript
+interface Currency {
+  code: string            // Código ISO (ej: 'CLP')
+  name: string            // Nombre completo (ej: 'Peso chileno')
+  flagCountryCode: string // Código de bandera (ej: 'CL')
+  symbol: string          // Símbolo (ej: '$')
+  decimalPlaces: number   // Decimales (ej: 0 para CLP, 2 para USD)
+  thousandSeparator: string
+  decimalSeparator: string
+  locale?: string         // Locale para formato (ej: 'es-CL')
+  alwaysVisible?: boolean // Siempre visible en búsqueda
+}
+\`\`\`
+`,
+      },
+    },
+  },
+  argTypes: {
+    action: {
+      description: 'Estado visual del componente',
+      control: { type: 'select' },
+      options: ['Default', 'NoValue', 'FromError', 'ToError', 'Error'],
+      table: {
+        type: { summary: 'QuoteAction' },
+        defaultValue: { summary: 'Default' },
+      },
+    },
+    isDisabled: {
+      description: 'Deshabilita toda la interacción',
+      control: { type: 'boolean' },
+      table: { type: { summary: 'boolean' }, defaultValue: { summary: 'false' } },
+    },
+    isLoading: {
+      description: 'Muestra estado de carga mientras se cotiza',
+      control: { type: 'boolean' },
+      table: { type: { summary: 'boolean' }, defaultValue: { summary: 'false' } },
+    },
+    fromLabel: {
+      description: 'Etiqueta del campo de origen',
+      control: { type: 'text' },
+      table: { type: { summary: 'string' } },
+    },
+    toLabel: {
+      description: 'Etiqueta del campo de destino',
+      control: { type: 'text' },
+      table: { type: { summary: 'string' } },
+    },
+    availableLabel: {
+      description: 'Texto del label de saldo disponible',
+      control: { type: 'text' },
+      table: { type: { summary: 'string' }, defaultValue: { summary: 'Disponible' } },
+    },
+    availableBalance: {
+      description: 'Texto formateado del saldo disponible (ya formateado)',
+      control: { type: 'text' },
+      table: { type: { summary: 'string' } },
+    },
+    errorMessage: {
+      description: 'Mensaje de error mostrado debajo del card',
+      control: { type: 'text' },
+      table: { type: { summary: 'string' } },
+    },
+    actionText: {
+      description: 'Texto del botón de acción (ej: cuando hay error de saldo)',
+      control: { type: 'text' },
+      table: { type: { summary: 'string' }, defaultValue: { summary: 'Cargar dinero' } },
+    },
+    showSwap: {
+      description: 'Muestra el botón para intercambiar monedas',
+      control: { type: 'boolean' },
+      table: { type: { summary: 'boolean' }, defaultValue: { summary: 'true' } },
+    },
+    singleInput: {
+      description: 'Oculta el campo de origen (útil para transferencias nacionales)',
+      control: { type: 'boolean' },
+      table: { type: { summary: 'boolean' }, defaultValue: { summary: 'false' } },
+    },
+    emptyResultsText: {
+      description: 'Texto cuando no hay resultados en la búsqueda de moneda',
+      control: { type: 'text' },
+      table: { type: { summary: 'string' }, defaultValue: { summary: 'Sin resultados' } },
+    },
+  },
+  args: {
+    action: 'Default',
+    fromLabel: 'Tú envías',
+    toLabel: 'Tu contacto recibe',
+    isDisabled: false,
+    isLoading: false,
+    showSwap: true,
+    singleInput: false,
+    availableBalance: '',
+    errorMessage: '',
+    actionText: 'Cargar dinero',
+    availableLabel: 'Disponible',
+    emptyResultsText: 'Sin resultados',
+  },
+}
+
+export default meta
+type Story = StoryObj<QuoteInstance>
+
+// ─── Básico (interactivo, controlado por args) ────────────────────────────────
+
+export const Basic: Story = {
+  name: 'Básico',
+  parameters: {
+    docs: {
+      description: {
+        story: 'Flujo completo con cotización simulada. Escribe un monto en cualquiera de los campos para disparar la cotización (debounce de 600ms). Cambia las monedas desde el selector o usa el swap.',
+      },
+    },
+  },
+  render: (args) => ({
+    components: { GQuote, GConfigProvider },
+    setup() {
+      const sim = useQuoteSimulator()
+      return { args, CURRENCIES, ...sim }
+    },
+    template: `
+      <g-config-provider>
+        <div style="width: 460px">
+          <g-quote
+            v-bind="args"
+            :from-currencies="CURRENCIES"
+            :to-currencies="CURRENCIES"
+            :from-currency="fromCurrency"
+            :to-currency="toCurrency"
+            :from-amount="fromAmount"
+            :to-amount="toAmount"
+            :is-loading="isLoading"
+            @from-input="handleFromInput"
+            @to-input="handleToInput"
+            @swap="handleSwap"
+            @from-currency-change="handleFromCurrencyChange"
+            @to-currency-change="handleToCurrencyChange"
+          />
+        </div>
+      </g-config-provider>
+    `,
+  }),
+}
+
+// ─── Con saldo disponible ─────────────────────────────────────────────────────
+
+export const WithAvailableBalance: Story = {
+  name: 'Con saldo disponible',
+  parameters: {
+    docs: {
+      description: {
+        story: 'Muestra el saldo disponible sobre el cotizador. El texto de `availableBalance` debe llegar ya formateado desde el consumidor.',
+      },
+    },
+  },
+  render: (args) => ({
+    components: { GQuote, GConfigProvider },
+    setup() {
+      const sim = useQuoteSimulator('COP', 'USD')
+      return { args, CURRENCIES, ...sim }
+    },
+    template: `
+      <g-config-provider>
+        <div style="width: 460px">
+          <g-quote
+            v-bind="args"
+            :from-currencies="CURRENCIES"
+            :to-currencies="CURRENCIES"
+            :from-currency="fromCurrency"
+            :to-currency="toCurrency"
+            :from-amount="fromAmount"
+            :to-amount="toAmount"
+            :is-loading="isLoading"
+            available-balance="$ 183.994.889 COP"
+            @from-input="handleFromInput"
+            @to-input="handleToInput"
+            @swap="handleSwap"
+            @from-currency-change="handleFromCurrencyChange"
+            @to-currency-change="handleToCurrencyChange"
+          />
+        </div>
+      </g-config-provider>
+    `,
+  }),
+}
+
+// ─── Error saldo insuficiente ─────────────────────────────────────────────────
+
+export const InsufficientBalance: Story = {
+  name: 'Error: saldo insuficiente',
+  parameters: {
+    docs: {
+      description: {
+        story: 'Cuando `action="FromError"` el componente muestra el botón de acción (por defecto "Cargar dinero") y el mensaje de error. El evento `action-click` notifica al consumidor para redirigir.',
+      },
+    },
+  },
+  render: () => ({
+    components: { GQuote, GConfigProvider },
+    setup() {
+      function handleActionClick() {
+        alert('Redirigir a cargar dinero')
+      }
+      return { CURRENCIES, handleActionClick }
+    },
+    template: `
+      <g-config-provider>
+        <div style="width: 460px">
+          <g-quote
+            from-currency="COP"
+            to-currency="USD"
+            from-amount="3672604"
+            to-amount=""
+            available-balance="$ 183.994.889 COP"
+            error-message="El monto que deseas convertir excede el saldo disponible"
+            action="FromError"
+            from-label="Tú envías"
+            to-label="Tu contacto recibe"
+            :from-currencies="CURRENCIES"
+            :to-currencies="CURRENCIES"
+            @action-click="handleActionClick"
+          />
+        </div>
+      </g-config-provider>
+    `,
+  }),
+}
+
+// ─── Estado deshabilitado ─────────────────────────────────────────────────────
+
+export const Disabled: Story = {
+  name: 'Deshabilitado',
+  parameters: {
+    docs: {
+      description: {
+        story: 'Estado `isDisabled` bloquea toda la interacción: inputs, selector de moneda y swap.',
+      },
+    },
+  },
+  render: () => ({
+    components: { GQuote, GConfigProvider },
+    setup() {
+      return { CURRENCIES }
+    },
+    template: `
+      <g-config-provider>
+        <div style="width: 460px">
+          <g-quote
+            from-currency="CLP"
+            to-currency="USD"
+            from-amount="100000"
+            to-amount="107.50"
+            from-label="Tú envías"
+            to-label="Tu contacto recibe"
+            :from-currencies="CURRENCIES"
+            :to-currencies="CURRENCIES"
+            is-disabled
+          />
+        </div>
+      </g-config-provider>
+    `,
+  }),
+}
+
+// ─── Single input (transferencia nacional) ───────────────────────────────────
+
+export const SingleInput: Story = {
+  name: 'Single input (nacional)',
+  parameters: {
+    docs: {
+      description: {
+        story: 'Con `single-input` solo se muestra el campo de destino. Útil para transferencias nacionales donde no hay conversión de moneda.',
+      },
+    },
+  },
+  render: () => ({
+    components: { GQuote, GConfigProvider },
+    setup() {
+      const toAmount = ref('')
+
+      function handleToInput(val: string) {
+        toAmount.value = val
+      }
+
+      return { CURRENCIES, toAmount, handleToInput }
+    },
+    template: `
+      <g-config-provider>
+        <div style="width: 460px">
+          <g-quote
+            from-currency="CLP"
+            to-currency="CLP"
+            :to-amount="toAmount"
+            from-label="Tú envías"
+            to-label="Tu contacto recibe"
+            :from-currencies="CURRENCIES"
+            :to-currencies="CURRENCIES"
+            single-input
+            @to-input="handleToInput"
+          />
+        </div>
+      </g-config-provider>
+    `,
+  }),
+}
+
+// ─── Sin swap ─────────────────────────────────────────────────────────────────
+
+export const NoSwap: Story = {
+  name: 'Sin swap',
+  parameters: {
+    docs: {
+      description: {
+        story: 'Con `show-swap="false"` se oculta el botón de intercambio. Útil cuando la dirección de la transacción es fija.',
+      },
+    },
+  },
+  render: (args) => ({
+    components: { GQuote, GConfigProvider },
+    setup() {
+      const sim = useQuoteSimulator('USD', 'PEN')
+      return { args, CURRENCIES, ...sim }
+    },
+    template: `
+      <g-config-provider>
+        <div style="width: 460px">
+          <g-quote
+            v-bind="args"
+            :from-currencies="CURRENCIES"
+            :to-currencies="CURRENCIES"
+            :from-currency="fromCurrency"
+            :to-currency="toCurrency"
+            :from-amount="fromAmount"
+            :to-amount="toAmount"
+            :is-loading="isLoading"
+            :show-swap="false"
+            from-label="Tú envías"
+            to-label="Tu contacto recibe"
+            @from-input="handleFromInput"
+            @to-input="handleToInput"
+            @from-currency-change="handleFromCurrencyChange"
+            @to-currency-change="handleToCurrencyChange"
+          />
+        </div>
+      </g-config-provider>
+    `,
+  }),
+}
+
+

--- a/yarn.lock
+++ b/yarn.lock
@@ -995,6 +995,18 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@flash-global66/g-quote@workspace:components/quote":
+  version: 0.0.0-use.local
+  resolution: "@flash-global66/g-quote@workspace:components/quote"
+  peerDependencies:
+    "@flash-global66/g-country-flag": ^0.0.1
+    "@flash-global66/g-dropdown": ^0.1.0
+    "@flash-global66/g-icon-font": ^0.13.0
+    vue: ^3.2.0
+    vue-currency-input: ^3.2.0
+  languageName: unknown
+  linkType: soft
+
 "@flash-global66/g-radio-group@workspace:components/radio-group":
   version: 0.0.0-use.local
   resolution: "@flash-global66/g-radio-group@workspace:components/radio-group"
@@ -1211,6 +1223,7 @@ __metadata:
     vite: "npm:5.2.11"
     vite-dts: "npm:1.0.4"
     vue: "npm:3.5.18"
+    vue-currency-input: "npm:3.2.2"
     vue-loader: "npm:16.8.3"
     vue-router: "npm:4.5.1"
     vue-tsc: "npm:2.2.12"
@@ -10316,6 +10329,15 @@ __metadata:
   version: 3.1.4
   resolution: "vue-component-type-helpers@npm:3.1.4"
   checksum: 10c0/82a30a3ee271bab57c697e04b46716521575fde6a1f397edeb8c69f9edf7fe705d8bbc9cafa501e6294ceaee9e5585daadf3f6385209479bd82f88ae54730b25
+  languageName: node
+  linkType: hard
+
+"vue-currency-input@npm:3.2.2":
+  version: 3.2.2
+  resolution: "vue-currency-input@npm:3.2.2"
+  peerDependencies:
+    vue: ^2.7 || ^3.0.0
+  checksum: 10c0/5fdcc415bffeecf72f50135b57fcb08d4c8457c7379067c9a0076668290b98d1c8ec94c9c07220ede31f5b932947d225b23959c77d636207816939c862052c71
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Cambios realizados

Implementación del componente `GQuote` (`@flash-global66/g-quote`).

**Funcionalidades:**
- Entrada bidireccional: el usuario puede ingresar monto desde el origen o el destino
- Selector de moneda con búsqueda por código o nombre, bandera y dropdown
- Botón de swap para intercambiar monedas con animación de fade
- Saldo disponible configurable sobre el cotizador
- Mensaje de error y acción personalizable (ej: "Cargar dinero")
- Modo `singleInput` para transferencias nacionales (oculta campo origen)
- Prop `showSwap` para ocultar el swap cuando la dirección es fija
- Estado deshabilitado global
- Accesibilidad: `<label>` semántico, `aria-label` en selector de moneda, `aria-invalid` en errores

**Stories:** 6 stories documentadas — Basic, WithAvailableBalance, InsufficientBalance, Disabled, SingleInput, NoSwap