### PR TITLE
[BMB-3530] perf(image): lazy-load illustrations via import.meta.glob

### DIFF
--- a/components/image/src/hooks/use-image.ts
+++ b/components/image/src/hooks/use-image.ts
@@ -1,8 +1,13 @@
-import { computed, ref, onMounted, onBeforeUnmount, watch } from 'vue';
+import { computed, ref, onMounted, onBeforeUnmount, watch, readonly } from 'vue';
 import { useIntersectionObserver } from '@vueuse/core';
 import { ImageProps } from '../image.props';
 import { IMAGE_SIZES } from '../constants/image.constants';
 import { ImageState } from '../types/image.types';
+
+const illustrations = import.meta.glob<string>('../assets/illustrations/*.webp', {
+  query: '?url',
+  import: 'default',
+});
 
 /**
  * Hook to handle the functionality of the Image component
@@ -13,27 +18,33 @@ export const useImage = (props: ImageProps): ImageState => {
   const isLoaded = ref<boolean>(false);
   const hasError = ref<boolean>(false);
   const imageContainer = ref<HTMLElement | null>(null);
+  const imageSrc = ref<string>('');
   let stopObserver: Function | null = null;
-  
+
   const sizeValue = computed<string>(() => IMAGE_SIZES[props.size as keyof typeof IMAGE_SIZES]);
-  
-  const imageSrc = computed<string>(() => {
-    try {
-      return new URL(`../assets/illustrations/${props.name}.webp`, import.meta.url).href;
-    } catch (error) {
+
+  const resolveSrc = async (): Promise<void> => {
+    const loader = illustrations[`../assets/illustrations/${props.name}.webp`];
+    if (!loader) {
       hasError.value = true;
-      return '';
+      return;
     }
-  });
+    try {
+      imageSrc.value = await loader();
+    } catch {
+      hasError.value = true;
+    }
+  };
 
   const handleImageError = (): void => {
     hasError.value = true;
   };
 
-  const loadImage = (): void => {
+  const loadImage = async (): Promise<void> => {
+    await resolveSrc();
     isLoaded.value = true;
   };
-  
+
   const setupObserver = (): void => {
     if (!props.lazyLoad) {
       loadImage();
@@ -59,7 +70,7 @@ export const useImage = (props: ImageProps): ImageState => {
           rootMargin: '50px',
         }
       );
-      
+
       stopObserver = stop;
     }
   };
@@ -73,9 +84,10 @@ export const useImage = (props: ImageProps): ImageState => {
       stopObserver();
     }
   });
-  
+
   watch(() => props.name, () => {
     isLoaded.value = false;
+    imageSrc.value = '';
     setupObserver();
   });
 
@@ -83,7 +95,7 @@ export const useImage = (props: ImageProps): ImageState => {
     sizeValue,
     isLoaded,
     hasError,
-    imageSrc,
+    imageSrc: readonly(imageSrc),
     imageContainer,
     handleImageError
   };

--- a/components/image/src/types/image.types.ts
+++ b/components/image/src/types/image.types.ts
@@ -1,4 +1,4 @@
-import { Ref, ComputedRef } from 'vue';
+import { Ref, ComputedRef, DeepReadonly } from 'vue';
 import { IMAGE_NAMES, IMAGE_SIZES } from '../constants/image.constants';
 
 export type ImageName = typeof IMAGE_NAMES[number];
@@ -11,7 +11,7 @@ export interface ImageState {
   isLoaded: Ref<boolean>;
   hasError: Ref<boolean>;
   sizeValue: ComputedRef<string>;
-  imageSrc: ComputedRef<string>;
+  imageSrc: DeepReadonly<Ref<string>>;
   imageContainer: Ref<HTMLElement | null>;
   handleImageError: () => void;
 }

--- a/components/image/vite.config.ts
+++ b/components/image/vite.config.ts
@@ -7,6 +7,11 @@ export default mergeConfig(baseConfig, defineConfig({
     lib: {
       entry: resolve(__dirname, 'index.ts'),
       name: 'B2BImage'
+    },
+    rollupOptions: {
+      output: {
+        inlineDynamicImports: false
+      }
     }
   }
 }));


### PR DESCRIPTION
## Descripción
- Se migran las 52 ilustraciones de `@flash-global66/g-image` de importación directa (inlined URLs dinámicas rotas en bundlers) a importaciones dinámicas asíncronas bajo demanda utilizando `import.meta.glob`.
- Se añade la propiedad `inlineDynamicImports: false` en `vite.config.ts` del componente para indicarle a Rollup que genere chunks individuales para las ilustraciones, evitando que intente aplanar e incrustar todo dentro del bundle principal.
- Se mantiene el contrato de solo lectura (`DeepReadonly`) para `imageSrc` en el hook `useImage` y en sus definiciones de TypeScript (`image.types.ts`) para evitar mutaciones externas en el componente.

## Por qué es necesario
- En preprod2/producción las URLs relativas dinámicas (`new URL(...)`) fallaban al resolverse en tiempo de ejecución.
- La importación en  inlined inflaba el entrypoint principal de la librería de componentes innecesariamente (~6.6MB). Este cambio optimiza y reduce el peso inicial de carga.

## Verificación Local
- Compilación del componente exitosa (`vite build` + generación de tipos TS `vue-tsc`).
- Se verificó que se generan los 52 chunks individuales correspondientes a cada ilustración `.webp`.
- Se validó localmente en la app `front-b2b` que la integración compila perfectamente sin warnings de dependencias circulares ni errores de tipos.
