### PR TITLE
[BMB-3554] Fix: Ajustar colores de tipografía en variante card de GInline

### DIFF
--- a/components/inline/src/inline.styles.scss
+++ b/components/inline/src/inline.styles.scss
@@ -131,5 +131,21 @@
     border-radius: var(--Radius-md, 0.5rem);
     background: var(--background-secondary, #FFF);
     box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.12);
+
+    @include e("title") {
+      @apply text-grey-700;
+    }
+
+    @include e("description") {
+      @apply text-grey-500;
+    }
+
+    @include e("icon") {
+      @apply text-everBlue-500;
+    }
+
+    @include e("link") {
+      @apply text-everBlue-500;
+    }
   }
 }


### PR DESCRIPTION
## Historia de Usuario
**RESPONSABLE**

| Nombre               | Equipo   | Proyecto / Iniciativa  | HU del desarrollo                                          |
|:--------------------:|:--------:|:----------------------:|:-----------------------------------------------------------|
| Anibal Royero        | B2B      | Global Design System   | [BMB-3554](https://global66.atlassian.net/browse/BMB-3554) |

**CONTEXTO**

Tras el merge del PR #236 (nueva variante `card` y props de apariencia en `GInline`), se detectó que los colores de tipografía de la variante `card` no coincidían con el diseño de Figma. Este PR corrige los estilos de texto del título, descripción, ícono y enlace para alinear la variante visual con los tokens del design system.

---

**FLUJOS AFECTADOS**

* Componente `@flash-global66/g-inline` — variante `type="card"`
* Storybook — story `Card` en `Data/Inline`

---

**CAMBIOS REALIZADOS**

* Ajuste de colores en la variante `card` dentro de `inline.styles.scss`:
  * **Título:** `text-grey-700`
  * **Descripción:** `text-grey-500`
  * **Ícono:** `text-everBlue-500`
  * **Enlace:** `text-everBlue-500`

**Archivo modificado:**
* `components/inline/src/inline.styles.scss`

---
