### PR TITLE
fix(tailwind): safelist custom spacing tokens for @apply in SCSS

### DIFF
--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -1,10 +1,20 @@
 const path = require("path");
 const plugin = require("tailwindcss/plugin");
 
+const SPACING_TOKENS = ["xxs", "xs", "sm", "md", "lg", "xl", "2xl", "3xl", "4xl", "5xl", "none"];
+const SPACING_UTILITIES = ["gap", "p", "px", "py", "pt", "pb", "pl", "pr", "m", "mx", "my", "mt", "mb", "ml", "mr", "h", "w", "min-h", "min-w", "max-h", "max-w", "space-x", "space-y"];
+
 module.exports = {
   content: [
     path.resolve(__dirname, "./components/**/*.{vue,js,ts,jsx,tsx}"),
     path.resolve(__dirname, "./stories/**/*.{vue,js,ts,jsx,tsx}"),
+  ],
+  safelist: [
+    ...SPACING_UTILITIES.flatMap((u) => SPACING_TOKENS.map((t) => `${u}-${t}`)),
+    ...["xs", "sm", "md", "lg", "xl", "2xl", "none"].map((t) => `rounded-${t}`),
+    ...["sm", "md", "lg", "xl"].map((t) => `shadow-${t}`),
+    "w-fit",
+    "gap-1",
   ],
   theme: {
     extend: {


### PR DESCRIPTION
## Root cause

Tailwind v3 JIT only generates utilities it finds in **content files** (Vue, TS, JS). Custom spacing tokens like `gap-xs`, `px-md`, `h-xl` are used **only** via `@apply` in component `.scss` files — never in any Vue template — so JIT never activates them. Result: `@apply gap-xs` throws `The `gap-xs` class does not exist`.

The two previous fixes (PR #238, PR #239) correctly addressed the jiti/Node 24 incompatibility and CWD content-path resolution, but neither addressed this JIT activation gap.

## Fix

Add a `safelist` to `tailwind.config.cjs` that explicitly activates all custom-token spacing utilities (`xxs/xs/sm/md/lg/xl/2xl/3xl/4xl/5xl/none`) for every layout utility (`gap`, `p`, `px`, `py`, `h`, `w`, `m`, `mx`, ...). This guarantees they are generated regardless of content scanning, so SCSS `@apply` directives always work.

## Test plan

- [ ] CI build passes for `g-button` (the component that triggered the failure)
- [ ] All other components build successfully