### PR TITLE
[BMB-3312] Chore: Bump g-select peer en g-table

### DIFF
--- a/components/table/package.json
+++ b/components/table/package.json
@@ -33,7 +33,7 @@
     "@flash-global66/g-icon-font": "^0.0.8",
     "@flash-global66/g-input": "^0.3.0",
     "@flash-global66/g-scrollbar": "^0.1.0",
-    "@flash-global66/g-select": "^0.3.0",
+    "@flash-global66/g-select": "^0.3.4",
     "@flash-global66/g-tooltip": "^0.1.0",
     "async-validator": "^4.2.5",
     "element-plus": "^2.9.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1119,7 +1119,7 @@ __metadata:
     "@flash-global66/g-icon-font": ^0.0.8
     "@flash-global66/g-input": ^0.3.0
     "@flash-global66/g-scrollbar": ^0.1.0
-    "@flash-global66/g-select": ^0.3.0
+    "@flash-global66/g-select": ^0.3.4
     "@flash-global66/g-tooltip": ^0.1.0
     async-validator: ^4.2.5
     element-plus: ^2.9.0


### PR DESCRIPTION
## Historia de Usuario
**RESPONSABLE**

| Nombre               | Equipo   | Proyecto / Iniciativa  | HU del desarrollo                                          |
|:--------------------:|:--------:|:----------------------:|:-----------------------------------------------------------|
| Brayan Basallo       | B2B      | Design System          | [BMB-3312](https://global66.atlassian.net/browse/BMB-3312) |

**CONTEXTO**

Actualización del peer `@flash-global66/g-select` del paquete `@flash-global66/g-table` para alinearlo con la versión publicada del select y mantener consistencia en el monorepo del Design System.

---

**FLUJOS AFECTADOS**

* Consumo de `@flash-global66/g-table` en aplicaciones que resuelven peers (p. ej. B2B) al instalar o actualizar dependencias.

---

**CAMBIOS REALIZADOS**

* `components/table/package.json`: peer `@flash-global66/g-select` de `^0.3.0` a `^0.3.4`.
* `yarn.lock`: entrada actualizada para reflejar el peer en el workspace.

----

**EXTRA INFO**

* Figma: N/A
* Tests unitarios: Sin cambios de código de tests en este PR (solo dependencias / lockfile).
* Feature Flag: N/A