### PR TITLE
[BMB-3554] Feat: Agregar variante card y nuevas props al componente GInline

### DIFF
--- a/components/inline/src/inline.styles.scss
+++ b/components/inline/src/inline.styles.scss
@@ -24,6 +24,28 @@
 
   @include e("link") {
     @apply text-2 underline text-grey-700 font-medium;
+
+    @include m("arrow") {
+      @apply font-semibold flex items-center gap-xs;
+      text-decoration: none;
+    }
+  }
+
+  @include e("link-arrow") {
+    @apply text-2;
+  }
+
+  @include e("icon-fill") {
+    display: flex;
+    min-width: 2rem;
+    min-height: 2rem;
+    padding: 0.25rem;
+    justify-content: center;
+    align-items: center;
+    gap: 0.625rem;
+    border-radius: 0.25rem;
+    background: rgba(236, 240, 249, 0.40);
+    flex-shrink: 0;
   }
 
   @include e("icon") {
@@ -60,6 +82,26 @@
     }
   }
 
+  @include m("shadow") {
+    box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.12);
+  }
+
+  @include m("no-border") {
+    border: none;
+  }
+
+  @include m("icon-align-top") {
+    @apply items-start;
+  }
+
+  @include m("icon-align-medium") {
+    @apply items-center;
+  }
+
+  @include m("icon-align-bottom") {
+    @apply items-end;
+  }
+
   @include m("success") {
     @apply border-success-bd bg-success-bg;
     @include e("icon") {
@@ -83,5 +125,11 @@
     @include e("icon") {
       @apply text-error-txt;
     }
+  }
+  @include m("card") {
+    border: none;
+    border-radius: var(--Radius-md, 0.5rem);
+    background: var(--background-secondary, #FFF);
+    box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.12);
   }
 }

--- a/components/inline/src/inline.ts
+++ b/components/inline/src/inline.ts
@@ -3,7 +3,7 @@ import type Inline from "./inline.vue";
 import { useAriaProps} from "element-plus";
 import { buildProps, definePropType, isBoolean, isNumber, isString } from "element-plus/es/utils/index.mjs";
 
