### PR TITLE
[BMB-3415] feat(table): add hover pen icon on editable cells

### DIFF
--- a/components/table/src/cell-edit/GCellEdit.vue
+++ b/components/table/src/cell-edit/GCellEdit.vue
@@ -14,10 +14,24 @@
       <button
         v-else
         type="button"
-        class="w-full h-full flex items-center px-xs cursor-pointer border-0 bg-transparent text-left font-inherit text-primary-txt"
+        class="relative w-full h-full flex items-center px-xs cursor-pointer border-0 bg-transparent text-left font-inherit text-primary-txt"
         @click="handleClick"
         @keydown="handleKeydown"
       >
+        <span
+          class="absolute top-xs right-xs opacity-0 group-hover:opacity-100 transition-opacity duration-150"
+        >
+          <span class="group/badge inline-flex items-center justify-center p-0.5 rounded-sm bg-primary-bg border border-primary-bd hover:border-secondary-bd transition-colors duration-150 cursor-pointer">
+            <span class="px-1 rounded-sm hover:bg-sec-hover-bg transition-colors duration-150">
+              <GIconFont
+                name="regular pen"
+                class="text-icon-primary group-hover/badge:text-icon-secondary leading-none"
+                style="font-size: 10px"
+                :aria-hidden="true"
+              />
+            </span>
+          </span>
+        </span>
         <slot name="view" :toggle="toggleEdit"></slot>
       </button>
     </transition>
@@ -26,6 +40,7 @@
 
 <script setup lang="ts">
 import { computed, inject, ref, watch, nextTick, onUnmounted } from 'vue'
