### PR TITLE
[BMB-3432] feat(icon-font): add money-bill-trend-up icon

### DIFF
--- a/components/icon-font/src/icon-sets.ts
+++ b/components/icon-font/src/icon-sets.ts
@@ -239,6 +239,7 @@ export const ICON_SETS = {
     "unlock",
     "lock-alt",
     "wallet",
+    "money-bill-trend-up"
   ] as const,
 
   light: [

--- a/components/icon-font/src/lib/far-regular-pro.ts
+++ b/components/icon-font/src/lib/far-regular-pro.ts
@@ -123,4 +123,5 @@ export {
   faPaperPlane,
   faUnlock,
   faWallet,
+  faMoneyBillTrendUp
 } from "@fortawesome/pro-regular-svg-icons";


### PR DESCRIPTION
## Historia de Usuario
**RESPONSABLE**

| Nombre          | Equipo | Proyecto / Iniciativa | HU del desarrollo                                                    |
|:---------------:|:------:|:---------------------:|:---------------------------------------------------------------------|
| Brayan Basallo  | B2B    | Global Design System  | [BMB-3432](https://global66.atlassian.net/browse/BMB-3432)           |

**CONTEXTO**

Se requiere agregar el ícono `money-bill-trend-up` al design system para soportar la corrección del porcentaje de rentabilidad en USD. El ícono proviene de la librería FontAwesome Pro (regular) y necesita ser registrado tanto en el set de íconos como en los exports de la librería.

---

**FLUJOS AFECTADOS**

* Flujo 01. Componente `g-icon-font` — nuevo ícono disponible en el set `regular`

---

**CAMBIOS REALIZADOS**

- `components/icon-font/src/icon-sets.ts` — se agrega `money-bill-trend-up` al array del set `regular`
- `components/icon-font/src/lib/far-regular-pro.ts` — se exporta `faMoneyBillTrendUp` desde `@fortawesome/pro-regular-svg-icons`

---

**EXTRA INFO**

* Figma: N/A
* Tests unitarios: N/A
* Feature Flag: N/A