### PR TITLE
  [BMB-3336] fix: focus input on mask click in InputCode password mode

### DIFF
--- a/components/input-code/InputCode.vue
+++ b/components/input-code/InputCode.vue
@@ -274,6 +274,7 @@ defineExpose({
             { disabled: disabled },
             classContentInput(index),
           ]"
+          @click="inputs[index + 1]?.focus()"
         >
           <input
             :ref="(el) => setInputs(el, index + 1)"


### PR DESCRIPTION
 Descripción:
                                                                                                                                                                                                                             
  ## Historia de Usuario                                    
  **RESPONSABLE**                                                                                                                                                                                                            
  
  | Nombre  | Equipo          | Proyecto        | HU del desarrollo                                                        |                                                                                                 
  |:-------:|:---------------:|:---------------:|:-------------------------------------------------------------------------|
  | Brayan  | Design System   | global-design-system | [BMB-3336](https://global66.atlassian.net/browse/BMB-3336)          |                                                                                                 
                                                                                                                                                                                                                             
  **CONTEXTO**
                                                                                                                                                                                                                             
  El componente `GInputCode` con la propiedad `password` activa muestra círculos/puntos                                                                                                                                      
  como máscara visual sobre cada campo. Al hacer clic sobre esos elementos, el foco no
  llegaba al `<input>` subyacente, generando fricción o bloqueo para el usuario.                                                                                                                                             
                                                                                                                                                                                                                             
  ---                                                                                                                                                                                                                        
                                                                                                                                                                                                                             
  **FLUJOS AFECTADOS**                                      

  * Cualquier flujo que use `GInputCode` con `password: true` (ej: ingreso de PIN/OTP).                                                                                                                                      
  
  ---                                                                                                                                                                                                                        
                                                            
  **CAMBIOS REALIZADOS**

  Se agrega `@click="inputs[index + 1]?.focus()"` en el wrapper `.gui-input-item` de                                                                                                                                         
  cada campo. Los pseudo-elementos (`::before`/`::after`) que renderizan los
  círculos/puntos son parte del div, por lo que el click sobre ellos dispara el handler                                                                                                                                      
  del wrapper y enfoca el input correcto. El optional chaining protege el caso donde                                                                                                                                         
  el ref aún no esté montado.                                                                                                                                                                                                
                                                                                                                                                                                                                             
  **Archivo modificado:** `components/input-code/InputCode.vue` (+1 línea)                                                                                                                                                   
                                                            
  ---                                                                                                                                                                                                                        
                                                            
  **EXTRA INFO**

  * Figma: N/A                                                                                                                                                                                                               
  * Tests unitarios: N/A (cambio de una línea, comportamiento de foco nativo)
  * Feature Flag: N/A                                                                                                                                                                                                        