### PR TITLE
fix(tailwind): rename config to .cjs for Node 24 compatibility

### DIFF
--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -1,6 +1,4 @@
-// eslint-disable-next-line @typescript-eslint/no-var-requires
-import type { Config } from "tailwindcss";
-import plugin from "tailwindcss/plugin";
+const plugin = require("tailwindcss/plugin");
 
 module.exports = {
   content: [
@@ -451,4 +449,4 @@ module.exports = {
     //   })
     // })
   ],
-} satisfies Config;
+};


### PR DESCRIPTION
## Summary

- Rename `tailwind.config.ts` → `tailwind.config.cjs`
- Remove `import type { Config }` and `satisfies Config` (TypeScript-only, no runtime value)
- Replace `import plugin from 'tailwindcss/plugin'` with `const plugin = require('tailwindcss/plugin')`

## Root cause

GitHub Actions now forces **Node 24** on all runners, even when the workflow declares `node-version: 20.x` ([GH changelog](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)).

`jiti` v1 (the TypeScript loader that Tailwind uses internally to load `.ts` config files) is incompatible with Node 24. When `jiti` fails to parse the config, Tailwind silently falls back to a default (empty) config. This means all **custom** utilities (`gap-xs`, `px-md`, `h-xl`, etc. from `theme.extend.spacing`) are not generated, causing `@apply gap-xs` in `button.style.scss` to throw a `CssSyntaxError`.

Standard Tailwind utilities (`inline-flex`, `border`, etc.) still work because they are baked into Tailwind's core — only the custom extensions were lost.

## Fix

`.cjs` files are loaded natively by Node without `jiti`. No functionality change — the config content is identical.

## Test plan

- [ ] CI passes on `fix/tailwind-config-node24` (g-button builds successfully)
- [ ] `yarn build` passes locally
- [ ] All Tailwind custom utilities (`gap-xs`, `px-md`, etc.) render correctly in Storybook