### PR TITLE
[BMB-3288] Table: celdas select, GCellEdit, documentación Storybook y estilos

### DIFF
--- a/components/table/index.ts
+++ b/components/table/index.ts
@@ -36,6 +36,7 @@ export type {
 export { useTableCellSelect } from './src/composables/useTableCellSelect'
 export type {
   TableCellSelectOption,
+  TableCellSelectGetOptions,
   TableCellSelectCellOptions,
   UseTableCellSelectOptions,
 } from './src/composables/useTableCellSelect'

--- a/components/table/src/cell-edit/GCellEdit.vue
+++ b/components/table/src/cell-edit/GCellEdit.vue
@@ -1,8 +1,11 @@
 <template>
   <div
+    ref="cellRef"
     :class="wrapperClass"
     :style="wrapperStyle"
-    ref="cellRef"
+    :data-g-cell-edit-amount-peer="
+      outsideCloseScope === 'amountRowPeer' ? '' : undefined
+    "
   >
     <transition name="gui-table-cell-edit" mode="out-in">
       <div v-if="isEditing" ref="editWrapperRef" :class="editWrapperClass">
@@ -43,6 +46,7 @@ export interface GCellEditProps {
   expandDirection?: 'left' | 'right'
   expandedWidth?: number
   leftOffset?: number
+  outsideCloseScope?: 'cell' | 'amountRowPeer'
 }
 
 const props = withDefaults(defineProps<GCellEditProps>(), {
@@ -53,13 +57,16 @@ const props = withDefaults(defineProps<GCellEditProps>(), {
   expandColspan: undefined,
   expandDirection: undefined,
   expandedWidth: undefined,
-  leftOffset: undefined
+  leftOffset: undefined,
+  outsideCloseScope: 'cell'
 })
 
 const emit = defineEmits<{
   'update:modelValue': [value: boolean]
   toggle: [value: boolean]
   close: []
+  'cell-edit-open': [row: Record<string, unknown>, column: Record<string, unknown>]
+  'cell-edit-close': [row: Record<string, unknown>, column: Record<string, unknown>]
 }>()
 
 const cellRef = ref<HTMLElement>()
@@ -75,9 +82,18 @@ const focusFirstInput = (el: HTMLElement | null | undefined) => {
   }
 }
 
+const internalEditing = ref(props.modelValue)
+
+watch(() => props.modelValue, (val) => {
+  internalEditing.value = val
+})
+
 const isEditing = computed({
-  get: () => props.modelValue,
-  set: (val) => emit('update:modelValue', val)
+  get: () => internalEditing.value,
+  set: (val: boolean) => {
+    internalEditing.value = val
+    emit('update:modelValue', val)
+  }
 })
 
 const computedExpandedWidth = ref<number | undefined>(undefined)
@@ -126,16 +142,42 @@ const closeEdit = () => {
   if (table?.emit && props.column) {
     table.emit('cell-edit-close', props.row, props.column)
   }
+  emit('cell-edit-close', props.row, props.column)
   isEditing.value = false
   emit('close')
+}
+
+const POPPER_SELECTORS = '.el-popper, .el-select-dropdown, .gui-select-dropdown, .el-date-picker, .el-picker-panel'
+
+function isInsidePopper(target: Node): boolean {
+  const el = target as HTMLElement
+  return Boolean(el.closest?.(POPPER_SELECTORS))
+}
+
+function isTargetInsideCloseScope(target: Node): boolean {
+  if (props.outsideCloseScope === 'cell') {
+    return Boolean(cellRef.value?.contains(target))
+  }
+  if (props.outsideCloseScope === 'amountRowPeer') {
+    const tr = cellRef.value?.closest('tr')
+    if (!tr) return false
+    const peers = Array.from(
+      tr.querySelectorAll('[data-g-cell-edit-amount-peer]')
+    )
+    for (const el of peers) {
+      if (el.contains(target)) return true
+    }
+    return false
+  }
+  return false
 }
 
 function handleClickOutside(e: MouseEvent) {
   if (!isEditing.value) return
   const target = e.target as Node
-  if (cellRef.value && !cellRef.value.contains(target)) {
-    closeEdit()
-  }
+  if (isInsidePopper(target)) return
+  if (isTargetInsideCloseScope(target)) return
+  closeEdit()
 }
 
 function setupClickOutsideListener() {
@@ -198,10 +240,14 @@ const wrapperStyle = computed(() => {
 
 const toggleEdit = (e?: Event) => {
   if (e) setActiveTableFromEvent(e)
-  isEditing.value = !isEditing.value
-  emit('toggle', isEditing.value)
-  if (isEditing.value && table?.emit && props.column) {
-    table.emit('cell-edit-open', props.row, props.column)
+  const newValue = !isEditing.value
+  isEditing.value = newValue
+  emit('toggle', newValue)
+  if (newValue) {
+    if (table?.emit && props.column) {
+      table.emit('cell-edit-open', props.row, props.column)
+    }
+    emit('cell-edit-open', props.row, props.column)
   }
 }
 

--- a/components/table/src/composables/useTableCellSelect.ts
+++ b/components/table/src/composables/useTableCellSelect.ts
@@ -5,12 +5,17 @@ export interface TableCellSelectOption {
   value: string | number
   title?: string
   label?: string
+  description?: string
   icon?: string
 }
 
+export type TableCellSelectGetOptions = (row: unknown) => TableCellSelectOption[]
+
 export interface UseTableCellSelectOptions {
-  /** Opciones del select (formato { value, title } o { value, label }) */
-  options: TableCellSelectOption[]
+  /** Opciones estáticas del select (formato { value, title } o { value, label }). Se ignora si se provee getOptions. */
+  options?: TableCellSelectOption[]
+  /** Función que devuelve las opciones por fila. Tiene prioridad sobre options. */
+  getOptions?: TableCellSelectGetOptions
   /** Label del select que se muestra sobre el componente en modo edición */
   label?: string
   /** Si true, la clave de edición usa el índice de fila (default cuando no hay rowKey) */
@@ -25,6 +30,8 @@ export interface UseTableCellSelectOptions {
 
 export interface TableCellSelectCellOptions {
   options: TableCellSelectOption[]
+  /** Función que devuelve las opciones por fila. Si está presente, el renderer la usa en lugar de options. */
+  getOptions?: TableCellSelectGetOptions
   label?: string
   getEditing: (row: unknown, prop: string, index?: number) => boolean
   toggle: (row: unknown, prop: string, index?: number) => void
@@ -42,15 +49,21 @@ export interface TableCellSelectCellOptions {
  * La UI del select (GSelect) se renderiza siempre desde el UI system; no hace falta pasar ningún template ni slot.
  *
  * @example
- * const tableData = ref([...])
+ * // Opciones estáticas (mismo listado para todas las filas)
  * const { cellOptions } = useTableCellSelect(tableData, { options: statusOptions, useRowIndex: true })
- * // <g-table-column prop="status" label="Estado" cell-type="select" :cell-options="cellOptions" />
+ *
+ * // Opciones dinámicas por fila
+ * const { cellOptions } = useTableCellSelect(tableData, {
+ *   getOptions: (row) => getOptionsForProduct(row.product),
+ *   rowKey: 'id',
+ * })
  */
 export function useTableCellSelect<T extends Record<string, unknown>>(
   dataRef: Ref<T[]>,
   config: UseTableCellSelectOptions
 ): { cellOptions: TableCellSelectCellOptions } {
-  const { options, label, useRowIndex, rowKey, expandColspan, expandDirection } = config
+  const { options = [], getOptions, label, useRowIndex, rowKey, expandColspan, expandDirection } =
+    config
   const { getEditing, toggle, setEditing } = useEditableCell(dataRef, {
     useRowIndex,
     rowKey
@@ -58,6 +71,7 @@ export function useTableCellSelect<T extends Record<string, unknown>>(
 
   const cellOptions: TableCellSelectCellOptions = {
     options,
+    getOptions,
     label,
     getEditing,
     toggle,

--- a/components/table/src/table-column/cell-renderers/select-cell-renderer.ts
+++ b/components/table/src/table-column/cell-renderers/select-cell-renderer.ts
@@ -13,6 +13,7 @@ interface SelectOption {
   value: string | number
   title?: string
   label?: string
+  description?: string
 }
 
 function getColumnIndex(column: TableColumnCtx<unknown>, data: RenderCellData): number {
@@ -40,8 +41,9 @@ export function renderSelectCell(
   cellOptions?: Record<string, unknown>,
   table?: { emit: TableEmit }
 ): VNode | null {
-  const opts = (cellOptions?.options as SelectOption[]) || []
   const co = cellOptions as Record<string, unknown> | undefined
+  const getOptionsFn = co?.getOptions as ((row: unknown) => SelectOption[]) | undefined
+  const opts = getOptionsFn ? getOptionsFn(data.row) : ((co?.options as SelectOption[]) || [])
   const getEditing = co?.getEditing as ((r: unknown, p: string, i?: number) => boolean) | undefined
   const toggle = co?.toggle as ((r: unknown, p: string, i?: number) => void) | undefined
   const setEditing = co?.setEditing as ((key: string | null) => void) | undefined
@@ -107,7 +109,7 @@ export function renderSelectCell(
     }
 
     const editVNode = h(GSelect, {
-      class: 'gui-table-cell-select w-full px-xs',
+      class: 'gui-table-cell-select gui-table-cell-select-editing w-full min-w-0 px-xs',
       modelValue: val,
       label: fieldLabel,
       automaticDropdown: true,
@@ -137,9 +139,11 @@ export function renderSelectCell(
     const readVNode = h(
       'div',
       {
-        class: 'gui-table-cell-select-read w-full h-full flex items-center px-xs',
+        class:
+          'gui-table-cell-select-read w-full h-full min-w-0 max-w-full flex items-center justify-start overflow-hidden px-xs',
         role: 'button',
         tabIndex: 0,
+        title: displayText,
         onClick: (e: MouseEvent) => {
           setActiveTableFromEvent(e)
           toggle(row, prop, idx)
@@ -158,11 +162,21 @@ export function renderSelectCell(
           }
         }
       },
-      displayText
+      [
+        h(
+          'span',
+          {
+            class:
+              'gui-table-cell-select-read__label min-w-0 w-full flex-1 text-left text-pretty break-words leading-snug line-clamp-2'
+          },
+          displayText
+        )
+      ]
     )
 
     const wrapperStyle: Record<string, string> = {}
-    const wrapperClass = 'gui-table-cell-edit-wrapper absolute top-0 left-0 h-full w-full flex items-center justify-center transition-all duration-200 ease-in hover:bg-everBlue-100 hover:bg-opacity-30'
+    const wrapperClass =
+      'gui-table-cell-edit-wrapper absolute top-0 left-0 h-full w-full flex items-center justify-start transition-all duration-200 ease-in hover:bg-everBlue-100 hover:bg-opacity-30'
 
     if (isEditing) {
       wrapperStyle.zIndex = '10'
@@ -188,9 +202,18 @@ export function renderSelectCell(
       },
       [
         h(
-          Transition,
-          { name: 'gui-table-cell-edit', mode: 'out-in' },
-          { default: () => (isEditing ? editVNode : readVNode) }
+          'div',
+          {
+            class:
+              'gui-table-cell-select-inner min-h-0 min-w-0 w-full h-full flex items-center justify-start'
+          },
+          [
+            h(
+              Transition,
+              { name: 'gui-table-cell-edit', mode: 'out-in' },
+              { default: () => (isEditing ? editVNode : readVNode) }
+            )
+          ]
         )
       ]
     )

--- a/components/table/src/table.styles.scss
+++ b/components/table/src/table.styles.scss
@@ -12,7 +12,8 @@
 
 @include b('table') {
   tbody {
-    &:has(.gui-table-cell-input-editing) {
+    &:has(.gui-table-cell-input-editing),
+    &:has(.gui-table-cell-select-editing) {
       overflow: visible !important;
     }
   }
@@ -76,7 +77,8 @@
         @apply bg-everBlue-100 bg-opacity-30;
       }
     }
-    &:has(.gui-table-cell-input-editing) {
+    &:has(.gui-table-cell-input-editing),
+    &:has(.gui-table-cell-select-editing) {
       overflow: visible !important;
       & .cell {
         overflow: visible !important;
@@ -110,11 +112,27 @@
         @apply border-everBlue-200;
       }
     }
+    // Select read: cell .cell already sets min-height; avoid double min-height + extra vertical padding.
     & .gui-table-cell-select-read {
-      @apply w-full flex items-center justify-center cursor-pointer outline-none py-xxs px-xs rounded;
-      min-height: 3.8rem;
+      @apply w-full h-full min-h-0 max-w-full flex items-center justify-start cursor-pointer outline-none py-0 px-xs rounded;
       &:focus {
         @apply ring-1 ring-everBlue-200 ring-offset-0;
+      }
+    }
+    & .gui-table-cell-select-inner {
+      @apply min-w-0 w-full h-full flex items-center justify-start;
+    }
+    & .gui-table-cell-edit-wrapper:has(.gui-table-cell-select-inner) {
+      justify-content: flex-start;
+    }
+
+    // align="center" sets is-center + text-align:center on the td; select editors should stay
+    // left-aligned like Storybook (columns without align).
+    &.is-center:has(.gui-table-cell-select-inner) {
+      text-align: left;
+
+      & .cell {
+        justify-content: flex-start;
       }
     }
     & .gui-table-cell-input {
@@ -132,8 +150,11 @@
       }
     }
     & .gui-table-cell-edit-wrapper {
-      @apply w-full flex items-center;
+      @apply w-full flex items-center bg-white;
       min-height: 3.8rem;
+      &:hover {
+        @apply bg-everBlue-100 !important;
+      }
       &.has-textarea {
         @apply items-start;
         align-items: flex-start;
@@ -224,7 +245,7 @@
   }
 
   @include e('row') {
-    @apply transition-all duration-200 ease-in;
+    @apply transition-colors duration-200 ease-in;
 
     /* &:has(.is-checked) {
       @apply bg-everBlue-50 border-everBlue-100 !important;
@@ -234,6 +255,9 @@
       & .gui-table__cell {
         @apply bg-everBlue-50 !important;
       }
+    }
+    &:hover .gui-table-cell-edit-wrapper {
+      @apply bg-everBlue-50;
     }
     @include m('striped') {
       & .gui-table__cell {
@@ -245,6 +269,30 @@
   & .gui-table-column--selection {
     & .cell {
       @apply flex items-center justify-center h-9;
+    }
+  }
+
+  // Horizontal scroll: instant content motion; no shadow/transition easing on fixed columns.
+  @include e('body-wrapper') {
+    .gui-scrollbar__wrap {
+      scroll-behavior: auto;
+    }
+  }
+
+  @include e((header-wrapper, body-wrapper, footer-wrapper)) {
+    tr {
+      td,
+      th {
+        &.gui-table-fixed-column--left,
+        &.gui-table-fixed-column--right {
+          &.is-last-column,
+          &.is-first-column {
+            &::before {
+              transition: none;
+            }
+          }
+        }
+      }
     }
   }
 }

--- a/components/table/src/table/defaults.ts
+++ b/components/table/src/table/defaults.ts
@@ -103,6 +103,12 @@ interface TableProps<T> {
   width?: string | number
   height?: string | number
   maxHeight?: string | number
+  /**
+   * Ancho mínimo en px del área scrollable de la tabla (suma efectiva del `<table>`).
+   * Tras el layout normal, si el valor parseado es mayor que el ancho calculado, se fuerza ese mínimo
+   * y se activa scroll horizontal cuando el contenedor es más estrecho.
+   */
+  scrollMinWidth?: string | number
   fit?: boolean
   stripe?: boolean
   border?: boolean
@@ -210,6 +216,10 @@ export default {
    * @description table's max-height. The legal value is a number or the height in px
    */
   maxHeight: [String, Number],
+  /**
+   * @description minimum width (px) of the table for horizontal scroll; see TableProps.scrollMinWidth
+   */
+  scrollMinWidth: [String, Number],
   /**
    * @description whether width of column automatically fits its container
    */

--- a/components/table/src/table/style-helper.ts
+++ b/components/table/src/table/style-helper.ts
@@ -14,6 +14,7 @@ import type { Table, TableProps } from './defaults'
 import type { Store } from '../store'
 import type TableLayout from '../table-layout'
 import type { TableColumnCtx } from '../table-column/defaults'
+import { parseWidth } from '../util'
 
 function useStyle<T>(
   props: TableProps<T>,
@@ -107,17 +108,41 @@ function useStyle<T>(
     }
   })
 
+  function applyScrollMinWidth() {
+    const raw = props.scrollMinWidth
+    if (raw === undefined || raw === null || raw === '') return
+    const parsed = parseWidth(raw)
+    if (parsed === '') return
+    const minW = Number(parsed)
+    if (!Number.isFinite(minW) || minW <= 0) return
+    const el = table.vnode.el as HTMLElement | undefined
+    if (!el) return
+    const current = Number(layout.bodyWidth.value) || 0
+    const nextWidth = Math.max(current, minW)
+    layout.bodyWidth.value = nextWidth
+    layout.scrollX.value = nextWidth > el.clientWidth
+  }
+
   const doLayout = () => {
     if (shouldUpdateHeight.value) {
       layout.updateElsHeight()
     }
     layout.updateColumnsWidth()
+    applyScrollMinWidth()
 
     // When the test case is running, the context environment simulated by jsdom may have been destroyed,
     // and window.requestAnimationFrame does not exist at this time.
     if (typeof window === 'undefined') return
     requestAnimationFrame(syncPosition)
   }
+
+  watch(
+    () => props.scrollMinWidth,
+    () => {
+      nextTick(() => doLayout())
+    }
+  )
+
   onMounted(async () => {
     await nextTick()
     store.updateColumns()

--- a/stories/table.stories.ts
+++ b/stories/table.stories.ts
@@ -103,11 +103,20 @@ yarn add ${generatePeerDepsInstalls(peerDependencies, true)}
 
 ## Celdas editables
 
+**Si usas \`cell-type="select"\`** (en especial con opciones que traen \`description\`), importa también los estilos de **GSelect** además de los de la tabla; sin ellos el menú del desplegable puede verse incompleto o sin los recortes de texto esperados.
+
+\`\`\`typescript
+import '@flash-global66/g-table/styles.scss'
+import '@flash-global66/g-select/styles.scss'
+\`\`\`
+
+**Alineación:** en columnas con select se recomienda dejar \`align\` por defecto o usar \`left\`. Si pones \`align="center"\`, los estilos de tabla **siguen mostrando el contenido del select alineado a la izquierda** en lectura y edición (comportamiento deliberado para alinearlo con columnas sin \`center\`). Un centrado explícito del texto del select sería un cambio de producto distinto.
+
 Para implementar celdas editables (input, select o UI personalizada con \`GCellEdit\`), expansión del overlay, eventos y validación, consulte la guía dedicada:
 
 👉 **[Guía: Celdas editables en Table](/docs/concept-guide-celdas-editables-en-table--docs)**
 
-En esta documentación de Table encontrará las historias de ejemplo: **Celda tipo select**, **Celda tipo input**, **Celda personalizada con GCellEdit**, **Eventos de celdas editables** y las de expansión.
+En esta documentación de Table encontrará historias de ejemplo alineadas con el comportamiento actual: **Celda tipo select**, **Celda tipo select (con description)** (menú con descripción acotada a dos líneas; en lectura solo el título de la opción), **Celda tipo input**, **Celda personalizada con GCellEdit**, **Eventos de celdas editables** y las de expansión.
 `
       }
     }
@@ -2437,6 +2446,12 @@ export const TableCellSelect: Story = {
 
 **Label:** \`input-label\` en \`GTableColumn\` o \`label\` en \`cellOptions\`; se muestra sobre el select en modo edición.
 
+**Modo lectura:** en la celda se muestra el texto de la opción elegida (\`title\` o \`label\`). Si tus opciones llevan \`description\`, esa segunda línea **no** aparece en la celda; solo en el menú al editar (véase la historia **Celda tipo select (con description)**).
+
+**Texto largo o celda estrecha:** el valor en lectura puede mostrarse en hasta **dos líneas** con recorte; el atributo nativo \`title\` del control ofrece el **texto completo** al pasar el cursor (tooltip del navegador).
+
+**Alineación:** conviene \`align\` por defecto o \`left\`. Con \`align="center"\` la tabla fuerza el bloque del select **alineado a la izquierda** dentro del \`td\` (documentado en la página principal de Table).
+
 **Ejemplo de implementación:**
 
 \`\`\`vue
@@ -2463,7 +2478,7 @@ const tableData = ref([
 ])
 
 const statusOptions = [
-  { value: 'active', title: 'Activo' },
+  { value: 'active', title: 'Activo Activo Activo Activo Activo Activo Activo Activo Activo Activo Activo Activo Activo Activo Activo ' },
   { value: 'pending', title: 'Pendiente' },
   { value: 'inactive', title: 'Inactivo' }
 ]
@@ -2608,7 +2623,7 @@ const { cellOptions } = useTableCellSelect(tableData, {
         }
       ])
       const statusOptions = [
-        { value: 'active', title: 'Activo' },
+        { value: 'active', title: 'Activo Activo Activo Activo Activo Activo Activo Activo Activo Activo Activo Activo Activo Activo Activo ' },
         { value: 'pending', title: 'Pendiente' },
         { value: 'inactive', title: 'Inactivo' }
       ]
@@ -2675,7 +2690,7 @@ const { cellOptions } = useTableCellSelect(tableData, {
         <g-table-column
           prop="role"
           label="Rol"
-          width="150"
+          width="200"
           cell-type="select"
           :cell-options="roleCellOptions"
           input-label="Rol del usuario"
@@ -2701,6 +2716,143 @@ const { cellOptions } = useTableCellSelect(tableData, {
       </g-table>
     </g-config-provider>`
   })
+}
+
+export const TableCellSelectWithDescription: Story = {
+  name: 'Celda tipo select (con description)',
+  parameters: {
+    docs: {
+      description: {
+        story: `**Cuándo usar:** cuando cada opción debe mostrar **título** y **texto aclaratorio** en el menú del \`GSelect\` al editar (p. ej. motivos de transferencia con ayuda contextual).
+
+**Formato:** \`{ value, title, description? }\` en \`options\` o en lo que devuelva \`getOptions\`. \`GSelect\` muestra la descripción como segunda línea bajo el título de cada ítem.
+
+**Menú (edición):** la descripción de cada opción está **limitada a dos líneas** en el listado, con puntos suspensivos si el texto es más largo. El título del ítem sigue en una sola línea con recorte horizontal si hace falta.
+
+**Ancho del panel:** lo controla **GSelect** (p. ej. \`fit-input-width\` en el componente o valores por defecto del design system), no la tabla. La tabla solo reserva el ancho de la columna y, si aplica, el \`expandColspan\` del overlay en edición.
+
+**Modo lectura:** en la celda solo se ve el **título** (\`title\` / \`label\`) de la opción elegida. La \`description\` sirve para orientar al usuario **al abrir** el desplegable. Si el título es largo o la columna es estrecha, en lectura puede mostrarse hasta **dos líneas** con recorte; el **tooltip nativo** (\`title\`) del control muestra el texto completo al pasar el cursor. El contenido queda alineado a la izquierda.
+
+**Código mínimo:**
+
+\`\`\`ts
+const purposeOptions = [
+  { value: 1, title: 'Pago a proveedores', description: 'A proveedores nacionales o internacionales.' },
+  { value: 2, title: 'Servicios digitales', description: 'Plataformas publicitarias, SaaS, etc.' }
+]
+const { cellOptions } = useTableCellSelect(tableData, {
+  options: purposeOptions,
+  label: 'Motivo',
+  rowKey: 'id'
+})
+\`\`\``
+      }
+    }
+  },
+  render: () => ({
+    components: { GTable, GTableColumn, GConfigProvider },
+    setup() {
+      const tableData = ref([
+        { id: 1, name: 'Empresa Alpha', purpose: 1 },
+        { id: 2, name: 'Empresa Beta', purpose: 2 },
+        { id: 3, name: 'Empresa Gamma', purpose: 3 }
+      ])
+      const purposeOptions = [
+        {
+          value: 1,
+          title: 'Pago a proveedores',
+          description: 'Transferencias a proveedores nacionales o internacionales.'
+        },
+        {
+          value: 2,
+          title: 'Pago de servicios digitales y plataformas',
+          description:
+            'Incluye plataformas publicitarias, SaaS y otros servicios en línea.'
+        },
+        {
+          value: 3,
+          title: 'Otros conceptos',
+          description: 'Operaciones que no encajan en las categorías anteriores.'
+        }
+      ]
+      const { cellOptions: purposeCellOptions } = useTableCellSelect(tableData, {
+        options: purposeOptions,
+        label: 'Motivo',
+        rowKey: 'id',
+        expandColspan: 2,
+        expandDirection: 'right'
+      })
+      return { tableData, purposeCellOptions }
+    },
+    template: `
+    <g-config-provider>
+      <p class="text-3 text-secondary-txt mb-md max-w-xl">
+        Columna «Motivo» estrecha (120px): en lectura solo el <strong>título</strong> de la opción (hasta 2 líneas con recorte); pasa el cursor para el texto completo vía <code class="text-2">title</code>. Al editar, en el menú cada opción muestra título + <code class="text-2">description</code> (la descripción, como máximo 2 líneas en el listado).
+      </p>
+      <g-table :data="tableData" style="width: 100%" :cell-style="{ zIndex: 'auto' }">
+        <g-table-column prop="name" label="Nombre" width="200" />
+        <g-table-column
+          prop="purpose"
+          label="Motivo"
+          min-width="120"
+          width="120"
+          cell-type="select"
+          :cell-options="purposeCellOptions"
+          empty-action-text="Seleccionar"
+        />
+      </g-table>
+    </g-config-provider>`
+  })
+}
+
+export const TableScrollMinWidth: Story = {
+  name: 'Scroll horizontal (scroll-min-width)',
+  parameters: {
+    docs: {
+      description: {
+        story: `**Cuándo usar:** el contenedor es más estrecho que el contenido que quieres mostrar y necesitas un **ancho mínimo total** del área de la tabla (scroll horizontal).
+
+**Prop \`scroll-min-width\`** (número o string en px): después del layout de columnas, el ancho del \`<table>\` será al menos ese valor; si el wrapper es más angosto, aparece scroll horizontal (\`gui-table--scrollable-x\`).
+
+**Cuándo no hace falta:** si todas las columnas tienen \`width\` / \`min-width\` y la suma ya supera el contenedor, \`fit\` puede activar el scroll solo. Usa \`scroll-min-width\` cuando quieras un **piso explícito** (p. ej. tablas en viewport móvil) aunque las columnas flex sumen menos.`,
+      },
+    },
+  },
+  render: () => ({
+    components: { GTable, GTableColumn, GConfigProvider },
+    setup() {
+      const tableData = ref([
+        { id: 1, colA: 'Alpha', colB: 'Beta', colC: 'Gamma', colD: 'Delta', colE: 'Épsilon' },
+        { id: 2, colA: 'A2', colB: 'B2', colC: 'C2', colD: 'D2', colE: 'E2' },
+        { id: 3, colA: 'A3', colB: 'B3', colC: 'C3', colD: 'D3', colE: 'E3' },
+      ])
+      return { tableData }
+    },
+    template: `
+    <g-config-provider>
+      <p class="text-3 text-secondary-txt mb-md max-w-sm">
+        Contenedor de 360px; la tabla fuerza un ancho mínimo de 900px — usa el scroll horizontal.
+      </p>
+      <div
+        class="rounded-md overflow-hidden border border-everBlue-100"
+        style="width: 360px; max-width: 100%;"
+      >
+        <g-table
+          :data="tableData"
+          border
+          :scroll-min-width="6000"
+          class="w-full"
+        >
+          <g-table-column prop="id" label="ID" width="80" />
+          <g-table-column prop="colA" label="Columna A" width="160" />
+          <g-table-column prop="colB" label="Columna B" width="160" />
+          <g-table-column prop="colC" label="Columna C" width="160" />
+          <g-table-column prop="colD" label="Columna D" width="160" />
+          <g-table-column prop="colE" label="Columna E" width="160" />
+        </g-table>
+      </div>
+    </g-config-provider>`,
+  }),
 }
 
 export const TableCellInput: Story = {


### PR DESCRIPTION
…## Historia de Usuario
**RESPONSABLE**

| Nombre | Equipo | Proyecto / Iniciativa | HU del desarrollo |
|:------:|:------:|:---------------------:|:------------------|
| Brayan Basallo | B2B / Design System | global-design-system | [BMB-3288](https://global66.atlassian.net/browse/BMB-3288) |

**CONTEXTO**

Se ajusta el comportamiento y la documentación de **GTable** para celdas **`cell-type="select"`** (lectura/edición, opciones con `description`, alineación frente a columnas `align="center"`), cambios en **GCellEdit**, tipos/export en el paquete **g-table**, estilos en `table.styles.scss` y **Storybook** (`table.stories.ts`) para que equipos que no participaron del desarrollo sepan cómo consumir select + estilos de **GSelect** y qué esperar en UI.

---

**FLUJOS AFECTADOS**

* Consumo de **@flash-global66/g-table** en aplicaciones que usan celdas editables tipo **select** (p. ej. tablas con motivos, estados, listas).
* Integración con **@flash-global66/g-select** (import de `styles.scss` recomendado en la documentación).
* Storybook **Data/Table** (historias de celda select, con/sin `description`, scroll mínimo cuando aplique).

---

**CAMBIOS REALIZADOS**

* Renderer y estilos de celda **select** (lectura alineada, coherencia con columnas centradas, tooltip/`title` en lectura truncada).
* **GCellEdit** y composable **useTableCellSelect** (incl. opciones/tipos exportados si aplica en el diff).
* **defaults** / **style-helper** de tabla según cambios del paquete.
* **stories/table.stories.ts**: documentación para consumidores (import `g-select` styles, descripción máx. 2 líneas en menú, lectura solo título, alineación, historias de ejemplo).

---

**EXTRA INFO**

* Figma: (indicar URL si la HU lo exige; si no aplica: N/A)
* Tests unitarios: (indicar si se añadieron/modificaron tests en g-table; si no: *Sin cambios en tests en este PR* o *Pendiente / N/A*)
* Feature Flag: N/A