### PR TITLE
fix(tailwind): use __dirname for absolute content paths

### DIFF
--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -1,9 +1,10 @@
+const path = require("path");
 const plugin = require("tailwindcss/plugin");
 
 module.exports = {
   content: [
-    "./components/**/*.{vue,js,ts,jsx,tsx}",
-    "./stories/**/*.{vue,js,ts,jsx,tsx}",
+    path.resolve(__dirname, "./components/**/*.{vue,js,ts,jsx,tsx}"),
+    path.resolve(__dirname, "./stories/**/*.{vue,js,ts,jsx,tsx}"),
   ],
   theme: {
     extend: {


### PR DESCRIPTION
## Root cause (second issue)

The first fix (#238) renamed `tailwind.config.ts` → `tailwind.config.cjs` to bypass jiti/Node 24 incompatibility. That was necessary but not sufficient.

When Lerna runs each component's build script, it `cd`s into the component directory (e.g. `components/button/`) before invoking Vite. This makes `process.cwd()` equal to the component directory, not the monorepo root.

Tailwind's PostCSS plugin resolves relative `content` patterns from the directory where the config file was found — but only when using the file's `__dirname`. Without it, glob resolution can fall back to `process.cwd()` in some code paths, which causes:

```
./components/**/*.vue  →  components/button/components/**/*.vue  (empty)
./stories/**/*.ts      →  components/button/stories/**/*.ts      (empty)
```

No content files found → Tailwind JIT generates no custom utilities → `@apply gap-xs` throws `CssSyntaxError`.

## Fix

Use `path.resolve(__dirname, ...)` so content paths are always anchored to the config file's location (monorepo root), regardless of `process.cwd()`.

```js
content: [
  path.resolve(__dirname, "./components/**/*.{vue,js,ts,jsx,tsx}"),
  path.resolve(__dirname, "./stories/**/*.{vue,js,ts,jsx,tsx}"),
],
```

## Test plan

- [ ] CI passes on this branch (g-button builds, `gap-xs` resolves correctly)
- [ ] `yarn build` passes locally