+import { GIconFont } from '@flash-global66/g-icon-font'
 import { TABLE_INJECTION_KEY } from '../tokens'
 import {
   calculateExpandedWidthSync,
@@ -209,7 +224,7 @@ onUnmounted(() => {
 })
 
 const wrapperClass = computed(() => {
-  const base = 'absolute top-0 left-0 h-full w-full flex items-center justify-center transition-all duration-200 ease-in'
+  const base = 'group absolute top-0 left-0 h-full w-full flex items-center justify-center transition-all duration-200 ease-in'
   if (isEditing.value) {
     return `${base} gui-table-cell-edit-wrapper hover:bg-everBlue-100 hover:bg-opacity-30 z-10`
   }

--- a/components/table/src/table-column/cell-renderers/input-cell-renderer.ts
+++ b/components/table/src/table-column/cell-renderers/input-cell-renderer.ts
@@ -1,5 +1,6 @@
 import { h, Transition, ref, type VNode } from 'vue'
 import { GInput } from '@flash-global66/g-input'
+import { GIconFont } from '@flash-global66/g-icon-font'
 import type { TableColumnCtx } from '../defaults'
 import type { RenderCellData } from './types'
 import type { TableCellValidationApi } from '../../composables/useTableCellValidation'
@@ -237,7 +238,7 @@ function createReadVNode(
   return h(
     'div',
     {
-      class: `w-full h-full flex items-center justify-center cursor-pointer px-xs ${errorReadClass}`,
+      class: `relative w-full h-full flex items-center justify-center cursor-pointer px-xs ${errorReadClass}`,
       role: 'button',
       tabIndex: 0,
       onClick: (e: MouseEvent) => {
@@ -261,11 +262,27 @@ function createReadVNode(
       }
     },
     [
+      h('span', {
+        class: 'absolute top-xs right-xs opacity-0 group-hover:opacity-100 transition-opacity duration-150'
+      }, [
+        h('span', {
+          class: 'group/badge inline-flex items-center justify-center p-0.5 rounded-sm bg-primary-bg border border-primary-bd hover:border-secondary-bd transition-colors duration-150 cursor-pointer'
+        }, [
+          h('span', { class: 'px-1 rounded-sm hover:bg-sec-hover-bg transition-colors duration-150' }, [
+            h(GIconFont as unknown as string, {
+              name: 'regular pen',
+              class: 'text-icon-primary group-hover/badge:text-icon-secondary leading-none',
+              style: { fontSize: '10px' },
+              'aria-hidden': true
+            })
+          ])
+        ])
+      ]),
       h('div', { class: 'flex flex-col items-center w-full min-w-0 overflow-hidden' }, [
         isEmpty && emptyActionText
           ? h(
               'span',
-              { class: `font-medium text-3 line-clamp-2 text-center px-xs w-full ${isValidationError ? 'text-error-def' : 'text-gray-500'}` },
+              { class: `font-medium text-3 line-clamp-2 text-center px-xs w-full ${isValidationError ? 'text-error-def' : 'text-gray-700'}` },
               emptyActionText
             )
           : h(
@@ -287,8 +304,8 @@ function computeWrapperClasses(
   computedEditingClasses: string | Record<string, boolean> | undefined
 ): string {
   let wrapperClass = config.isEditing
-    ? `${cellWrapperClass} gui-table-cell-input-wrapper gui-table-cell-input-editing hover:bg-everBlue-100 hover:bg-opacity-30`
-    : `${cellWrapperClass} gui-table-cell-input-wrapper gui-table-cell-input-reading hover:bg-everBlue-100 hover:bg-opacity-30`
+    ? `${cellWrapperClass} group gui-table-cell-input-wrapper gui-table-cell-input-editing hover:bg-everBlue-100 hover:bg-opacity-30`
+    : `${cellWrapperClass} group gui-table-cell-input-wrapper gui-table-cell-input-reading hover:bg-everBlue-100 hover:bg-opacity-30`
 
   if (config.isValidationError) {
     wrapperClass = `${wrapperClass} gui-table-cell-input-wrapper--error`

--- a/components/table/src/table-column/cell-renderers/select-cell-renderer.ts
+++ b/components/table/src/table-column/cell-renderers/select-cell-renderer.ts
@@ -1,5 +1,6 @@
 import { h, Transition, nextTick, type VNode } from 'vue'
 import { GSelect } from '@flash-global66/g-select'
+import { GIconFont } from '@flash-global66/g-icon-font'
 import type { TableColumnCtx } from '../defaults'
 import type { RenderCellData } from './types'
 import {
@@ -140,7 +141,7 @@ export function renderSelectCell(
       'div',
       {
         class:
-          'gui-table-cell-select-read w-full h-full min-w-0 max-w-full flex items-center justify-start overflow-hidden px-xs',
+          'gui-table-cell-select-read relative w-full h-full min-w-0 max-w-full flex items-center justify-start overflow-hidden px-xs',
         role: 'button',
         tabIndex: 0,
         title: displayText,
@@ -163,6 +164,22 @@ export function renderSelectCell(
         }
       },
       [
+        h('span', {
+          class: 'absolute top-xxs right-xxs opacity-0 group-hover:opacity-100 transition-opacity duration-150'
+        }, [
+          h('span', {
+            class: 'group/badge inline-flex items-center justify-center p-0.5 rounded-sm bg-primary-bg border border-primary-bd hover:border-secondary-bd transition-colors duration-150 cursor-pointer'
+          }, [
+            h('span', { class: 'px-1 rounded-sm hover:bg-sec-hover-bg transition-colors duration-150' }, [
+              h(GIconFont as unknown as string, {
+                name: 'regular pen',
+                class: 'text-icon-primary group-hover/badge:text-icon-secondary leading-none',
+                style: { fontSize: '10px' },
+                'aria-hidden': true
+              })
+            ])
+          ])
+        ]),
         h(
           'span',
           {
@@ -176,7 +193,7 @@ export function renderSelectCell(
 
     const wrapperStyle: Record<string, string> = {}
     const wrapperClass =
-      'gui-table-cell-edit-wrapper absolute top-0 left-0 h-full w-full flex items-center justify-start transition-all duration-200 ease-in hover:bg-everBlue-100 hover:bg-opacity-30'
+      'group gui-table-cell-edit-wrapper absolute top-0 left-0 h-full w-full flex items-center justify-start transition-all duration-200 ease-in hover:bg-everBlue-100 hover:bg-opacity-30'
 
     if (isEditing) {
       wrapperStyle.zIndex = '10'


### PR DESCRIPTION
## Historia de Usuario
**RESPONSABLE**

| Nombre | Equipo | Proyecto / Iniciativa | HU del desarrollo |
|:---:|:---:|:---:|:---|
| Brayan Basallo | GDS | Global Design System | [BMB-3415](https://global66.atlassian.net/browse/BMB-3415) |

**CONTEXTO**

Agregar un ícono de lápiz que aparece al hacer hover sobre celdas editables de la tabla (input y select), indicando visualmente al usuario que la celda es editable.

---

**FLUJOS AFECTADOS**

* Tabla con celdas editables tipo `input`
* Tabla con celdas editables tipo `select`
* Componente genérico `GCellEdit`

---

**CAMBIOS REALIZADOS**

- Ícono de lápiz (`regular pen`) con badge visible al hover de la fila, posicionado en la esquina superior derecha de la celda
- Badge con fondo `bg-primary-bg`, borde `border-primary-bd` y hover `hover:bg-sec-hover-bg` usando tokens del design system
- Ícono con `leading-none` para evitar altura extra por `line-height`
- Implementado en `GCellEdit.vue`, `input-cell-renderer.ts` y `select-cell-renderer.ts`
- Uso de `group` y `group/badge` (Tailwind named groups) para aislar los estados de hover

---

**EXTRA INFO**

* Tests unitarios: No aplica (cambio puramente visual/estilo)