-import { InlineEnum, InlineLinks, InlineSize } from "./inline.type";
+import { InlineEnum, InlineIconAlign, InlineLinks, InlineSize } from "./inline.type";
 import { IconString } from "@flash-global66/g-icon-font";
 
 export const inlineProps = buildProps({
@@ -55,6 +55,41 @@ export const inlineProps = buildProps({
   links: {
     type: definePropType<InlineLinks[]>(Array),
     default: () => [],
+  },
+  /**
+   * @description activates box-shadow
+   */
+  shadow: {
+    type: Boolean,
+    default: false,
+  },
+  /**
+   * @description shows/hides the border
+   */
+  border: {
+    type: Boolean,
+    default: true,
+  },
+  /**
+   * @description vertical alignment of the left icon
+   */
+  iconAlign: {
+    type: definePropType<InlineIconAlign>(String),
+    default: 'medium',
+  },
+  /**
+   * @description adds a filled background behind the left icon
+   */
+  iconFill: {
+    type: Boolean,
+    default: false,
+  },
+  /**
+   * @description shows a chevron-right arrow on each link
+   */
+  showArrow: {
+    type: Boolean,
+    default: true,
   },
   ...useAriaProps(["ariaLabel"]),
 });

--- a/components/inline/src/inline.type.ts
+++ b/components/inline/src/inline.type.ts
@@ -4,6 +4,8 @@ export interface InlineLinks {
   ariaLabel?: string;
 }
 
-export type InlineEnum = 'success' | 'warning' | 'error' | 'info';
+export type InlineEnum = 'success' | 'warning' | 'error' | 'info' | 'card';
 
 export type InlineSize = 'md' | 'sm';
+
+export type InlineIconAlign = 'top' | 'medium' | 'bottom';

--- a/components/inline/src/inline.vue
+++ b/components/inline/src/inline.vue
@@ -1,9 +1,6 @@
 <script lang="ts" setup>
-import {
-  useFormSize,
-  useNamespace,
-} from "element-plus";
-import { computed, defineComponent, PropType, reactive, ref, watch } from "vue";
+import { useFormSize, useNamespace } from "element-plus";
+import { computed, ref } from "vue";
 import { GIconFont } from '@flash-global66/g-icon-font';
 import { inlineEmits, inlineProps } from "./inline";
 
@@ -21,13 +18,15 @@ const inlineClass = computed(() => [
   ns.b(),
   ns.m(inlineSize.value),
   ns.m(props.type),
+  props.shadow && ns.m('shadow'),
+  !props.border && ns.m('no-border'),
+  ns.m(`icon-align-${props.iconAlign}`),
 ])
 
-async function onClose(event: MouseEvent) {
+function onClose(event: MouseEvent) {
   visible.value = false;
   emits('close', event)
 }
-
 </script>
 
 
@@ -39,11 +38,20 @@ async function onClose(event: MouseEvent) {
       ref="inlineRef"
       :aria-label="ariaLabel || 'inline'"
     >
+      <div v-if="iconFill" :class="ns.e('icon-fill')">
+        <g-icon-font
+          aria-label="icon informative"
+          :class="ns.e('icon')"
+          :name="icon"
+        />
+      </div>
       <g-icon-font
+        v-else
         aria-label="icon informative"
-        :class="[ns.e('icon')]" :name="icon"
+        :class="ns.e('icon')"
+        :name="icon"
       />
-      <div class="">
+      <div>
         <h3 v-if="title" :class="[ns.e('title')]"> {{ title }} </h3>
         <p :class="[ns.e('description')]">
           <slot name="default">
@@ -58,12 +66,17 @@ async function onClose(event: MouseEvent) {
           <button
             v-for="(link, idx) in links"
             :key="idx"
-            @click="link.action" 
-            :class="[ns.e('link')]"
+            @click="link.action()"
+            :class="[ns.e('link'), showArrow && ns.em('link', 'arrow')]"
             :aria-label="link.ariaLabel || link.label"
             type="button"
           >
             {{ link.label }}
+            <g-icon-font
+              v-if="showArrow"
+              name="regular chevron-right"
+              :class="ns.e('link-arrow')"
+            />
           </button>
         </div>
       </div>

--- a/stories/inline.stories.ts
+++ b/stories/inline.stories.ts
@@ -107,12 +107,38 @@ import { GInline } from '@flash-global66/g-inline';
     type: {
       description: "Tipo de mensaje a mostrar. Colores de fondo y estilo de texto.",
       control: "select",
-      options: ["success", "info", "warning", "error"],
+      options: ["success", "info", "warning", "error", "card"],
       defaultValue: "success",
     },
     links: {
       description: "Lista de enlaces interactivos con etiquetas y acciones.",
       control: "object",
+    },
+    shadow: {
+      description: "Activa el sombreado del componente.",
+      control: "boolean",
+      defaultValue: false,
+    },
+    border: {
+      description: "Muestra u oculta el borde del componente.",
+      control: "boolean",
+      defaultValue: true,
+    },
+    iconAlign: {
+      description: "Alineación vertical del ícono izquierdo.",
+      control: "select",
+      options: ["top", "medium", "bottom"],
+      defaultValue: "medium",
+    },
+    iconFill: {
+      description: "Agrega un fondo detrás del ícono izquierdo.",
+      control: "boolean",
+      defaultValue: false,
+    },
+    showArrow: {
+      description: "Muestra u oculta el ícono de flecha en cada enlace.",
+      control: "boolean",
+      defaultValue: true,
     },
     ariaLabel: {
       description: "Etiqueta ARIA para accesibilidad.",
@@ -150,6 +176,11 @@ import { GInline } from '@flash-global66/g-inline';
         action: () => alert("Acción 2"),
       },
     ],
+    shadow: false,
+    border: true,
+    iconAlign: "medium",
+    iconFill: false,
+    showArrow: true,
     ariaLabel: "inline",
   },
 };
@@ -305,6 +336,74 @@ export const WithoutIcon: Story = {
           title="Sin ícono"
           description="Este mensaje no tiene ícono"
         />
+      </g-config-provider>
+    `
+  })
+};
+
+// Variante card
+export const Card: Story = {
+  name: 'Card',
+  parameters: {
+    docs: {
+      description: {
+        story: 'Variante card: fondo blanco, sin borde y con sombra. Ideal para destacar información dentro de un panel o sección.'
+      }
+    }
+  },
+  render: () => ({
+    components: { GInline, GConfigProvider },
+    template: `
+      <g-config-provider>
+        <g-inline
+          type="card"
+          title="Más información"
+          description="Consulta los detalles de tu transacción en el historial."
+          icon="solid info-circle"
+          icon-align="top"
+          :icon-fill="true"
+          :links="[{ label: 'Ver detalle', action: () => {} }]"
+          :show-arrow="true"
+          :hide-close="true"
+        />
+      </g-config-provider>
+    `
+  })
+};
+
+// Icon fill y shadow
+export const WithIconFillAndShadow: Story = {
+  name: 'Con fill y sombra',
+  parameters: {
+    docs: {
+      description: {
+        story: 'Combinación de icon-fill y shadow para dar mayor énfasis visual al componente.'
+      }
+    }
+  },
+  render: () => ({
+    components: { GInline, GConfigProvider },
+    template: `
+      <g-config-provider>
+        <div class="space-y-4">
+          <g-inline
+            type="info"
+            title="Con fill y sombra"
+            description="El ícono tiene fondo y el componente tiene sombra."
+            icon="solid info-circle"
+            :icon-fill="true"
+            :shadow="true"
+            :links="[{ label: 'Más información', action: () => {} }]"
+          />
+          <g-inline
+            type="warning"
+            title="Alineación superior"
+            description="Cuando el contenido es largo, el ícono se alinea al tope del componente para mantener la jerarquía visual."
+            icon="solid triangle-exclamation"
+            :icon-fill="true"
+            icon-align="top"
+          />
+        </div>
       </g-config-provider>
     `
   })


### PR DESCRIPTION
## Historia de Usuario
**RESPONSABLE**

| Nombre               | Equipo   | Proyecto / Iniciativa  | HU del desarrollo                                          |
|:--------------------:|:--------:|:----------------------:|:-----------------------------------------------------------|
| Anibal Royero        | B2B      | Global Design System   | [BMB-3554](https://global66.atlassian.net/browse/BMB-3554) |

**CONTEXTO**

Se requiere extender el componente `GInline` del design system para soportar una nueva variante visual tipo **card** y mayor control sobre la apariencia del ícono, los enlaces y el contenedor. Esto permite reutilizar el componente en contextos donde se necesita destacar información dentro de paneles o secciones, alineado al diseño definido en Figma para BMB-3554.

---

**FLUJOS AFECTADOS**

* Storybook — componente `Data/Inline` (nuevas stories y argTypes)
* Consumidores de `@flash-global66/g-inline` que usen el componente con la variante card o las nuevas props

---

**CAMBIOS REALIZADOS**

* Nueva variante `type="card"`: fondo blanco, sin borde, border-radius y sombra.
* Nuevas props de apariencia:
  * `shadow` — activa box-shadow en el contenedor.
  * `border` — muestra u oculta el borde (default: `true`).
  * `iconAlign` — alineación vertical del ícono (`top` | `medium` | `bottom`).
  * `iconFill` — fondo relleno detrás del ícono izquierdo.
  * `showArrow` — chevron en los enlaces (default: `true`).
* Estilos actualizados en `inline.styles.scss` para links con flecha, icon-fill y modificadores de alineación.
* Stories de Storybook: `Card`, `Con fill y sombra` y argTypes documentados para las nuevas props.

**Archivos modificados:**
* `components/inline/src/inline.ts`
* `components/inline/src/inline.type.ts`
* `components/inline/src/inline.vue`
* `components/inline/src/inline.styles.scss`
* `stories/inline.stories.ts`

---

**EXTRA INFO**

* Figma: _(agregar URL si aplica)_
* Tests unitarios: No se agregaron tests unitarios.
* Feature Flag: No aplica.

---

## Test plan

- [ ] Ejecutar `yarn storybook` y revisar las stories `Card` y `Con fill y sombra` en `Data/Inline`.
- [ ] Verificar que las variantes existentes (`success`, `info`, `warning`, `error`) siguen funcionando sin cambios.
- [ ] Probar combinaciones de `iconFill`, `shadow`, `iconAlign` y `showArrow`.
- [ ] Confirmar que el botón de cierre y los links siguen siendo accesibles (ARIA).