### PR TITLE
fix(build): resolver fallo de build en el pipeline (Tailwind config + tipos de tsconfig)

### DIFF
--- a/components/date-picker/tsconfig.json
+++ b/components/date-picker/tsconfig.json
@@ -7,7 +7,7 @@
     "jsx": "preserve",
     "jsxFactory": "h",
     "jsxFragmentFactory": "Fragment",
-    "types": ["vue", "node"]
+    "types": ["vite/client", "vue", "node"]
   },
   "include": ["./**/*.ts", "./**/*.d.ts", "./**/*.tsx", "./**/*.vue"],
   "exclude": ["dist", "vite.config.ts"]

--- a/components/input-tag/tsconfig.json
+++ b/components/input-tag/tsconfig.json
@@ -7,13 +7,8 @@
     "jsx": "preserve",
     "jsxFactory": "h",
     "jsxFragmentFactory": "Fragment",
-    "types": ["vue", "node"]
+    "types": ["vite/client", "vue", "node"]
   },
-  "include": [
-    "./**/*.ts",
-    "./**/*.d.ts",
-    "./**/*.tsx",
-    "./**/*.vue"
-  ],
+  "include": ["./**/*.ts", "./**/*.d.ts", "./**/*.tsx", "./**/*.vue"],
   "exclude": ["dist", "vite.config.ts"]
 }

--- a/components/select/tsconfig.json
+++ b/components/select/tsconfig.json
@@ -7,13 +7,8 @@
     "jsx": "preserve",
     "jsxFactory": "h",
     "jsxFragmentFactory": "Fragment",
-    "types": ["vue", "node"]
+    "types": ["vite/client", "vue", "node"]
   },
-  "include": [
-    "./**/*.ts",
-    "./**/*.d.ts",
-    "./**/*.tsx",
-    "./**/*.vue"
-  ],
+  "include": ["./**/*.ts", "./**/*.d.ts", "./**/*.tsx", "./**/*.vue"],
   "exclude": ["dist", "vite.config.ts"]
 }

--- a/components/time-picker/tsconfig.json
+++ b/components/time-picker/tsconfig.json
@@ -7,7 +7,7 @@
     "jsx": "preserve",
     "jsxFactory": "h",
     "jsxFragmentFactory": "Fragment",
-    "types": ["vue", "node"]
+    "types": ["vite/client", "vue", "node"]
   },
   "include": ["./**/*.ts", "./**/*.d.ts", "./**/*.tsx", "./**/*.vue"],
   "exclude": ["dist", "vite.config.ts"]

--- a/postcss.config.cjs
+++ b/postcss.config.cjs
@@ -1,6 +1,8 @@
+const path = require("path");
+
 module.exports = {
   plugins: {
-    tailwindcss: {},
+    tailwindcss: { config: path.resolve(__dirname, "./tailwind.config.cjs") },
     autoprefixer: {}
   }
 }


### PR DESCRIPTION
## Contexto

El pipeline de Actions (`Publish Packages`) llevaba 4 corridas fallando seguidas en `main`. Los intentos anteriores (#238, #239, #240) atacaron síntomas relacionados pero no llegaron a la causa raíz completa.

## Causa raíz 1: Tailwind no encontraba su config (`postcss.config.cjs`)

`postcss.config.cjs` declaraba `tailwindcss: {}` sin ruta explícita. Tailwind v3 solo busca `tailwind.config.*` en `process.cwd()` — **no sube directorios padre**. Como Lerna ejecuta `vite build` de cada componente con cwd = `components/<nombre>/`, Tailwind nunca encontraba el `tailwind.config.cjs` de la raíz y caía silenciosamente a una config vacía (sin `content`, sin `safelist`). Por eso `@apply gap-xs` en `button.style.scss` fallaba con `The gap-xs class does not exist`, aunque `gap-xs` sí estaba en el safelist agregado en #240.

**Fix:** `postcss.config.cjs` ahora pasa `config: path.resolve(__dirname, "./tailwind.config.cjs")`, forzando la ruta absoluta sin importar el cwd desde el que se invoque.

## Causa raíz 2: tsconfig de 4 componentes perdía `vite/client`

Al validar el pipeline completo localmente (`yarn build` con los 41 componentes) apareció un segundo bloqueo, independiente del anterior: `date-picker`, `input-tag`, `select` y `time-picker` sobrescriben `"types"` en su `tsconfig.json` con `["vue", "node"]`. TypeScript **no mezcla** ese array al extender el tsconfig raíz, lo reemplaza — así que se perdía `"vite/client"`, y `vue-tsc` fallaba al tipar `g-utils/error.util.ts` (que usa `import.meta.env`) en `date-picker:build:types`. Los otros tres quedaban con el mismo bug latente, listos para romperse en cuanto su grafo de imports tocara ese archivo.

**Fix:** se agregó `"vite/client"` al array `types` en los 4 tsconfig afectados.

## Verificación

Corrí localmente los mismos pasos que ejecuta el workflow (`yarn build`, que compila los 41 componentes vía Lerna) antes y después de cada fix:

- Antes: fallaba en `g-button` (CSS) y luego en `g-date-picker` (tipos) al destrabar el primero.
- Después: `yarn build` termina con `✅ All components built successfully`, sin errores en ningún componente.

## Test plan

- [x] `yarn build` local completo (41 componentes) sin errores
- [ ] CI (`Publish Packages`) pasa en verde en este PR