### PR TITLE
feat(g-utils): ep-extraction-v3 WU-1 — utils base (componentSizes, isValidComponentSize, isPromise, mutable)

### DIFF
--- a/common/g-utils/src/types/component.type.ts
+++ b/common/g-utils/src/types/component.type.ts
@@ -5,3 +5,13 @@
  * compatibilidad con los consumidores migrados.
  */
 export type ComponentSize = 'large' | 'default' | 'small';
+
+/**
+ * Valores runtime válidos para el tamaño de un componente.
+ *
+ * Incluye `''` (cadena vacía) para mantener paridad con el validador de
+ * element-plus, aunque el tipo `ComponentSize` la omite intencionalmente.
+ * Es la fuente de verdad para `isValidComponentSize` y para la prop de
+ * tamaño construida en `@flash-global66/g-hooks` (`useSizeProp`).
+ */
+export const componentSizes = ['', 'default', 'small', 'large'] as const;

--- a/common/g-utils/src/types/utils.type.ts
+++ b/common/g-utils/src/types/utils.type.ts
@@ -16,3 +16,29 @@ export type { NamespaceHelpers } from '../composables/useNamespace';
  * las props de validación y de forms.
  */
 export type Arrayable<T> = T | T[];
+
+/**
+ * Elimina el modificador `readonly` de todas las propiedades de `T`.
+ *
+ * Copiado del tipo helper `Mutable<T>` de element-plus.
+ */
+export type Mutable<T> = { -readonly [P in keyof T]: T[P] };
+
+/**
+ * Cast de identidad que "desreadonlyfica" un literal `as const` a nivel de
+ * tipo, sin alterar la referencia en runtime.
+ *
+ * Copiado del algoritmo exacto de element-plus: `mutable` retorna el mismo
+ * valor recibido, solo re-tipado como `Mutable<T>`. Útil para pasar arrays u
+ * objetos `as const` a APIs (como `buildProps`) que esperan un tipo mutable.
+ *
+ * @param val - El valor `readonly` (típicamente `as const`) a re-tipar.
+ * @returns La misma referencia de `val`, tipada como `Mutable<T>`.
+ *
+ * @example
+ * const sizes = ['small', 'large'] as const;
+ * const mutableSizes = mutable(sizes); // mismo array, tipo sin readonly
+ */
+export const mutable = <T extends readonly unknown[] | Record<string, unknown>>(
+  val: T,
+): Mutable<T> => val as Mutable<T>;

--- a/common/g-utils/src/utils/validators.util.ts
+++ b/common/g-utils/src/utils/validators.util.ts
@@ -1,3 +1,6 @@
+import { componentSizes } from '../types/component.type';
+import { isFunction } from './function.util';
+
 /**
  * Comprueba si un valor es de tipo `boolean`.
  *
@@ -47,3 +50,32 @@ export const isString = (val: unknown): val is string =>
  */
 export const isObject = (val: unknown): val is Record<string, unknown> =>
   val !== null && typeof val === 'object';
+
+/**
+ * Comprueba si un valor es un tamaño de componente válido.
+ *
+ * Usa `componentSizes` (que incluye `''` para paridad con el validador de
+ * element-plus) como fuente de verdad de los valores aceptados.
+ *
+ * @param val - El valor a verificar.
+ * @returns `true` si `val` pertenece a `componentSizes`.
+ */
+export const isValidComponentSize = (val: string): boolean =>
+  (componentSizes as readonly string[]).includes(val);
+
+/**
+ * Comprueba si un valor es una `Promise` nativa o un objeto "thenable"
+ * (con métodos `then` y `catch`).
+ *
+ * Copiado del algoritmo exacto de element-plus para mantener paridad de
+ * comportamiento con los consumidores migrados.
+ *
+ * Actúa como type guard de TypeScript.
+ *
+ * @param val - El valor a verificar.
+ * @returns `true` si `val` es una `Promise` o un thenable.
+ */
+export const isPromise = <T = unknown>(val: unknown): val is Promise<T> =>
+  isObject(val) &&
+  isFunction((val as Record<string, unknown>).then) &&
+  isFunction((val as Record<string, unknown>).catch);

--- a/common/g-utils/src/utils/validators.util.ts
+++ b/common/g-utils/src/utils/validators.util.ts
@@ -1,4 +1,4 @@
-import { componentSizes } from '../types/component.type';
+import { componentSizes, ComponentSize } from '../types/component.type';
 import { isFunction } from './function.util';
 
 /**
@@ -60,15 +60,16 @@ export const isObject = (val: unknown): val is Record<string, unknown> =>
  * @param val - El valor a verificar.
  * @returns `true` si `val` pertenece a `componentSizes`.
  */
-export const isValidComponentSize = (val: string): boolean =>
+export const isValidComponentSize = (val: string): val is ComponentSize | '' =>
   (componentSizes as readonly string[]).includes(val);
 
 /**
- * Comprueba si un valor es una `Promise` nativa o un objeto "thenable"
- * (con métodos `then` y `catch`).
+ * Comprueba si un valor es una `Promise` nativa o un objeto/función
+ * "thenable" (con métodos `then` y `catch`).
  *
- * Copiado del algoritmo exacto de element-plus para mantener paridad de
- * comportamiento con los consumidores migrados.
+ * Replica el algoritmo de `@vue/shared` (reexportado por element-plus como
+ * `isPromise`): acepta tanto objetos como funciones, siempre que expongan
+ * `then` y `catch`, para cubrir thenables invocables.
  *
  * Actúa como type guard de TypeScript.
  *
@@ -76,6 +77,6 @@ export const isValidComponentSize = (val: string): boolean =>
  * @returns `true` si `val` es una `Promise` o un thenable.
  */
 export const isPromise = <T = unknown>(val: unknown): val is Promise<T> =>
-  isObject(val) &&
+  (isObject(val) || isFunction(val)) &&
   isFunction((val as Record<string, unknown>).then) &&
   isFunction((val as Record<string, unknown>).catch);

--- a/common/g-utils/tests/imports.spec.ts
+++ b/common/g-utils/tests/imports.spec.ts
@@ -32,6 +32,10 @@ import {
   UPDATE_MODEL_EVENT,
   CHANGE_EVENT,
   EVENT_CODE,
+  componentSizes,
+  isValidComponentSize,
+  isPromise,
+  mutable,
 } from '@flash-global66/g-utils';
 import { ref } from 'vue';
 
@@ -104,5 +108,14 @@ describe('@flash-global66/g-utils barrel exports', () => {
     expect(UPDATE_MODEL_EVENT).toBe('update:modelValue');
     expect(CHANGE_EVENT).toBe('change');
     expect(EVENT_CODE.esc).toBe('Escape');
+  });
+
+  it('exports the ep-extraction-v3 WU-1 additions (component-size + promise + mutable)', () => {
+    expect(componentSizes).toEqual(['', 'default', 'small', 'large']);
+    expect(isValidComponentSize('large')).toBe(true);
+    expect(isValidComponentSize('huge')).toBe(false);
+    expect(isPromise(Promise.resolve())).toBe(true);
+    const frozen = ['a'] as const;
+    expect(mutable(frozen)).toBe(frozen);
   });
 });

--- a/common/g-utils/tests/types/component.type.spec.ts
+++ b/common/g-utils/tests/types/component.type.spec.ts
@@ -1,0 +1,12 @@
+import { describe, it, expect } from 'vitest';
+import { componentSizes } from '../../src/types/component.type';
+
+describe('componentSizes', () => {
+  it('contains the empty string first for element-plus validator parity', () => {
+    expect(componentSizes[0]).toBe('');
+  });
+
+  it('equals the exact EP-faithful runtime tuple', () => {
+    expect(componentSizes).toEqual(['', 'default', 'small', 'large']);
+  });
+});

--- a/common/g-utils/tests/types/utils.type.spec.ts
+++ b/common/g-utils/tests/types/utils.type.spec.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest';
+import { mutable } from '../../src/types/utils.type';
+import type { Mutable } from '../../src/types/utils.type';
+
+describe('mutable', () => {
+  it('returns the exact same reference it received', () => {
+    const input = ['a', 'b'] as const;
+    const result = mutable(input);
+    expect(result).toBe(input);
+  });
+
+  it('preserves the values of a readonly object literal', () => {
+    const input = { a: 1, b: 2 } as const;
+    const result = mutable(input);
+    expect(result).toEqual({ a: 1, b: 2 });
+  });
+
+  it('strips readonly at the type level (compile-time check)', () => {
+    const input = ['x', 'y'] as const;
+    const result: Mutable<typeof input> = mutable(input);
+    // This assignment would fail to compile if `result` were still readonly.
+    result[0] = 'z';
+    expect(result[0]).toBe('z');
+  });
+});

--- a/common/g-utils/tests/utils/validators.util.spec.ts
+++ b/common/g-utils/tests/utils/validators.util.spec.ts
@@ -5,6 +5,7 @@ import {
   isValidComponentSize,
   isPromise,
 } from '../../src/utils/validators.util';
+import type { ComponentSize } from '../../src/types/component.type';
 
 describe('isBoolean', () => {
   it('returns true for true', () => {
@@ -81,6 +82,15 @@ describe('isValidComponentSize', () => {
       expect(isValidComponentSize(val)).toBe(false);
     },
   );
+
+  it('narrows the type to ComponentSize | "" in TS', () => {
+    const val: string = 'default';
+    if (isValidComponentSize(val)) {
+      // TypeScript should accept this without error
+      const _narrowed: ComponentSize | '' = val;
+      expect(typeof _narrowed).toBe('string');
+    }
+  });
 });
 
 describe('isPromise', () => {
@@ -91,6 +101,13 @@ describe('isPromise', () => {
   it('returns true for a {then, catch}-shaped thenable', () => {
     const thenable = { then: () => {}, catch: () => {} };
     expect(isPromise(thenable)).toBe(true);
+  });
+
+  it('returns true for a callable thenable (a function with then/catch attached)', () => {
+    const callableThenable = () => {};
+    callableThenable.then = () => {};
+    callableThenable.catch = () => {};
+    expect(isPromise(callableThenable)).toBe(true);
   });
 
   it('returns false for a plain object', () => {

--- a/common/g-utils/tests/utils/validators.util.spec.ts
+++ b/common/g-utils/tests/utils/validators.util.spec.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import { isBoolean, isString } from '../../src/utils/validators.util';
+import {
+  isBoolean,
+  isString,
+  isValidComponentSize,
+  isPromise,
+} from '../../src/utils/validators.util';
 
 describe('isBoolean', () => {
   it('returns true for true', () => {
@@ -59,5 +64,48 @@ describe('isString', () => {
 
   it('returns false for undefined', () => {
     expect(isString(undefined)).toBe(false);
+  });
+});
+
+describe('isValidComponentSize', () => {
+  it.each(['', 'default', 'small', 'large'])(
+    'returns true for the EP-valid value %j',
+    val => {
+      expect(isValidComponentSize(val)).toBe(true);
+    },
+  );
+
+  it.each(['medium', 'xl', 'huge'])(
+    'returns false for the invalid value %j',
+    val => {
+      expect(isValidComponentSize(val)).toBe(false);
+    },
+  );
+});
+
+describe('isPromise', () => {
+  it('returns true for a native Promise', () => {
+    expect(isPromise(Promise.resolve())).toBe(true);
+  });
+
+  it('returns true for a {then, catch}-shaped thenable', () => {
+    const thenable = { then: () => {}, catch: () => {} };
+    expect(isPromise(thenable)).toBe(true);
+  });
+
+  it('returns false for a plain object', () => {
+    expect(isPromise({})).toBe(false);
+  });
+
+  it('returns false for null', () => {
+    expect(isPromise(null)).toBe(false);
+  });
+
+  it('returns false for a function', () => {
+    expect(isPromise(() => {})).toBe(false);
+  });
+
+  it('returns false for an object missing catch', () => {
+    expect(isPromise({ then: () => {} })).toBe(false);
   });
 });

--- a/openspec/changes/ep-extraction-v3/design.md
+++ b/openspec/changes/ep-extraction-v3/design.md
@@ -1,0 +1,267 @@
+# Technical Design: EP Extraction v3 — First Form-Control Slice
+
+> Artifact store: hybrid. Design phase of `ep-extraction-v3`. Reads `proposal.md` (same dir) / engram `sdd/ep-extraction-v3/proposal`.
+> Scope locked: build the hooks/utils the 5 packages actually import, migrate `checkbox, radio, switch, segmented, input`. `input-number` deferred to v4.
+
+## 1. Technical Approach
+
+Copy EP algorithms **exactly** (no "improvements") into own-code packages, cover each with Vitest unit tests **before** wiring it into a component (strict TDD), then re-point the 5 packages' imports mechanically and delete their `.eslintrc.cjs` `excludedFiles` entries only after each is lint-clean under `--max-warnings 0`.
+
+The dependency layering is already established by v2 and stays strictly one-directional:
+
+```
+g-utils        (leaf — no internal DS deps; pure helpers, types, constants, useNamespace)
+   ▲
+g-hooks        (deps: g-utils)  — generic Vue composables, no form-context coupling
+   ▲
+g-form         (deps: g-hooks, g-utils) — form-context-derived composables
+   ▲
+components/{checkbox,radio,switch,segmented,input}  (deps: g-utils, g-hooks, g-form)
+```
+
+This graph is **acyclic** and every new symbol lands in the lowest layer that can host it without creating a back-edge. That single rule resolves Decision 1 and Decision 3 below.
+
+### 1.1 Discovery that reshapes the slice (verified against `main`)
+
+The proposal's "build in g-utils" list was written against the pre-v2 state. Grepping `common/g-utils/src` shows **v2 already shipped most of it**. Do NOT rebuild these — they exist and are tested:
+
+| Proposal said "build"                         | Actual state on `main`                     | Location                      |
+| --------------------------------------------- | ------------------------------------------ | ----------------------------- |
+| `isBoolean` / `isString` / `isObject`         | EXISTS                                     | `utils/validators.util.ts`    |
+| `buildProps` / `buildProp` / `definePropType` | EXISTS                                     | `utils/props.util.ts`         |
+| `debugWarn` / `throwError`                    | EXISTS                                     | `utils/error.util.ts`         |
+| `withInstall` / `SFCWithInstall`              | EXISTS                                     | `utils/install.util.ts`       |
+| `ComponentSize` type                          | EXISTS (`'large' \| 'default' \| 'small'`) | `types/component.type.ts`     |
+| `isNumber` / `addUnit`                        | EXISTS                                     | `utils/number.util.ts`        |
+| `isArray`                                     | EXISTS                                     | `utils/array.util.ts`         |
+| `isClient`                                    | EXISTS                                     | `utils/dom.util.ts`           |
+| `NOOP`                                        | EXISTS                                     | `utils/function.util.ts`      |
+| `isUndefined` / `isPropAbsent`                | EXISTS                                     | `utils/object.util.ts`        |
+| `UPDATE_MODEL_EVENT` / `CHANGE_EVENT`         | EXISTS                                     | `constants/event.constant.ts` |
+| `useNamespace`                                | EXISTS + tested                            | `composables/useNamespace.ts` |
+
+**What is genuinely still MISSING in g-utils** (this is the real WU-1, much smaller than the proposal implied):
+
+- `isValidComponentSize` (used by switch, input) — NOT present.
+- `componentSizes` constant (backing `useSizeProp` + `isValidComponentSize`) — NOT present.
+- `mutable` type/util (used by `input.ts`) — NOT present.
+- `isPromise` (used by `switch.vue`) — NOT present.
+- `ValidateComponentsMap` (used by `input.vue`) — NOT present, and it is **NOT a byte-copy candidate** (see Decision 3.4).
+
+> `INPUT_EVENT` is intentionally **NOT** in scope for v3: grep confirms it is consumed only by `input-number` (deferred to v4), not by `input`. `switch` already imports `INPUT_EVENT` from its **local** `./constants` (not from `element-plus`), so it needs no g-utils addition. Do not add `INPUT_EVENT` in v3.
+
+This shrinks WU-1 to 4 small additions and keeps every WU comfortably under the 400-line budget.
+
+## 2. Resolved Architecture Decisions
+
+### 2.1 Decision 1 — `useFormSize` placement: **put it in `g-form`** (option a)
+
+**Chosen:** `useFormSize` lives in `@flash-global66/g-form` next to its structural twin `useFormDisabled`.
+
+**Why this is the only acyclic choice.** `useFormSize` must read the form/form-item injection context to honor size precedence. Those injection keys (`formContextKey`, `formItemContextKey`) live in `g-form` (`components/form/src/constants.ts`). `g-form` already depends on `g-hooks` (it imports `useProp`/`useId`). Therefore `g-hooks` importing those keys from `g-form` would create the cycle `g-hooks → g-form → g-hooks`. Hosting the hook in `g-form` keeps the edge one-directional.
+
+`useFormDisabled` (already in `g-form/src/hooks/use-form-common-props.ts`) is the exact precedent: it composes `useProp` (from `g-hooks`) with `inject(formContextKey)` (from `g-form`). `useFormSize` is the size-domain sibling and belongs in the same file. The **generic tiers stay generic**: `useProp` and `useGlobalSize` remain in `g-hooks` and are _composed_ by `useFormSize` — so `g-hooks` never learns about form context.
+
+**Behavior — `prop > global config` only (pure refactor, no new feature).** DS `g-form` has **no `size` prop today** (verified: `formProps` in `components/form/src/form.ts` exposes only `disabled` + validation; `FormContext`/`FormItemContext` carry no `size`). Form-level size inheritance simply does not exist in the DS, so EP's `useFormSize` in these components already resolves the form tier to `undefined` and the effective behavior is `prop > global`. **v3 preserves this exactly.** `useFormSize` lives in `g-form` (acyclic placement, correct) and resolves:
+
+```
+explicit prop (useProp<ComponentSize>('size')) > fallback > useGlobalSize() > 'default'
+```
+
+with **no form-context size tier**. This is a migration, not a feature: we do NOT add a `size` prop to `formProps`/`formItemProps` (rejected as scope creep — it would introduce behavior that does not exist today).
+
+> **Future enhancement (out of v3 scope):** if form-level size inheritance is ever wanted, add an optional `size?: ComponentSize` to `formProps`/`formItemProps` and reinstate the `formItem?.size > form?.size` tiers in `useFormSize`. This is a deliberate deferral, not an oversight.
+
+**Rejected alternatives:**
+
+- **(b) Move the injection keys into `g-hooks`/`g-utils`.** Requires refactoring g-form's whole context system (form-item, validation, disabled all depend on those keys), high blast radius, out of slice scope, and inverts domain ownership (form context is a form concern).
+- **(c) Pass form size as a param.** Breaks the "mechanical migration" goal: segmented/switch currently call `useFormSize()` with no plumbing; forcing every call site to `inject` and pass the context would be a non-mechanical, error-prone rewrite of the exact code we want to swap by import path only.
+
+### 2.2 Decision 2 — Hook / util API signatures (EP-faithful, so migration is import-swap only)
+
+All signatures below mirror the exact EP shapes the 5 packages already call, so migration changes only the module specifier.
+
+**`g-utils` additions (WU-1):**
+
+```ts
+// types/component.type.ts (or a new size.type.ts)
+export const componentSizes = ['', 'default', 'small', 'large'] as const;
+// NOTE fidelity: the runtime values array mirrors EP (includes '') so that
+// isValidComponentSize / useSizeProp accept the same set EP accepted at runtime,
+// even though the exported ComponentSize *type* stays 'large' | 'default' | 'small'.
+
+// utils/validators.util.ts
+export const isValidComponentSize = (val: string): boolean =>
+  ['', 'default', 'small', 'large'].includes(val);
+export const isPromise = <T = any>(val: unknown): val is Promise<T> =>
+  isObject(val) &&
+  isFunction((val as any).then) &&
+  isFunction((val as any).catch);
+
+// types/utils.type.ts  (Mutable is an EP type helper; `mutable` is its identity cast)
+export type Mutable<T> = { -readonly [P in keyof T]: T[P] };
+export const mutable = <T extends readonly any[] | Record<string, unknown>>(
+  val: T,
+) => val as Mutable<T>;
+```
+
+**`g-hooks` shared form-control hooks (WU-2):**
+
+```ts
+// useAriaProps.ts — returns { ariaProps } with a buildProp'd String entry per requested aria key
+export const useAriaProps: <Arias extends Array<keyof AriaAttributes>>(
+  arias: Arias,
+) => { ariaProps: Pick<AriaProps, Arias[number]> };
+
+// useSizeProp.ts — a buildProp'd prop DEFINITION constant (not a function), mirroring EP
+export const useSizeProp: EpProp<
+  StringConstructor,
+  (typeof componentSizes)[number],
+  false
+>;
+// = buildProp({ type: String, values: componentSizes, required: false } as const)
+```
+
+**`g-form` (WU-2):**
+
+```ts
+// hooks/use-form-common-props.ts — sibling of useFormDisabled
+export const useFormSize: (
+  fallback?: MaybeRef<ComponentSize | undefined>,
+  ignore?: Partial<Record<'prop' | 'global', boolean>>,
+) => ComputedRef<ComponentSize>;
+// resolution (pure refactor — no form-context tier, since g-form has no size prop):
+//   prop(useProp<ComponentSize>('size')) > unref(fallback) > useGlobalSize() > 'default'
+```
+
+**`g-hooks` input sub-family (WU-4):**
+
+```ts
+// useComposition.ts
+export const useComposition: (opts: {
+  afterComposition: (event: CompositionEvent) => void;
+  emit?: SetupContext['emit'];
+}) => {
+  isComposing: Ref<boolean>;
+  handleComposition: (event: CompositionEvent) => void;
+  handleCompositionStart: (event: CompositionEvent) => void;
+  handleCompositionUpdate: (event: CompositionEvent) => void;
+  handleCompositionEnd: (event: CompositionEvent) => void;
+};
+
+// useCursor.ts
+export const useCursor: (
+  input: Ref<HTMLInputElement | HTMLTextAreaElement | undefined>,
+) => [record: () => void, restore: () => void];
+
+// useFocusController.ts
+export const useFocusController: <T extends { focus: () => void }>(
+  target: Ref<T | undefined>,
+  opts?: {
+    afterFocus?: () => void;
+    beforeBlur?: (event: FocusEvent) => boolean | undefined;
+    afterBlur?: () => void;
+  },
+) => {
+  wrapperRef: ShallowRef<HTMLElement | undefined>;
+  isFocused: Ref<boolean>;
+  handleFocus: (event: FocusEvent) => void;
+  handleBlur: (event: FocusEvent) => void;
+  handleClick: () => void;
+};
+
+// useAttrs.ts — EP-flavored merged attrs (distinct from Vue's useAttrs)
+export const useAttrs: (params?: {
+  excludeListeners?: boolean;
+  excludeKeys?: ComputedRef<string[]>;
+}) => ComputedRef<Record<string, unknown>>;
+// DEFAULT_EXCLUDE_KEYS = ['class', 'style']; LISTENER_PREFIX = /^on[A-Z]/
+```
+
+### 2.3 Decision 3 — Input sub-family placement: **`g-hooks`** (except `ValidateComponentsMap`)
+
+`useComposition`, `useCursor`, `useFocusController`, and the EP-flavored `useAttrs` go in **`g-hooks`**, not input-local.
+
+**Why g-hooks (the proposal's "prefer g-hooks if reusable by v4" test):** all four are pure Vue composables with **no form-context coupling** (only `g-utils` + Vue), so no cycle risk (`g-hooks → g-utils` only). And each is consumed by v4's deferred packages: `input-tag` and `select`'s filter input reuse `useComposition`/`useCursor`/`useFocusController`; `useAttrs` is a generic attr-merge used across many wrappers. Extracting to `g-hooks` now avoids a second extraction in v4.
+
+**Exception — `ValidateComponentsMap` is NOT a byte-copy and does NOT go in g-utils.** In EP it maps validate states to `@element-plus/icons-vue` components (`Loading`/`CircleCheck`/`CircleClose`). The DS renders icons via `@flash-global66/g-icon-font` (`IconString`/`GIconFont`), so this map must be **re-authored against DS icons**, not copied. Putting it in `g-utils` would force `g-utils` to depend on `g-icon-font`, polluting the leaf layer. **Decision: keep `ValidateComponentsMap` input-local** (`components/input/src/`), authored against DS icons, migrated inside WU-5. First action in WU-5: confirm whether `input.vue` still _uses_ the symbol (grep shows only the import line) — if unused, drop the import entirely; if used, re-author with DS icons. This is a proposal deviation (proposal placed it in g-utils) and the one non-mechanical piece of the input migration.
+
+### 2.4 Decision 4 — WU sequencing (chained PRs, `stacked-to-main`, ≤400 lines, publish per WU)
+
+Refined from the proposal to reflect the discoveries (smaller WU-1; `useFormSize` in g-form so WU-2 publishes g-hooks **+ g-form**):
+
+| WU   | Deliverable                                                                                                                   | Depends on | Publishes       | Est. lines |
+| ---- | ----------------------------------------------------------------------------------------------------------------------------- | ---------- | --------------- | ---------: |
+| WU-1 | `g-utils`: `isValidComponentSize`, `componentSizes`, `isPromise`, `mutable`/`Mutable` + unit tests                            | —          | g-utils         |       ~150 |
+| WU-2 | `g-hooks`: `useAriaProps`, `useSizeProp` + tests; **`g-form`: `useFormSize` (`prop > global`, no form-context tier) + tests** | WU-1       | g-hooks, g-form |       ~300 |
+| WU-3 | Migrate the 4 light controls (checkbox, radio, switch, segmented) + remove their 4 ESLint excludes                            | WU-1, WU-2 | 4 controls      |       ~260 |
+| WU-4 | `g-hooks` input sub-family: `useComposition`, `useCursor`, `useFocusController`, EP `useAttrs` + tests                        | WU-1       | g-hooks         |       ~380 |
+| WU-5 | Migrate `input` (incl. `ValidateComponentsMap` decision) + remove its ESLint exclude                                          | WU-2, WU-4 | input           |       ~220 |
+
+**Ordering rationale:** foundations before consumers. WU-1 (utils) unblocks everything. WU-2 ships the shared hooks + `useFormSize`; note **WU-2 must publish g-form** because switch and segmented both consume `useFormSize`. WU-3 migrates the 4 controls that need only WU-1+WU-2. WU-4 is the heaviest (4 input hooks) and is isolated so it never blocks the light controls. WU-5 migrates `input` last on top of clean hooks.
+
+**Parallelism:** WU-4 depends only on WU-1, so it can be developed **in parallel with WU-2/WU-3** (independent of the shared-hook and light-control work). Within WU-3 the four packages are independent files and can be migrated concurrently, but ship as one PR. WU-5 requires both WU-2 (useSizeProp/useAriaProps, useFormSize not needed by input but useSizeProp is) and WU-4.
+
+**Chain strategy:** `stacked-to-main` — each WU is its own PR merging to `main` in order; each child PR body carries the dependency diagram marking the current PR with `📍` and states start/end/prior-deps/out-of-scope (chained-pr skill). Incremental Lerna publish per merged WU so `front-b2b` consumes the migration incrementally.
+
+### 2.5 Decision 5 — Test strategy (strict TDD, Vitest, unit-only, `yarn test:run`)
+
+Every new symbol lands red→green with a unit test authored first. Concrete first tests:
+
+- **`isValidComponentSize`**: `true` for `''`, `'default'`, `'small'`, `'large'`; `false` for `'medium'`, `'xl'`, `undefined`-coerced.
+- **`componentSizes`**: equals `['', 'default', 'small', 'large']`.
+- **`isPromise`**: `true` for a real `Promise` and a `{then, catch}` thenable; `false` for `{}`, `null`, functions.
+- **`mutable`/`Mutable`**: runtime identity (returns the same ref); type test that `readonly` is stripped.
+- **`useAriaProps`**: returns `{ ariaProps }` containing exactly one buildProp'd `String` entry per requested aria key; unknown keys excluded.
+- **`useSizeProp`**: prop def with `type === String`, `required === false`, `values` deep-equal `componentSizes`; validator accepts each valid size, rejects `'huge'`.
+- **`useFormSize`**: mounted-component tests asserting `prop > fallback > useGlobalSize() > 'default'` — explicit prop wins; `fallback` beats global when prop absent; with no prop/fallback falls back to `useGlobalSize()` → `'default'`; `ignore.prop`/`ignore.global` flags neutralize each tier. (No form-context tier is asserted — it does not exist in v3.)
+- **`useComposition`**: `compositionstart`/`update` set `isComposing = true`; `compositionend` sets it `false` and invokes `afterComposition`; verify the EP Firefox guard on `update`.
+- **`useCursor`**: `record()` then mutate value then `restore()` reinstates `selectionStart`/`selectionEnd`; no-throw when the ref is `undefined`.
+- **`useFocusController`**: `handleFocus` sets `isFocused = true` + fires `afterFocus`; `handleBlur` respects `beforeBlur` veto (returns `true` ⇒ blur suppressed) and otherwise clears focus + fires `afterBlur`; `handleClick` calls `target.focus()`.
+- **`useAttrs`**: computed excludes `class`/`style` + provided `excludeKeys`; `excludeListeners: true` strips `on[A-Z]*` handlers; passes everything else through reactively.
+
+## 3. Per-Package Migration (mechanical import re-point)
+
+Each row lists the import specifier swaps; algorithms are unchanged. Remove the package's `excludedFiles` entry only after it is lint-clean.
+
+| Package       | `element-plus` → own code                                                                                                                                                                                                                                                                                                                                                                                                                 |
+| ------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **checkbox**  | `useNamespace`→g-utils; `useAriaProps`→g-hooks; `debugWarn`/`isArray`/`isBoolean`/`isObject`/`isString`/`isNumber`/`isPropAbsent`/`isUndefined`→g-utils; `UPDATE_MODEL_EVENT`→g-utils constants; `useFormDisabled`→g-form                                                                                                                                                                                                                 |
+| **radio**     | `useId`→g-hooks; `useNamespace`→g-utils; `useAriaProps`→g-hooks; `buildProps`/`isBoolean`/`isNumber`/`isString`/`isPropAbsent`→g-utils; `UPDATE_MODEL_EVENT`/`CHANGE_EVENT`→g-utils constants                                                                                                                                                                                                                                             |
+| **switch**    | `useAriaProps`/`useSizeProp`→g-hooks; `useFormDisabled`/`useFormSize`→g-form; `useNamespace`→g-utils; `addUnit`/`debugWarn`/`isBoolean`/`isPromise`/`throwError`/`isValidComponentSize`/`buildProps`/`definePropType`/`isNumber`/`isString`→g-utils; `ComponentSize` type→g-utils. (`INPUT_EVENT`/`CHANGE_EVENT`/`UPDATE_MODEL_EVENT` are already imported from local `./constants` — unchanged.)                                         |
+| **segmented** | `useFormSize`→g-form; `useId`→g-hooks; `useNamespace`→g-utils; `buildProps`/`definePropType`/`isBoolean`/`isNumber`/`isString`/`isObject`/`debugWarn`→g-utils                                                                                                                                                                                                                                                                             |
+| **input**     | `useAttrs`/`useComposition`/`useCursor`/`useFocusController`→g-hooks; `useAriaProps`/`useSizeProp`→g-hooks; `useNamespace`→g-utils; `NOOP`/`debugWarn`/`isClient`/`isObject`/`mutable`/`isString`/`definePropType`/`buildProps`→g-utils; `UPDATE_MODEL_EVENT`→g-utils constants; `useFormItem`/`useFormItemInputId`/`useFormDisabled` already g-form; **`ValidateComponentsMap`→input-local (re-author with DS icons or drop if unused)** |
+
+**Constraints honored:** no public API change to any of the 5 components (props/emits/slots untouched — only internal imports move); source-only packages stay `buildable:false`; each migration WU validated in `front-b2b` with **real copies** in `node_modules` (never symlinks — symlinks strip base CSS / Tailwind `@apply`); build via `node scripts/build-components.js`; lint `eslint --max-warnings 0`; env node v20.19.3 + dummy `GBP_PACKAGE_TOKEN`.
+
+## 4. Risks (design-level)
+
+| Risk                                                                       | Mitigation                                                                                                                                                          |
+| -------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Someone re-adds form-level size inheritance during migration (scope creep) | `useFormSize` resolves `prop > global` ONLY; no `size` prop added to g-form. Pure refactor — behavior preserved exactly. Future enhancement is explicitly out of v3 |
+| `ValidateComponentsMap` can't be byte-copied (EP icons vs g-icon-font)     | Input-local re-author against DS icons; verify it's still used before porting (grep shows import only)                                                              |
+| `componentSizes` includes `''` but `ComponentSize` type omits it           | Keep runtime values array EP-faithful (incl. `''`) for validator parity; type stays as-is — documented fidelity note in code                                        |
+| Copied composition/cursor/focus algorithms drift                           | Byte-exact copy + dedicated unit tests before wiring (WU-4 precedes WU-5)                                                                                           |
+| WU-2 must publish g-form (not just g-hooks) or switch/segmented break      | Publish set for WU-2 = g-hooks + g-form; noted in sequencing table                                                                                                  |
+
+## 5. Dependency Graph (final, acyclic)
+
+```
+                 g-utils
+                (componentSizes, isValidComponentSize,
+                 isPromise, mutable/Mutable  + existing v2 helpers)
+                    ▲            ▲
+                    │            │
+     ┌──────────────┘            └───────────────┐
+   g-hooks                                      g-form
+  (useAriaProps, useSizeProp,                 (useFormSize  ← composes
+   useComposition, useCursor,                  useProp + useGlobalSize from g-hooks;
+   useFocusController, useAttrs                 resolves prop > global,
+   + existing useId/useProp/useGlobalSize)      no form-context size tier)
+                    ▲                                   ▲
+                    └──────────────┬────────────────────┘
+                                   │
+        components/{checkbox, radio, switch, segmented, input}
+```
+
+No back-edges. `useFormSize` is the only contested node and is placed in `g-form` precisely to avoid the `g-hooks → g-form` cycle.

--- a/openspec/changes/ep-extraction-v3/proposal.md
+++ b/openspec/changes/ep-extraction-v3/proposal.md
@@ -1,0 +1,121 @@
+# Proposal: EP Extraction v3 — Migrate the First Form-Control Slice off element-plus Internals
+
+> Artifact store: hybrid. Continues `ep-extraction-v2` (archived 2026-07-08, PR #242).
+> This is a **SLICE**, not the full 22-package migration. It migrates 5 simple form-control packages and builds only the hooks/utils those 5 actually need. `input-number` and the heavy popper/overlay/table families are deferred to a future `ep-extraction-v4`.
+
+## Intent
+
+After v2, `main` has an extended `g-utils`, a new `g-hooks` (`useId`/`useGlobalSize`/`useProp`), a `g-form` composables package, 19 migrated packages, and an ESLint guard — but **22 packages still import element-plus internals** because the hooks they need were never extracted. The guard keeps them on an `excludedFiles` allowlist, so nothing prevents their EP coupling from growing and the allowlist masks real debt.
+
+We start closing that gap now with the lowest-risk, highest-clarity subset: **5 form-control packages** whose EP dependency is utilities + a small set of form-control composables, no popper/overlay machinery. Migrating them proves the v2 pattern scales to a second wave, removes 5 packages from the guard's allowlist, and produces the reusable form-control hooks that the rest of v4 will build on. Doing this as an isolated slice keeps each PR reviewable and lets `front-b2b` consume the migration incrementally instead of waiting for a 22-package big-bang.
+
+## Scope
+
+### In Scope
+
+**(a) Build the hooks/utils the 5 packages actually import** (verified by grepping real `element-plus` imports in the 5 target packages — NOT the full seed candidate list):
+
+- **New composables in `common/g-hooks`** (source-only, `buildable:false`, algorithms copied exactly from EP):
+  - `useAriaProps` — used by checkbox, radio, switch, segmented, input
+  - `useSizeProp` — used by input
+  - `useFormSize` — used by segmented (final package placement — `g-hooks` vs `g-form` — is a design-phase decision, see Proposal question round)
+  - Input sub-family used only by `input`: `useComposition`, `useCursor`, `useFocusController`, and the EP-flavored merged `useAttrs` (distinct from Vue's `useAttrs`; `input.vue` imports both — required for `input` to fully drop element-plus)
+- **New helpers in `common/g-utils`** (source-only, `buildable:false`, pure):
+  - Type guards: `isBoolean`, `isObject`, `isString`
+  - Prop builders: `buildProps`, `definePropType`
+  - `debugWarn`; size validator `isValidComponentSize`
+  - Install helper `withInstall` + type `SFCWithInstall`
+  - Map still missing: `ValidateComponentsMap` (used by `input`)
+- All new hooks/utils **ship with Vitest unit tests** (strict TDD active, `yarn test:run`, unit-only policy).
+
+**Reused, NOT built** (already extracted; migration just re-points imports to own code):
+
+- `useNamespace` — already exists in `@flash-global66/g-utils` (`common/g-utils/src/composables/useNamespace.ts`, already unit-tested). Used by all 5 packages, currently imported from `element-plus`.
+- `useId` — already in `@flash-global66/g-hooks` (used by radio, segmented).
+- `useFormItem` / `useFormItemInputId` / `useFormDisabled` — already in `@flash-global66/g-form`, already imported by the 5 packages.
+
+**(b) Migrate the 5 form-control packages** off element-plus internals onto the own-code hooks/utils (and the already-extracted `g-utils`/`g-hooks`/`g-form`):
+`checkbox`, `radio`, `switch`, `segmented`, `input`.
+
+**(c) Shrink the ESLint guard**: remove exactly these 5 entries from `excludedFiles` in `.eslintrc.cjs` as each package is migrated — `components/{checkbox,radio,switch,segmented,input}/**`. All other deferred packages stay excluded until v4.
+
+### Out of Scope (Non-Goals)
+
+- **`input-number`, deferred to v4.** It is the heaviest of the original candidates: it needs `useLocale` (i18n) and the `vRepeatClick` directive (neither built in v3), and it depends on `@flash-global66/g-input` (`InputInstance`) — which v3 migrates, so v4 can migrate `input-number` on top of a clean `g-input`. v4 will build `useLocale` + `vRepeatClick` and then migrate it.
+- **The heavy/popper-dependent family, deferred to v4**: select, table, tooltip, popper, date-picker, time-picker, dialog, dropdown, collapse, toast, pagination, scrollbar, slot, focus-trap, input-tag, inline. **Do NOT build the `usePopper*` family, `useSameTarget`, or `useEscapeKeydown` in v3.**
+- **`iconPropType`** and other prop-helpers NOT imported by these 5 (verified absent) — build them when the package that needs them is migrated.
+- **The 8 permanent islands** (wrap whole EP components): badge, menu, config-provider, popover, radio-group, form-item, skeleton, infinite-scroll — permanently out.
+- Removing `element-plus` from any package's `peerDependencies`.
+- Any DOM/integration test (unit-only policy).
+
+## Capabilities
+
+### Modified Capabilities
+
+- `g-hooks-package`: add the form-control composable set (`useAriaProps`, `useSizeProp`, `useFormSize`) plus the input sub-family (`useComposition`, `useCursor`, `useFocusController`, EP `useAttrs`).
+- `g-utils-extended`: add `isBoolean`, `isObject`, `isString`, `buildProps`, `definePropType`, `debugWarn`, `isValidComponentSize`, `withInstall`, `SFCWithInstall`, `ValidateComponentsMap`.
+- `eslint-ep-import-guard`: remove the 5 migrated packages from `excludedFiles`.
+
+## Approach
+
+Dependency-ordered, isolated per work unit so each WU is an independently reviewable, independently publishable chained PR. Build utils first, then the shared form-control hooks, migrate the 4 light controls, then build the input-specific hooks and migrate `input` last. Copy EP algorithms EXACTLY (no "improvements") to avoid behavior drift; cover each with unit tests before wiring it into a component. Extend the guard by deletion (remove excludes) only after each package is migrated and lint-clean, so `--max-warnings 0` always passes.
+
+**Discovered heaviness (baked into ordering):** `input` is NOT as simple as checkbox/radio/switch/segmented — it pulls an input-specific hook sub-family (`useComposition`, `useCursor`, `useFocusController`, EP `useAttrs`). It is isolated into its own hook WU + migration WU to protect the review budget and to keep the 4 light controls shippable without waiting on the input family. (`input-number`, originally the heaviest, is deferred to v4 — see Out of Scope.)
+
+## Work Unit Grouping (this slice)
+
+| WU   | Deliverable                                                                                                                                                                 | Depends on | Publish    |
+| ---- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------- | ---------- |
+| WU-1 | `g-utils` additions (type guards, `buildProps`/`definePropType`, `debugWarn`, `isValidComponentSize`, `withInstall`/`SFCWithInstall`, `ValidateComponentsMap`) + unit tests | —          | g-utils    |
+| WU-2 | `g-hooks` shared form-control composables (`useAriaProps`, `useSizeProp`, `useFormSize`) + unit tests                                                                       | WU-1       | g-hooks    |
+| WU-3 | Migrate 4 light controls: checkbox, radio, switch, segmented + remove their 4 ESLint excludes                                                                               | WU-1, WU-2 | 4 controls |
+| WU-4 | `g-hooks` input sub-family (`useComposition`, `useCursor`, `useFocusController`, EP `useAttrs`) + unit tests                                                                | WU-1       | g-hooks    |
+| WU-5 | Migrate input + remove its ESLint exclude                                                                                                                                   | WU-2, WU-4 | input      |
+
+## Delivery / Rollout
+
+- **Chained PRs by work unit**, strategy `stacked-to-main`: each WU is its own PR that merges to `main` in order. WU-3 and WU-5 are the two migration slices; WU-1/WU-2/WU-4 are hook/util foundations.
+- **Incremental publish per WU**: each merged WU publishes its packages via Lerna; `front-b2b` consumes the migration incrementally rather than in one big-bang.
+- **b2b validation with REAL COPIES in `node_modules`, never symlinks** — symlinks strip base CSS / Tailwind `@apply` processing (documented gotcha). Validate each migration WU against b2b before moving on.
+- **Strict TDD**: new hooks/utils land red→green with `yarn test:run` (unit-only; 129 tests currently green). Env requires node v20.19.3 and a dummy `GBP_PACKAGE_TOKEN` for yarn/npx.
+- Review budget: each WU targets ≤400 changed lines. With `input-number` deferred, WU-5 is now a single-package migration and comfortably within budget.
+
+## Affected Areas
+
+| Area                                                                       | Impact   | Description                                                       |
+| -------------------------------------------------------------------------- | -------- | ----------------------------------------------------------------- |
+| `common/g-utils/src/**`                                                    | Modified | New pure helpers, guards, `ValidateComponentsMap`                 |
+| `common/g-hooks/src/**`                                                    | Modified | New form-control + input composables                              |
+| `components/{checkbox,radio,switch,segmented,input}/src/**` and `index.ts` | Modified | EP internal imports replaced with own code / `g-utils` / `g-form` |
+| `.eslintrc.cjs`                                                            | Modified | Remove the 5 migrated packages from `excludedFiles`               |
+
+## Risks
+
+| Risk                                                                                  | Likelihood      | Mitigation                                                                                                                   |
+| ------------------------------------------------------------------------------------- | --------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| Copied EP algorithms drift (e.g. `useComposition`, `useCursor`, `useFocusController`) | Medium          | Copy exactly, no improvements; dedicated unit tests per hook before wiring                                                   |
+| `input` heavier than "simple" label; scope/budget creep                               | Medium          | Isolated in WU-4/WU-5; hooks built and tested before the migration WU                                                        |
+| Re-pointing `useNamespace` (used by all 5) introduces a class-name regression         | Low             | Already extracted and unit-tested in `g-utils`; migration only swaps the import path; validate on the 4 light controls first |
+| Symlinked b2b validation hides CSS/`@apply` breakage                                  | High if misused | Mandatory real-copy validation per migration WU                                                                              |
+| Incremental publish leaves b2b on a mixed set of versions mid-slice                   | Low             | WUs are additive/independent; each published package is self-consistent                                                      |
+
+## Rollback Plan
+
+Each WU is a separate PR/merge commit. Roll back a WU with `git revert` of its merge commit; hooks/utils are additive and imports are swapped file-by-file, so reverting a migration WU restores the prior EP imports without touching unrelated work. No data migration or external state involved.
+
+## Success Criteria
+
+- [ ] Zero `from ['"]element-plus` matches under the 5 migrated packages' `src/**` and `index.ts`.
+- [ ] New hooks/utils each have passing Vitest unit tests; full suite stays green.
+- [ ] `.eslintrc.cjs` `excludedFiles` no longer lists the 5 migrated packages (the other deferred packages, `input-number`, and the 8 islands remain).
+- [ ] `yarn build` succeeds for all buildable packages; `yarn lint` passes with `--max-warnings 0`.
+- [ ] Each migration WU validated in `front-b2b` via real copies (no symlinks).
+
+## Proposal question round
+
+Open product/scope decisions worth confirming before `sdd-spec`/`sdd-design`:
+
+1. **`useFormSize` placement** — it reads form context for size. Does it belong in `g-hooks` (size domain) or in `@flash-global66/g-form` (form-context domain, where `useFormItem`/`useFormDisabled` already live)? Assumption: build it where it minimizes cross-package coupling; defer the final call to `sdd-design`.
+2. **Publish cadence** — assumption: publish per WU (incremental). Confirm vs. publishing once at the end of the slice.
+
+_Resolved: `input-number` is deferred to v4 (user decision) — v3 covers 5 packages._

--- a/openspec/changes/ep-extraction-v3/spec.md
+++ b/openspec/changes/ep-extraction-v3/spec.md
@@ -1,0 +1,69 @@
+# Spec: ep-extraction-v3
+
+> Artifact store: hybrid. Continues `ep-extraction-v2`. Branch: `feat/ds-ep-extraction-v2`.
+> Consolidated view of the domain deltas below. Per-domain files live at `openspec/changes/ep-extraction-v3/specs/<domain>/spec.md`.
+> Corrected 2026-07-08: previous draft mis-specified several g-utils symbols as ADDED when v2 already shipped them, misplaced `useFormSize` in `g-hooks`, and omitted `ValidateComponentsMap`'s real (input-local) placement. See "Corrections" at the end.
+
+## Domain: g-utils-extended (Modified Capability — delta)
+
+**ADDED**: `componentSizes` (runtime `['', 'default', 'small', 'large']`), `isValidComponentSize`, `isPromise`, `mutable`/`Mutable` — all verified absent from `common/g-utils/src` via grep. Each ships a Vitest unit test; full suite green via `yarn test:run`.
+
+**Non-Goals**: `isBoolean`, `isObject`, `isString`, `buildProps`, `definePropType`, `debugWarn`, `withInstall`, `SFCWithInstall` already exist since `ep-extraction-v2` — reused, not re-added. `ValidateComponentsMap` is NOT here (input-local, DS-icon-based — see `form-control-migration`). `INPUT_EVENT` stays out (only `input-number` uses it).
+
+Full requirements/scenarios: `specs/g-utils-extended/spec.md`.
+
+## Domain: g-hooks-package (Modified Capability — delta)
+
+**ADDED**: `useAriaProps` (checkbox/radio/switch/segmented/input), `useSizeProp` (input, a `buildProp`'d prop definition, not a hook fn), input sub-family `useComposition`/`useCursor`/`useFocusController`/own-code EP-flavored `useAttrs` (input only). Each ships a Vitest unit test; full suite green.
+
+**Non-Goals**: `useFormSize` is NOT added here — see `g-form` domain (avoids a `g-hooks → g-form` cycle). `usePopper*`/`useSameTarget`/`useEscapeKeydown` deferred to v4.
+
+Full requirements/scenarios: `specs/g-hooks-package/spec.md`.
+
+## Domain: g-form (New Capability)
+
+Purpose: hosts form-context-derived composables; new domain introduced by this change specifically to host `useFormSize` next to the existing `useFormItem`/`useFormItemInputId`/`useFormDisabled` (pre-existing, out of scope here).
+
+**ADDED**: `useFormSize` — resolves size via **`prop > fallback > useGlobalSize() > 'default'`**, with `ignore.prop`/`ignore.global` flags. **No form-context size tier**: `g-form`'s `formProps`/`formItemProps` expose no `size` field in this version, so there is nothing to read at that tier. This is a pure refactor of existing (already form-context-tier-less) EP behavior, not a new feature.
+
+**Non-Goals**: adding a `size` prop to `formProps`/`formItemProps` or reinstating a form-context tier (documented future enhancement, explicitly out of v3 scope — scope-creep risk).
+
+Full requirements/scenarios: `specs/g-form/spec.md`.
+
+## Domain: eslint-ep-import-guard (Modified Capability — delta)
+
+**MODIFIED** `island-override-exclusion`: `checkbox`, `radio`, `switch`, `segmented`, `input` removed from `excludedFiles` — guarded like any other component. `input-number` and the remaining deferred packages stay excluded.
+
+Full requirements/scenarios: `specs/eslint-ep-import-guard/spec.md`.
+
+## Domain: form-control-migration (New Capability)
+
+Purpose: migrate `checkbox`, `radio`, `switch`, `segmented`, `input` off `element-plus` internal imports onto own hooks/utils, without changing public API. `input-number` out of scope.
+
+Key requirements: zero EP imports per package; public API unchanged; `useNamespace`/`useId`/`useFormItem`-family re-pointed to existing extractions; **`switch`/`segmented` use `useFormSize` (`g-form`)**, **`input` uses `useSizeProp` (`g-hooks`)** — not the reverse; `input` additionally wires `useComposition`/`useCursor`/`useFocusController`/`useAttrs`; `ValidateComponentsMap` is authored **input-local** against `@flash-global66/g-icon-font` (dropped if the WU-5 usage audit finds it unused, not ported); `input-number` untouched; migration gated by green tests before each ESLint exclude removal.
+
+Full requirements/scenarios: `specs/form-control-migration/spec.md`.
+
+## Non-Goals (apply to all domains above)
+
+- Any DOM/integration test (unit-only policy)
+- Changing public API (props/emits/slots) of any of the 5 migrated packages
+- Migrating `input-number` or any popper/overlay-dependent package
+- Removing `element-plus` from any package's `peerDependencies`
+- Reimplementing `useNamespace`, `useId`, `useFormItem`, `useFormItemInputId`, `useFormDisabled` (already extracted; reused as-is)
+- Reimplementing `isBoolean`, `isObject`, `isString`, `buildProps`, `definePropType`, `debugWarn`, `withInstall`, `SFCWithInstall` (already extracted in v2; reused as-is)
+- Adding a `g-icon-font` dependency to `g-utils`/`g-hooks`
+
+## Corrections vs. previous draft
+
+1. **g-utils ADDED shrunk**: removed `additional-type-guards`, `prop-builder-utilities`, `install-helper`, and the `debugWarn` half of `dev-warning-and-size-validation` — all already shipped in v2 (verified by grep against `common/g-utils/src`). Real ADDED delta is only `componentSizes`/`isValidComponentSize`/`isPromise`/`mutable`/`Mutable`.
+2. **`mutable`/`Mutable` reclassified as ADDED, not reused.** Grep against `common/g-utils/src` and the wider `common/` tree found zero matches for `mutable` or `Mutable` — they do not exist yet. This matches `design.md`'s own discovery table (WU-1 includes `mutable`/`Mutable`) and is now the source of truth over any instruction claiming they already exist.
+3. **`useFormSize` moved out of `g-hooks-package` into a new `g-form` domain**, matching design decision 2.1 (avoids `g-hooks → g-form` cycle). The old `form-size-resolution-precedence` requirement (4-tier, including a form-context tier) is replaced by a 3-tier `prop > fallback > global > default` requirement — the DS has no form-level `size` today, so the 4-tier scenario never reflected real behavior.
+4. **`ValidateComponentsMap` moved from `g-utils-extended` to `form-control-migration`**, input-local, re-authored against `@flash-global66/g-icon-font` (not byte-copyable from EP, which references `@element-plus/icons-vue`). Flagged for a confirm-and-drop-if-unused check during WU-5.
+
+## References
+
+- Proposal: `openspec/changes/ep-extraction-v3/proposal.md` (Engram #252)
+- Design: `openspec/changes/ep-extraction-v3/design.md` (decisions 2.1, 2.3)
+- Baseline specs: `openspec/specs/g-utils-extended/spec.md`, `openspec/specs/g-hooks-package/spec.md`, `openspec/specs/eslint-ep-import-guard/spec.md`
+- Prior change: `openspec/archive/2026-07-08-ep-extraction-v2/`

--- a/openspec/changes/ep-extraction-v3/specs/eslint-ep-import-guard/spec.md
+++ b/openspec/changes/ep-extraction-v3/specs/eslint-ep-import-guard/spec.md
@@ -1,0 +1,27 @@
+# Delta for eslint-ep-import-guard
+
+## MODIFIED Requirements
+
+### Requirement: island-override-exclusion
+
+The rule MUST include exclusions for the 8 permanent island packages and the deferred packages that have not yet been migrated off element-plus internals, so their legitimate element-plus imports are not blocked. After this change, `excludedFiles` MUST NO LONGER list `checkbox`, `radio`, `switch`, `segmented`, or `input` — these 5 packages are migrated and become guarded like any other component source path. The remaining deferred packages and `input-number` (explicitly deferred to `ep-extraction-v4`) MUST stay excluded.
+
+(Previously: exclusions covered the 8 island packages and all deferred packages, including `checkbox`, `radio`, `switch`, `segmented`, and `input`.)
+
+#### Scenario: island import not blocked
+
+- GIVEN the guard active and exclusions configured for island/deferred packages
+- WHEN a file in `components/badge/index.ts` (island) imports `from 'element-plus'`
+- THEN ESLint reports no error
+
+#### Scenario: migrated packages are no longer excluded
+
+- GIVEN `checkbox`, `radio`, `switch`, `segmented`, and `input` removed from `excludedFiles`
+- WHEN a file under `components/checkbox/src/**` imports `from 'element-plus'`
+- THEN ESLint reports error `'element-plus' import is restricted`
+
+#### Scenario: input-number stays excluded
+
+- GIVEN `input-number` is deferred to `ep-extraction-v4` and remains in `excludedFiles`
+- WHEN a file under `components/input-number/src/**` imports `from 'element-plus'`
+- THEN ESLint reports no error

--- a/openspec/changes/ep-extraction-v3/specs/form-control-migration/spec.md
+++ b/openspec/changes/ep-extraction-v3/specs/form-control-migration/spec.md
@@ -1,0 +1,112 @@
+# form-control-migration Specification
+
+## Purpose
+
+Migrate 5 form-control component packages — `checkbox`, `radio`, `switch`, `segmented`, `input` — off `element-plus` internal imports onto the design system's own hooks/utils (`g-utils`, `g-hooks`, `g-form`), without changing any package's public API. `input-number` is explicitly excluded from this change.
+
+## Requirements
+
+### Requirement: zero-ep-imports-per-migrated-package
+
+For each of `checkbox`, `radio`, `switch`, `segmented`, and `input`, no file under `components/<pkg>/src/**` nor `components/<pkg>/index.ts` MUST import any specifier starting with `element-plus`.
+
+#### Scenario: grep audit passes per package
+
+- GIVEN a migrated package
+- WHEN `grep -r "from ['\"]element-plus" components/<pkg>/src/ components/<pkg>/index.ts` runs
+- THEN zero matches are returned
+
+### Requirement: public-api-preserved
+
+Each migrated package's props, emits, and slots MUST be identical before and after migration. This is an internal refactor, not a breaking change for `front-b2b` or `front-admin`.
+
+#### Scenario: consumers compile and render unchanged
+
+- GIVEN a fixed set of props/emits/slots usage for a migrated component, exercised before and after migration
+- WHEN compared
+- THEN no prop/emit/slot is added, removed, renamed, or retyped, and rendered output is unchanged
+
+### Requirement: reused-composables-repointed
+
+Each migrated package MUST import `useNamespace` from `@flash-global66/g-utils`, `useId` from `@flash-global66/g-hooks` (where used, e.g. radio, segmented), and `useFormItem`/`useFormItemInputId`/`useFormDisabled` from `@flash-global66/g-form`, instead of `element-plus`.
+
+#### Scenario: import source swapped without behavior change
+
+- GIVEN a migrated package that previously imported `useNamespace` from `element-plus`
+- WHEN it now imports `useNamespace` from `@flash-global66/g-utils`
+- THEN generated CSS class names are byte-identical to the pre-migration output
+
+### Requirement: size-composable-wired-per-component
+
+`switch` and `segmented` MUST resolve their effective size via `useFormSize` from `@flash-global66/g-form` (they read form-context-aware size). `input` MUST resolve its `size` prop via `useSizeProp` from `@flash-global66/g-hooks` instead — `input` has no `useFormSize` call in element-plus and none is introduced by this change.
+
+#### Scenario: switch and segmented use the form-aware size hook
+
+- GIVEN `switch` and `segmented` migrated
+- WHEN their source is inspected
+- THEN both import `useFormSize` from `@flash-global66/g-form` and no longer import a size hook from `element-plus`
+
+#### Scenario: input uses the prop-only size hook
+
+- GIVEN `input` migrated
+- WHEN its source is inspected
+- THEN it declares `size` via `useSizeProp` from `@flash-global66/g-hooks` and does not import `useFormSize`
+
+### Requirement: input-specific-hooks-wired
+
+`input` MUST additionally use `useComposition`, `useCursor`, `useFocusController`, and the own-code EP-flavored `useAttrs` from `@flash-global66/g-hooks`, replacing its element-plus equivalents.
+
+#### Scenario: input behavior unchanged after hook rewiring
+
+- GIVEN `input` wired to the new `g-hooks` composables
+- WHEN IME composition, cursor movement, focus/blur, and attribute merging are exercised
+- THEN observed behavior matches the pre-migration element-plus-backed implementation
+
+### Requirement: validate-components-map-input-local
+
+`ValidateComponentsMap` MUST be authored as an `input`-local constant (`components/input/src/`), re-mapping validation states to `@flash-global66/g-icon-font` icons instead of copying element-plus's `@element-plus/icons-vue` mapping. Before porting, the migration work unit MUST confirm the symbol is still consumed by `input.vue` (not just imported); if unused, the import MUST be dropped instead of re-authored.
+
+#### Scenario: map is DS-icon-based and input-local
+
+- GIVEN `input` migrated and `ValidateComponentsMap` still in use
+- WHEN its module location and icon references are inspected
+- THEN it lives under `components/input/src/` (not `g-utils`/`g-hooks`) and references `@flash-global66/g-icon-font` icons, not `@element-plus/icons-vue`
+
+#### Scenario: unused import is dropped, not ported
+
+- GIVEN the WU-5 usage audit finds `ValidateComponentsMap` imported but never referenced in `input.vue`
+- WHEN the migration is completed
+- THEN the import is removed entirely and no local `ValidateComponentsMap` file is created
+
+### Requirement: input-number-out-of-scope
+
+`input-number` MUST NOT be modified by this change. It depends on hooks (`useLocale`, `vRepeatClick`) not built in this slice and is deferred to `ep-extraction-v4`.
+
+#### Scenario: input-number untouched
+
+- GIVEN this change is applied
+- WHEN `components/input-number/src/**` is inspected
+- THEN its element-plus imports remain exactly as before this change
+
+### Requirement: migration-gated-by-green-tests
+
+For each migrated package, all relevant unit tests (existing plus new hook/util tests) MUST pass via `yarn test:run` before that package's ESLint exclude is removed.
+
+#### Scenario: tests green gates exclude removal
+
+- GIVEN a migration work unit for one of the 5 packages
+- WHEN `yarn test:run` is executed as part of that work unit
+- THEN it passes with no failing tests before `.eslintrc.cjs` is updated to remove that package's exclude
+
+## Non-Goals
+
+- Any DOM/integration test (unit-only policy)
+- Changing public API (props/emits/slots) of any of the 5 packages
+- Migrating `input-number` or any popper/overlay-dependent package
+- Removing `element-plus` from any package's `peerDependencies`
+- Adding a `g-icon-font` dependency to `g-utils` or `g-hooks` (icon mapping stays input-local)
+
+## References
+
+- Depends on: `openspec/specs/g-utils-extended/spec.md`, `openspec/specs/g-hooks-package/spec.md`, `openspec/changes/ep-extraction-v3/specs/g-form/spec.md`
+- Change: `ep-extraction-v3` (proposal #252)

--- a/openspec/changes/ep-extraction-v3/specs/g-form/spec.md
+++ b/openspec/changes/ep-extraction-v3/specs/g-form/spec.md
@@ -1,0 +1,58 @@
+# g-form Specification
+
+> New OpenSpec domain, introduced by `ep-extraction-v3` because the size-resolution composable must live next to `g-form`'s existing form/form-item injection context (`useFormItem`, `useFormItemInputId`, `useFormDisabled`), not in `g-hooks`, to keep the dependency graph acyclic (`g-hooks → g-form` is forbidden). This spec documents only the NEW composable this change adds; `useFormItem`/`useFormItemInputId`/`useFormDisabled` already exist (shipped pre-v3) and are out of scope for this documentation pass.
+
+## Purpose
+
+`@flash-global66/g-form` hosts form-context-derived composables — logic that must `inject()` the form/form-item provide keys. It depends on `@flash-global66/g-hooks` and `@flash-global66/g-utils`; nothing may depend back on it from those lower layers.
+
+## Requirements
+
+### Requirement: form-aware-size-resolution
+
+`useFormSize` MUST be added to `@flash-global66/g-form`, resolving a component's effective size with this precedence, highest first: (1) an explicit `size` prop (via `useProp<ComponentSize>('size')` from `g-hooks`), (2) an optional `fallback` argument, (3) `useGlobalSize()` from `g-hooks`, (4) `'default'`. It MUST NOT read a form/form-item context size tier: `g-form`'s `formProps`/`formItemProps` expose no `size` field in this version, so no such tier exists to read. `ignore.prop`/`ignore.global` flags MAY be passed to skip the corresponding tier.
+
+#### Scenario: explicit prop wins over fallback and global
+
+- GIVEN a component with an explicit `size="large"` prop, a `fallback` of `'small'`, and a global size config of `'default'`
+- WHEN `useFormSize(fallback)` resolves size
+- THEN it returns `'large'`
+
+#### Scenario: fallback wins when prop is absent
+
+- GIVEN no `size` prop set, `fallback` of `'small'`, and a global size config of `'default'`
+- WHEN `useFormSize(fallback)` resolves size
+- THEN it returns `'small'`
+
+#### Scenario: falls through to global default with nothing set
+
+- GIVEN no `size` prop, no `fallback`, and no DS global size config active
+- WHEN `useFormSize()` resolves size
+- THEN it returns `'default'`
+
+#### Scenario: ignore flags neutralize their tier
+
+- GIVEN an explicit `size` prop set and `ignore: { prop: true }` passed
+- WHEN `useFormSize(undefined, { prop: true })` resolves size
+- THEN it evaluates the next tier (`fallback` then global) instead of the prop
+
+### Requirement: new-hook-unit-tested
+
+`useFormSize` MUST ship mounted-component Vitest unit tests covering all four precedence tiers and both `ignore` flags. Tests MUST be unit-only, and the full suite MUST pass via `yarn test:run`.
+
+#### Scenario: full suite green after addition
+
+- GIVEN `useFormSize` implemented with unit tests
+- WHEN `yarn test:run` executes
+- THEN all tests pass, including the new hook's tests
+
+## Non-Goals
+
+- Adding a `size` prop to `formProps`/`formItemProps` or reinstating a form-context size tier — rejected as scope creep; this is a migration, not a new feature. Documented as a future enhancement outside `ep-extraction-v3`.
+- Reimplementing or re-documenting `useFormItem`, `useFormItemInputId`, `useFormDisabled` — already exist, unaffected by this change.
+- Moving `formContextKey`/`formItemContextKey` out of `g-form` into `g-hooks`/`g-utils`.
+
+## References
+
+- Depends on: `@flash-global66/g-hooks` (`useProp`, `useGlobalSize`), `@flash-global66/g-utils` (`ComponentSize`)
+- Change: `ep-extraction-v3` (proposal #252, design decision 2.1)

--- a/openspec/changes/ep-extraction-v3/specs/g-hooks-package/spec.md
+++ b/openspec/changes/ep-extraction-v3/specs/g-hooks-package/spec.md
@@ -1,0 +1,60 @@
+# Delta for g-hooks-package
+
+## ADDED Requirements
+
+### Requirement: form-control-aria-composable
+
+`useAriaProps` MUST be added to `@flash-global66/g-hooks`, replicating the element-plus algorithm exactly (no reimplementation), and MUST be consumed by `checkbox`, `radio`, `switch`, `segmented`, and `input` in place of the element-plus import.
+
+#### Scenario: aria attrs resolve identically to element-plus
+
+- GIVEN a component calling `useAriaProps(...)` with the same inputs as its pre-migration element-plus call
+- WHEN the returned aria attribute object is compared to the pre-migration output
+- THEN the attributes are identical
+
+### Requirement: input-size-prop-composable
+
+`useSizeProp` MUST be added to `g-hooks` as a `buildProp`'d prop DEFINITION constant (mirroring element-plus, not a hook function) built from `componentSizes` (`@flash-global66/g-utils`), and consumed by `input` to declare its reactive `size` prop.
+
+#### Scenario: prop definition validates size values
+
+- GIVEN `input`'s `size` prop declared via `useSizeProp`
+- WHEN a value from `componentSizes` is assigned versus an invalid value like `'huge'`
+- THEN valid values are accepted and `'huge'` fails the prop validator
+
+### Requirement: input-composable-subfamily
+
+`useComposition`, `useCursor`, `useFocusController`, and an EP-flavored `useAttrs` (distinct from Vue core's `useAttrs`; `input.vue` imports both) MUST be added to `g-hooks`, with algorithms copied exactly from element-plus. This subfamily MUST be consumed only by `input`.
+
+#### Scenario: composition and cursor state preserved
+
+- GIVEN an IME composition sequence and a subsequent cursor-position update on the same input
+- WHEN `useComposition` and `useCursor` process the events
+- THEN composing state and cursor position match element-plus's pre-migration behavior
+
+#### Scenario: focus controller forwards events
+
+- GIVEN `input`'s focus/blur handlers wired through `useFocusController`
+- WHEN the input gains and loses focus
+- THEN `focus`/`blur` events fire with the same payload shape as before migration
+
+#### Scenario: EP-flavored useAttrs excludes class/style and listeners on demand
+
+- GIVEN `useAttrs({ excludeListeners: true })` on a component with `class`, `style`, and an `onClick` handler in `$attrs`
+- WHEN the computed attrs object is read
+- THEN `class`, `style`, and `onClick` are absent while other attrs pass through reactively
+
+### Requirement: new-hooks-unit-tested
+
+Every composable added by this delta (`useAriaProps`, `useSizeProp`, `useComposition`, `useCursor`, `useFocusController`, EP-flavored `useAttrs`) MUST ship a Vitest unit test file. Tests MUST be unit-only (no DOM/integration), and the full suite MUST pass via `yarn test:run`.
+
+#### Scenario: full suite green after additions
+
+- GIVEN all hooks in this delta implemented with unit tests
+- WHEN `yarn test:run` executes
+- THEN all tests pass, including the new hook tests
+
+## Non-Goals
+
+- `useFormSize` — NOT added to `g-hooks`. It requires form/form-item injection context (`formContextKey`/`formItemContextKey`), which live in `g-form`; hosting it in `g-hooks` would create a `g-hooks → g-form → g-hooks` cycle. See the `g-form` domain.
+- `usePopper*`, `useSameTarget`, `useEscapeKeydown` — deferred to `ep-extraction-v4`.

--- a/openspec/changes/ep-extraction-v3/specs/g-utils-extended/spec.md
+++ b/openspec/changes/ep-extraction-v3/specs/g-utils-extended/spec.md
@@ -1,0 +1,62 @@
+# Delta for g-utils-extended
+
+## ADDED Requirements
+
+### Requirement: component-size-validation
+
+`componentSizes` MUST be added as a runtime constant array `['', 'default', 'small', 'large']` (keeps `''` for element-plus validator parity). `isValidComponentSize(val)` MUST return `true` only for values in `componentSizes`. The existing `ComponentSize` type (`'large' | 'default' | 'small'`) is unchanged — it intentionally omits `''`.
+
+#### Scenario: size validator accepts EP-valid values including empty string
+
+- GIVEN `isValidComponentSize('')`, `isValidComponentSize('small')`, `isValidComponentSize('large')`
+- WHEN each is called
+- THEN each returns `true`
+
+#### Scenario: size validator rejects invalid values
+
+- GIVEN `isValidComponentSize('huge')`
+- WHEN it is called
+- THEN it returns `false`
+
+### Requirement: promise-type-guard
+
+`isPromise<T>(val): val is Promise<T>` MUST be added as a pure type guard, returning `true` for native `Promise` instances and `{then, catch}`-shaped thenables.
+
+#### Scenario: guard recognizes real and thenable promises
+
+- GIVEN a native `Promise.resolve()` and a plain object `{then: fn, catch: fn}`
+- WHEN `isPromise` is called on each
+- THEN both return `true`
+
+#### Scenario: guard rejects non-promise values
+
+- GIVEN `isPromise({})`, `isPromise(null)`, `isPromise(() => {})`
+- WHEN each is called
+- THEN each returns `false`
+
+### Requirement: mutable-identity-cast
+
+`mutable<T>(val)` and the type `Mutable<T> = { -readonly [P in keyof T]: T[P] }` MUST be added, providing a readonly-stripping identity cast for `as const` literal arrays/objects (used by `input`'s prop definitions). `mutable` MUST return the same reference it received, only re-typed.
+
+#### Scenario: identity cast preserves reference and strips readonly
+
+- GIVEN a `readonly` tuple `['a', 'b'] as const`
+- WHEN passed through `mutable(...)`
+- THEN the returned value is reference-equal to the input and its static type is no longer `readonly`
+
+### Requirement: new-utils-unit-tested
+
+Every symbol added by this delta (`componentSizes`, `isValidComponentSize`, `isPromise`, `mutable`/`Mutable`) MUST ship a Vitest unit test file. Tests MUST be unit-only (no DOM/integration), and the full suite MUST pass via `yarn test:run`.
+
+#### Scenario: full suite green after additions
+
+- GIVEN all utilities in this delta implemented with unit tests
+- WHEN `yarn test:run` executes
+- THEN all tests pass, including the new utility tests
+
+## Non-Goals
+
+- Re-adding `isBoolean`, `isObject`, `isString`, `buildProps`, `definePropType`, `debugWarn`, `withInstall`, `SFCWithInstall` — these already ship in `@flash-global66/g-utils` since `ep-extraction-v2` and are only re-pointed-to (reused as-is) by the migrated packages.
+- `ValidateComponentsMap` — NOT added here. It maps to `@element-plus/icons-vue` components in EP and must be re-authored against `@flash-global66/g-icon-font` to avoid `g-utils` depending on an icon package. It is input-local; see `form-control-migration`.
+- `INPUT_EVENT` — consumed only by `input-number` (deferred to v4), not by `input`; `switch` already imports it from its own local `./constants`.
+- Adding a `g-icon-font` dependency to `g-utils`.

--- a/openspec/changes/ep-extraction-v3/tasks.md
+++ b/openspec/changes/ep-extraction-v3/tasks.md
@@ -1,0 +1,133 @@
+# Tasks: ep-extraction-v3
+
+> Artifact store: hybrid. Depends on `spec.md` + `design.md` (same dir; engram `sdd/ep-extraction-v3/spec` #257, `sdd/ep-extraction-v3/design` #258).
+> Strict TDD is ACTIVE. Test runner: `yarn test:run` (Vitest, unit-only, no DOM/integration). Env: node v20.19.3 + dummy `GBP_PACKAGE_TOKEN` for yarn/npx. 129 pre-existing tests must stay green throughout.
+> Chain strategy: **stacked-to-main** — each WU is its own PR merging to `main` in dependency order (proposal §Delivery, design §2.4). Incremental Lerna publish per merged WU.
+
+## Dependency graph (WU level)
+
+```
+WU-1 (g-utils)
+   │
+   ├──────────────┬───────────────┐
+   ▼              ▼               ▼
+WU-2 (g-hooks   WU-4 (g-hooks   [WU-2 and WU-4 can be
+ shared +         input sub-      developed in parallel —
+ g-form)          family)         both depend only on WU-1]
+   │              │
+   ▼              │
+WU-3 (4 light     │
+ controls)        │
+   │              ▼
+   │           WU-5 (input) ← depends on WU-2 AND WU-4
+   ▼
+(WU-3 and WU-4/WU-5 track are independent chains after WU-1;
+ WU-5 cannot start until BOTH WU-2 and WU-4 are merged)
+```
+
+Every child PR body must include this diagram with the current PR marked `📍`, plus start/end state, prior dependencies, and out-of-scope items (chained-pr skill).
+
+---
+
+## WU-1 — `g-utils` additions (foundations, no dependencies)
+
+Publishes: `@flash-global66/g-utils`. Est. ~150 changed lines. Requirements: `g-utils-extended` → `component-size-validation`, `promise-type-guard`, `mutable-identity-cast`, `new-utils-unit-tested`.
+
+- [ ] T1.1 Write failing unit test for `componentSizes` (equals `['', 'default', 'small', 'large']`) — extend `common/g-utils/tests/utils/validators.util.spec.ts` or a new `tests/types/component.type.spec.ts`.
+- [ ] T1.2 Implement `componentSizes` constant next to `ComponentSize` in `common/g-utils/src/types/component.type.ts` (runtime array keeps `''` for EP validator parity; do NOT change the `ComponentSize` type union). Run `yarn test:run` → green.
+- [ ] T1.3 Write failing unit tests for `isValidComponentSize` (`true` for `''`/`'default'`/`'small'`/`'large'`, `false` for `'medium'`/`'xl'`) in `common/g-utils/tests/utils/validators.util.spec.ts`.
+- [ ] T1.4 Implement `isValidComponentSize` in `common/g-utils/src/utils/validators.util.ts` using `componentSizes.includes(val)`. Run `yarn test:run` → green.
+- [ ] T1.5 Write failing unit tests for `isPromise` (`true` for a real `Promise` and a `{then, catch}` thenable; `false` for `{}`, `null`, functions) in `common/g-utils/tests/utils/validators.util.spec.ts`.
+- [ ] T1.6 Implement `isPromise` in `common/g-utils/src/utils/validators.util.ts` (reuses existing `isObject` + `isFunction` guards — do not reimplement those). Run `yarn test:run` → green.
+- [ ] T1.7 Write failing unit test for `mutable`/`Mutable` (runtime identity — returns the same reference; type-level test that `readonly` is stripped) — new `common/g-utils/tests/types/utils.type.spec.ts`.
+- [ ] T1.8 Implement `Mutable<T>` type + `mutable()` identity cast in `common/g-utils/src/types/utils.type.ts`. Run `yarn test:run` → green.
+- [ ] T1.9 Update `common/g-utils/src/index.ts` barrel to export the 4 new symbols.
+- [ ] T1.10 Confirm zero regressions: full `yarn test:run` (129 + new tests), `yarn lint --max-warnings 0` on `common/g-utils/**`.
+- [ ] T1.11 **Do NOT touch** already-shipped helpers (`isBoolean`/`isObject`/`isString`/`buildProps`/`definePropType`/`debugWarn`/`withInstall`/`SFCWithInstall`) — verify via `git diff --stat` that only the 4 new-symbol files changed.
+- [ ] T1.12 Commit as one work unit (`feat(g-utils): add componentSizes, isValidComponentSize, isPromise, mutable`), open PR #1 (stacked-to-main, target `main`), Lerna-publish `g-utils` on merge.
+
+## WU-2 — `g-hooks` shared form-control composables + `g-form: useFormSize` (depends on WU-1; parallelizable with WU-4)
+
+Publishes: `@flash-global66/g-hooks` AND `@flash-global66/g-form`. Est. ~300 changed lines. Requirements: `g-hooks-package` → `form-control-aria-composable`, `input-size-prop-composable`, `new-hooks-unit-tested`; `g-form` → `form-aware-size-resolution`, `new-hook-unit-tested`.
+
+- [ ] T2.1 Write failing unit test for `useAriaProps` (returns `{ ariaProps }` with exactly one `buildProp`'d `String` entry per requested aria key; unknown keys excluded) — new `common/g-hooks/tests/composables/useAriaProps.spec.ts`.
+- [ ] T2.2 Implement `useAriaProps` in `common/g-hooks/src/composables/useAriaProps.ts` (uses `buildProps`/`definePropType` from `@flash-global66/g-utils` — reused, not reimplemented). Run `yarn test:run` → green.
+- [ ] T2.3 Write failing unit test for `useSizeProp` (prop def with `type === String`, `required === false`, `values` deep-equal `componentSizes`; validator accepts each valid size, rejects `'huge'`) — new `common/g-hooks/tests/composables/useSizeProp.spec.ts`.
+- [ ] T2.4 Implement `useSizeProp` in `common/g-hooks/src/composables/useSizeProp.ts` as a `buildProp`'d prop **definition constant** (not a function), sourcing `componentSizes` from `@flash-global66/g-utils` (WU-1). Run `yarn test:run` → green.
+- [ ] T2.5 Update `common/g-hooks/src/index.ts` barrel to export `useAriaProps`, `useSizeProp`.
+- [ ] T2.6 Write failing unit tests for `useFormSize` (mounted-component tests): explicit prop wins over everything; `fallback` beats global when prop absent; no prop/fallback falls back to `useGlobalSize()` → `'default'`; `ignore.prop`/`ignore.global` flags neutralize each tier; assert NO form-context tier exists — new test file alongside `components/form/src/hooks/use-form-common-props.ts` (create a `components/form/tests/` dir following the `tests/composables|utils` convention used by g-hooks/g-utils, e.g. `components/form/tests/hooks/use-form-common-props.spec.ts`).
+- [ ] T2.7 Implement `useFormSize` in `components/form/src/hooks/use-form-common-props.ts` (sibling of the existing `useFormDisabled` in the same file), composing `useProp<ComponentSize>('size')` + `useGlobalSize()` from `g-hooks` — resolution: `prop > unref(fallback) > useGlobalSize() > 'default'`, **no form-context tier** (do NOT add a `size` prop to `formProps`/`formItemProps` — rejected scope creep per design §2.1). Run `yarn test:run` → green.
+- [ ] T2.8 Update `components/form/src/hooks/index.ts` barrel to export `useFormSize`.
+- [ ] T2.9 Full `yarn test:run` (green), `yarn lint --max-warnings 0` on `common/g-hooks/**` and `components/form/**`.
+- [ ] T2.10 Commit as one work unit (`feat(g-hooks,g-form): add useAriaProps, useSizeProp, useFormSize`), open PR #2 targeting `main` after PR #1 merges (stacked-to-main), Lerna-publish **both** `g-hooks` and `g-form` on merge (design §2.4 — WU-2 must publish g-form or switch/segmented break).
+
+## WU-3 — Migrate 4 light controls: checkbox, radio, switch, segmented (depends on WU-1, WU-2)
+
+Publishes: `checkbox`, `radio`, `switch`, `segmented`. Est. ~260 changed lines. Requirements: `form-control-migration` → `zero-ep-imports-per-migrated-package`, `public-api-preserved`, `reused-composables-repointed`, `size-composable-wired-per-component`, `migration-gated-by-green-tests`; `eslint-ep-import-guard` → `island-override-exclusion` (4 entries).
+
+The 4 packages are independent files and can be migrated concurrently by different contributors, but ship as **one PR** (design §2.4).
+
+- [ ] T3.1 **checkbox**: re-point `useNamespace`→g-utils, `useAriaProps`→g-hooks, `debugWarn`/`isArray`/`isBoolean`/`isObject`/`isString`/`isNumber`/`isPropAbsent`/`isUndefined`→g-utils, `UPDATE_MODEL_EVENT`→g-utils constants, `useFormDisabled`→g-form. Zero public API change. `yarn test:run` green for checkbox's existing tests.
+- [ ] T3.2 **radio**: re-point `useId`→g-hooks, `useNamespace`→g-utils, `useAriaProps`→g-hooks, `buildProps`/`isBoolean`/`isNumber`/`isString`/`isPropAbsent`→g-utils, `UPDATE_MODEL_EVENT`/`CHANGE_EVENT`→g-utils constants. Zero public API change. `yarn test:run` green.
+- [ ] T3.3 **switch**: re-point `useAriaProps`/`useSizeProp`→g-hooks, `useFormDisabled`/`useFormSize`→g-form, `useNamespace`→g-utils, `addUnit`/`debugWarn`/`isBoolean`/`isPromise`/`throwError`/`isValidComponentSize`/`buildProps`/`definePropType`/`isNumber`/`isString`→g-utils, `ComponentSize` type→g-utils. `INPUT_EVENT`/`CHANGE_EVENT`/`UPDATE_MODEL_EVENT` stay on local `./constants` (unchanged). Zero public API change. `yarn test:run` green.
+- [ ] T3.4 **segmented**: re-point `useFormSize`→g-form, `useId`→g-hooks, `useNamespace`→g-utils, `buildProps`/`definePropType`/`isBoolean`/`isNumber`/`isString`/`isObject`/`debugWarn`→g-utils. Zero public API change. `yarn test:run` green.
+- [ ] T3.5 Grep-verify zero `from ['"]element-plus` matches under `components/{checkbox,radio,switch,segmented}/src/**` and `index.ts`.
+- [ ] T3.6 Remove `'components/checkbox/**'`, `'components/radio/**'`, `'components/switch/**'`, `'components/segmented/**'` from `excludedFiles` in `.eslintrc.cjs`. Run `yarn lint --max-warnings 0` (must pass with the excludes removed).
+- [ ] T3.7 `yarn build` succeeds for the 4 packages.
+- [ ] T3.8 Validate in `front-b2b` using **real copies in `node_modules`** (never symlinks — symlinks strip base CSS/Tailwind `@apply`) for the 4 published packages.
+- [ ] T3.9 Commit as one work unit per package or a cohesive multi-package commit that tells one story (`feat(checkbox,radio,switch,segmented): migrate off element-plus internals`), open PR #3 targeting `main` after PR #2 merges. Lerna-publish the 4 packages on merge. Rollback = `git revert` this merge commit (restores prior EP imports without touching WU-1/WU-2).
+
+## WU-4 — `g-hooks` input sub-family (depends on WU-1 only; parallelizable with WU-2/WU-3)
+
+Publishes: `@flash-global66/g-hooks` (second publish, additive). Est. ~380 changed lines (heaviest WU — watch the 400-line budget). Requirements: `g-hooks-package` → `input-composable-subfamily`, `new-hooks-unit-tested`.
+
+- [ ] T4.1 Write failing unit tests for `useComposition` (`compositionstart`/`compositionupdate` set `isComposing = true`; `compositionend` sets it `false` and invokes `afterComposition`; verify the EP Firefox guard on `update`) — new `common/g-hooks/tests/composables/useComposition.spec.ts`.
+- [ ] T4.2 Implement `useComposition` in `common/g-hooks/src/composables/useComposition.ts` — byte-exact copy of EP algorithm, no improvements. Run `yarn test:run` → green.
+- [ ] T4.3 Write failing unit tests for `useCursor` (`record()` then mutate value then `restore()` reinstates `selectionStart`/`selectionEnd`; no-throw when the ref is `undefined`) — new `common/g-hooks/tests/composables/useCursor.spec.ts`.
+- [ ] T4.4 Implement `useCursor` in `common/g-hooks/src/composables/useCursor.ts` — byte-exact copy. Run `yarn test:run` → green.
+- [ ] T4.5 Write failing unit tests for `useFocusController` (`handleFocus` sets `isFocused = true` + fires `afterFocus`; `handleBlur` respects `beforeBlur` veto and otherwise clears focus + fires `afterBlur`; `handleClick` calls `target.focus()`) — new `common/g-hooks/tests/composables/useFocusController.spec.ts`.
+- [ ] T4.6 Implement `useFocusController` in `common/g-hooks/src/composables/useFocusController.ts` — byte-exact copy. Run `yarn test:run` → green.
+- [ ] T4.7 Write failing unit tests for the EP-flavored `useAttrs` (computed excludes `class`/`style` + provided `excludeKeys`; `excludeListeners: true` strips `on[A-Z]*` handlers; passes everything else through reactively) — new `common/g-hooks/tests/composables/useAttrs.spec.ts`.
+- [ ] T4.8 Implement `useAttrs` in `common/g-hooks/src/composables/useAttrs.ts` (`DEFAULT_EXCLUDE_KEYS = ['class', 'style']`, `LISTENER_PREFIX = /^on[A-Z]/`) — name this distinctly enough in the barrel/docs to avoid confusion with Vue's own `useAttrs` (both are imported by `input.vue`). Run `yarn test:run` → green.
+- [ ] T4.9 Update `common/g-hooks/src/index.ts` barrel to export `useComposition`, `useCursor`, `useFocusController`, `useAttrs`.
+- [ ] T4.10 Full `yarn test:run` (green), `yarn lint --max-warnings 0` on `common/g-hooks/**`. If the diff is trending over ~400 lines, split T4.1-4.4 (composition+cursor) and T4.5-4.8 (focus+attrs) into two sequential commits within this same PR rather than opening a second WU.
+- [ ] T4.11 Commit as one work unit (`feat(g-hooks): add input sub-family — useComposition, useCursor, useFocusController, useAttrs`), open PR #4. Since WU-4 depends only on WU-1, it may be branched off WU-1's merge and developed in parallel with WU-2/WU-3; sequence the actual PR-to-`main` merge order per stacked-to-main policy (after WU-1, coordinate merge order with WU-2/WU-3 to avoid rebase churn). Lerna-publish `g-hooks` again on merge.
+
+## WU-5 — Migrate `input` (depends on WU-2 AND WU-4 — last in the chain)
+
+Publishes: `input`. Est. ~220 changed lines. Requirements: `form-control-migration` → `zero-ep-imports-per-migrated-package`, `public-api-preserved`, `reused-composables-repointed`, `size-composable-wired-per-component`, `input-specific-hooks-wired`, `validate-components-map-input-local`, `input-number-out-of-scope`, `migration-gated-by-green-tests`; `eslint-ep-import-guard` → `island-override-exclusion` (input entry).
+
+- [ ] T5.1 **First action**: audit whether `input.vue` still _uses_ `ValidateComponentsMap` (grep shows only an import line in the current EP-coupled code) — confirm usage before writing any migration code.
+- [ ] T5.2a (if used) Write failing unit test for a DS-icon-authored `ValidateComponentsMap` (mapping validate states to `@flash-global66/g-icon-font` `IconString`/`GIconFont`, NOT `@element-plus/icons-vue`) in `components/input/tests/`, then implement it **input-local** in `components/input/src/`. Run `yarn test:run` → green.
+- [ ] T5.2b (if unused) Drop the `ValidateComponentsMap` import entirely from `input.vue` — do not port it, do not add it to `g-utils`.
+- [ ] T5.3 Re-point `useAttrs`/`useComposition`/`useCursor`/`useFocusController`→g-hooks (WU-4), `useAriaProps`/`useSizeProp`→g-hooks (WU-2), `useNamespace`→g-utils, `NOOP`/`debugWarn`/`isClient`/`isObject`/`mutable`/`isString`/`definePropType`/`buildProps`→g-utils, `UPDATE_MODEL_EVENT`→g-utils constants. `useFormItem`/`useFormItemInputId`/`useFormDisabled` already g-form (unchanged, reused as-is). Zero public API change.
+- [ ] T5.4 Confirm `input-number` is untouched (no import from `input` into `input-number` breaks; `input-number` stays on its current EP imports, deferred to v4).
+- [ ] T5.5 `yarn test:run` green for `input`'s existing + new tests; grep-verify zero `from ['"]element-plus` matches under `components/input/src/**` and `index.ts`.
+- [ ] T5.6 Remove `'components/input/**'` from `excludedFiles` in `.eslintrc.cjs` (leave `'components/input-number/**'` excluded). Run `yarn lint --max-warnings 0`.
+- [ ] T5.7 `yarn build` succeeds for `input`.
+- [ ] T5.8 Validate in `front-b2b` using **real copies in `node_modules`** (never symlinks) for the published `input` package.
+- [ ] T5.9 Commit as one work unit (`feat(input): migrate off element-plus internals`), open PR #5 targeting `main` after both PR #2 and PR #4 merge (stacked-to-main; if PR #4 merges after PR #2/#3, rebase PR #5 onto latest `main` before opening). Lerna-publish `input` on merge. Rollback = `git revert` this merge commit.
+
+## Cross-cutting (apply to every WU)
+
+- [ ] X.1 Every WU PR body includes: the dependency diagram (this file's header) with the current PR marked `📍`, start state, finished state, prior dependencies, follow-up work, and out-of-scope items (chained-pr skill Output Contract).
+- [ ] X.2 Every WU is verified independently before merge: `yarn test:run` green, `yarn lint --max-warnings 0`, `yarn build` (where applicable), and — for migration WUs (3, 5) — `front-b2b` real-copy validation.
+- [ ] X.3 No WU introduces a `g-icon-font` dependency into `g-utils` or `g-hooks` (leaf-layer purity, per design §2.3).
+- [ ] X.4 No WU adds a `size` prop to `g-form`'s `formProps`/`formItemProps` (scope-creep guard, per design §2.1).
+- [ ] X.5 After all 5 WUs merge, confirm the slice-level Success Criteria from `proposal.md`: zero EP imports across the 5 packages, all new hooks/utils unit-tested with the full suite green, `excludedFiles` no longer lists the 5 packages, `yarn build`/`yarn lint --max-warnings 0` pass repo-wide, each migration WU validated in `front-b2b` via real copies.
+
+---
+
+## Review Workload Forecast
+
+| WU   | Deliverable                           | Est. changed lines | Chained PR recommended                | 400-line budget risk                                                                                           | Decision needed before apply                                                                                                                  |
+| ---- | ------------------------------------- | -----------------: | ------------------------------------- | -------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| WU-1 | g-utils additions                     |               ~150 | Yes (already locked: stacked-to-main) | Low                                                                                                            | No — strategy pre-decided in proposal/design                                                                                                  |
+| WU-2 | g-hooks shared + g-form `useFormSize` |               ~300 | Yes                                   | Low–Medium                                                                                                     | No                                                                                                                                            |
+| WU-3 | Migrate 4 light controls              |               ~260 | Yes                                   | Low                                                                                                            | No                                                                                                                                            |
+| WU-4 | g-hooks input sub-family              |               ~380 | Yes                                   | **Medium** (closest to the 400-line ceiling; T4.10 has a fallback split-in-two-commits plan if it creeps over) | No — but flag to orchestrator/user if actual diff exceeds ~400 during apply, since it is the one WU at real risk of tripping `size:exception` |
+| WU-5 | Migrate input                         |               ~220 | Yes                                   | Low                                                                                                            | No                                                                                                                                            |
+
+**Overall**: 5 chained PRs, `stacked-to-main`, all WUs individually under the 400-line budget per current estimates. No `size:exception` anticipated. The only watch item is **WU-4**, which sits closest to the ceiling — if the actual diff (4 composables + 4 test files, byte-exact EP copies tend to run long) exceeds ~400 lines during `sdd-apply`, split it into two sequential commits (composition+cursor, then focus+attrs) within the same PR rather than opening a new WU, per T4.10.
+
+**Parallelism summary**: WU-2 and WU-4 both depend only on WU-1 and can be developed in parallel (design §2.4). WU-3's four packages (checkbox, radio, switch, segmented) are independent files migrable concurrently but ship as one PR. WU-5 is strictly sequential — it cannot start until both WU-2 and WU-4 have merged.

--- a/openspec/changes/ep-extraction-v3/tasks.md
+++ b/openspec/changes/ep-extraction-v3/tasks.md
@@ -33,18 +33,18 @@ Every child PR body must include this diagram with the current PR marked `📍`,
 
 Publishes: `@flash-global66/g-utils`. Est. ~150 changed lines. Requirements: `g-utils-extended` → `component-size-validation`, `promise-type-guard`, `mutable-identity-cast`, `new-utils-unit-tested`.
 
-- [ ] T1.1 Write failing unit test for `componentSizes` (equals `['', 'default', 'small', 'large']`) — extend `common/g-utils/tests/utils/validators.util.spec.ts` or a new `tests/types/component.type.spec.ts`.
-- [ ] T1.2 Implement `componentSizes` constant next to `ComponentSize` in `common/g-utils/src/types/component.type.ts` (runtime array keeps `''` for EP validator parity; do NOT change the `ComponentSize` type union). Run `yarn test:run` → green.
-- [ ] T1.3 Write failing unit tests for `isValidComponentSize` (`true` for `''`/`'default'`/`'small'`/`'large'`, `false` for `'medium'`/`'xl'`) in `common/g-utils/tests/utils/validators.util.spec.ts`.
-- [ ] T1.4 Implement `isValidComponentSize` in `common/g-utils/src/utils/validators.util.ts` using `componentSizes.includes(val)`. Run `yarn test:run` → green.
-- [ ] T1.5 Write failing unit tests for `isPromise` (`true` for a real `Promise` and a `{then, catch}` thenable; `false` for `{}`, `null`, functions) in `common/g-utils/tests/utils/validators.util.spec.ts`.
-- [ ] T1.6 Implement `isPromise` in `common/g-utils/src/utils/validators.util.ts` (reuses existing `isObject` + `isFunction` guards — do not reimplement those). Run `yarn test:run` → green.
-- [ ] T1.7 Write failing unit test for `mutable`/`Mutable` (runtime identity — returns the same reference; type-level test that `readonly` is stripped) — new `common/g-utils/tests/types/utils.type.spec.ts`.
-- [ ] T1.8 Implement `Mutable<T>` type + `mutable()` identity cast in `common/g-utils/src/types/utils.type.ts`. Run `yarn test:run` → green.
-- [ ] T1.9 Update `common/g-utils/src/index.ts` barrel to export the 4 new symbols.
-- [ ] T1.10 Confirm zero regressions: full `yarn test:run` (129 + new tests), `yarn lint --max-warnings 0` on `common/g-utils/**`.
-- [ ] T1.11 **Do NOT touch** already-shipped helpers (`isBoolean`/`isObject`/`isString`/`buildProps`/`definePropType`/`debugWarn`/`withInstall`/`SFCWithInstall`) — verify via `git diff --stat` that only the 4 new-symbol files changed.
-- [ ] T1.12 Commit as one work unit (`feat(g-utils): add componentSizes, isValidComponentSize, isPromise, mutable`), open PR #1 (stacked-to-main, target `main`), Lerna-publish `g-utils` on merge.
+- [x] T1.1 Write failing unit test for `componentSizes` (equals `['', 'default', 'small', 'large']`) — extend `common/g-utils/tests/utils/validators.util.spec.ts` or a new `tests/types/component.type.spec.ts`.
+- [x] T1.2 Implement `componentSizes` constant next to `ComponentSize` in `common/g-utils/src/types/component.type.ts` (runtime array keeps `''` for EP validator parity; do NOT change the `ComponentSize` type union). Run `yarn test:run` → green.
+- [x] T1.3 Write failing unit tests for `isValidComponentSize` (`true` for `''`/`'default'`/`'small'`/`'large'`, `false` for `'medium'`/`'xl'`) in `common/g-utils/tests/utils/validators.util.spec.ts`.
+- [x] T1.4 Implement `isValidComponentSize` in `common/g-utils/src/utils/validators.util.ts` using `componentSizes.includes(val)`. Run `yarn test:run` → green.
+- [x] T1.5 Write failing unit tests for `isPromise` (`true` for a real `Promise` and a `{then, catch}` thenable; `false` for `{}`, `null`, functions) in `common/g-utils/tests/utils/validators.util.spec.ts`.
+- [x] T1.6 Implement `isPromise` in `common/g-utils/src/utils/validators.util.ts` (reuses existing `isObject` + `isFunction` guards — do not reimplement those). Run `yarn test:run` → green.
+- [x] T1.7 Write failing unit test for `mutable`/`Mutable` (runtime identity — returns the same reference; type-level test that `readonly` is stripped) — new `common/g-utils/tests/types/utils.type.spec.ts`.
+- [x] T1.8 Implement `Mutable<T>` type + `mutable()` identity cast in `common/g-utils/src/types/utils.type.ts`. Run `yarn test:run` → green.
+- [x] T1.9 Update `common/g-utils/src/index.ts` barrel to export the 4 new symbols. (Already covered by existing `export *` wildcards from `types/component.type`, `types/utils.type`, `utils/validators.util`; locked in with an `imports.spec.ts` regression assertion.)
+- [x] T1.10 Confirm zero regressions: full `yarn test:run` (129 + new tests), `yarn lint --max-warnings 0` on `common/g-utils/**`. (158/158 green; touched files lint-clean.)
+- [x] T1.11 **Do NOT touch** already-shipped helpers (`isBoolean`/`isObject`/`isString`/`buildProps`/`definePropType`/`debugWarn`/`withInstall`/`SFCWithInstall`) — verify via `git diff --stat` that only the 4 new-symbol files changed. (Confirmed: only additions, zero deletions, no shipped helper touched.)
+- [x] T1.12 Commit as one work unit (`feat(g-utils): add componentSizes, isValidComponentSize, isPromise, mutable`), open PR #1 (stacked-to-main, target `main`), Lerna-publish `g-utils` on merge. (Committed as `d3cb617` on `feat/ds-ep-extraction-v3-wu1`. PR opening / Lerna publish left to the user per task scope — not pushed.)
 
 ## WU-2 — `g-hooks` shared form-control composables + `g-form: useFormSize` (depends on WU-1; parallelizable with WU-4)
 

--- a/openspec/config.yaml
+++ b/openspec/config.yaml
@@ -1,45 +1,56 @@
 ## SDD Config — global-design-system
 ## Generated: 2026-06-20
+## Refreshed: 2026-07-08 (testing capabilities corrected — Vitest is live, not pending)
 
 project: global-design-system
 artifact_store: hybrid
 
 context:
   stack: Vue 3.5 / TypeScript 5.9 / Vite 5 / Storybook 8.6
-  monorepo: Lerna 8 (independent, conventionalCommits) / Yarn 4
+  monorepo: Lerna 8 (independent, conventionalCommits) / Yarn 4.11.0 (Berry)
   workspaces: [components/*, common/*, config/*]
-  component_count: 59
+  component_count: 58
   base_library: element-plus 2.9.7
   styling: Sass + Tailwind 3.4
   ci: GitHub Actions → publish to GitHub Packages + Storybook on gh-pages
-  component_pattern: "src/{name}.vue + {name}.ts + {name}.type.ts + {name}.styles.scss + use-{name}.ts"
+  component_pattern: 'src/{name}.vue + {name}.ts + {name}.type.ts + {name}.styles.scss + use-{name}.ts'
+  source_only_packages: "common/g-utils and common/g-hooks are buildable:false — consumed as .ts source, compiled by the consumer's bundler"
+  node_version: '20.19.3 (see .nvmrc)'
+  env_note: 'yarn/npx commands require GBP_PACKAGE_TOKEN set (dummy value works locally) and node 20.19.3 on PATH (nvm use)'
 
 testing:
-  strict_tdd: false
-  reason: "No test runner configured. Vitest setup is a pending task."
-  test_command: null
-  unit: false
+  strict_tdd: true
+  reason: 'Vitest v2.1.9 fully configured and green: 129 unit tests across 18 files, verified by direct execution on 2026-07-08.'
+  test_command: 'yarn test:run'
+  test_command_alias: 'yarn test (both resolve to `vitest run`)'
+  test_policy: 'UNIT-ONLY. No integration, no DOM/component tests (2 DOM tests were deleted). New tests must be pure logic (utils/composables/props/use* hooks).'
+  config_file: 'vitest.config.ts (jsdom environment, setupFiles ./tests/setup.ts)'
+  include_globs:
+    ['components/**/tests/**/*.spec.ts', 'common/**/tests/**/*.spec.ts']
+  unit: true
   integration: false
   e2e: false
   coverage: false
+  push_gate: 'simple-git-hooks pre-push runs `yarn test:run` (full vitest suite) — NEW as of this refresh'
+  pre_commit_gate: 'simple-git-hooks pre-commit runs `npx lint-staged` (eslint --fix + prettier on staged files)'
+  hooks_manager: 'simple-git-hooks (NOT Husky)'
   quality:
-    linter: "eslint (.eslintrc.cjs)"
-    type_checker: "vue-tsc (build:types)"
-    formatter: "prettier (via prettier-vue)"
+    linter: 'eslint . --ext .vue,.ts,.js --max-warnings 0 (any warning fails)'
+    type_checker: 'vue-tsc (build:types)'
+    formatter: 'prettier --write --cache .'
 
 phases:
   proposal:
-    description: "Intent, scope, approach, risks. No code yet."
+    description: 'Intent, scope, approach, risks. No code yet.'
   spec:
-    description: "Delta specs with requirements and scenarios. Based on proposal."
+    description: 'Delta specs with requirements and scenarios. Based on proposal.'
   design:
-    description: "Architecture decisions, component structure, data flow."
+    description: 'Architecture decisions, component structure, data flow.'
   tasks:
-    description: "Actionable ordered checklist. Based on spec + design."
+    description: 'Actionable ordered checklist. Based on spec + design.'
   apply:
-    description: "Implementation following task checklist. Work-unit commits."
-    note: "strict_tdd is false — no automated test assertions required until Vitest configured."
+    description: 'Implementation following task checklist. Work-unit commits. STRICT TDD MODE ACTIVE — write failing unit test first, then implementation. Test runner: yarn test:run.'
   verify:
-    description: "Validate implementation against spec and tasks."
+    description: 'Validate implementation against spec and tasks. Run yarn test:run and yarn lint as evidence.'
   archive:
-    description: "Close change, merge delta specs, persist archive report."
+    description: 'Close change, merge delta specs, persist archive report.'


### PR DESCRIPTION
## ep-extraction-v3 · PR #1 de 5 (WU-1) — utils base en `g-utils`

Primer PR de la cadena **stacked-to-main** de `ep-extraction-v3` (migrar 5 form-controls de element-plus a código propio). Este WU es **plomería pura**: agrega utilidades nuevas a `@flash-global66/g-utils` que todavía **nadie consume** → es aditivo y no cambia el comportamiento de ningún componente.

### Qué agrega (test-first, paridad exacta con element-plus)

| Símbolo | Detalle |
|---|---|
| `componentSizes` | Array runtime `['', 'default', 'small', 'large']` — mantiene `''` para paridad con el validador de EP; el tipo `ComponentSize` queda `'large' \| 'default' \| 'small'` |
| `isValidComponentSize(val)` | Type-guard `val is ComponentSize \| ''` (paridad con `validator.d.ts` de EP) |
| `isPromise(val)` | Copia de `@vue/shared`: `(isObject(val) \|\| isFunction(val)) && isFunction(val.then) && isFunction(val.catch)` — acepta thenables invocables |
| `Mutable<T>` / `mutable()` | Identity-cast que quita `readonly`, copiado de EP |

### Verificación

- `yarn test:run` → **160/160 verdes** (Vitest, unit-only)
- `yarn lint` → limpio (`--max-warnings 0`)
- Símbolos re-exportados por el barrel + smoke test en `imports.spec.ts`
- Revisión fresca pre-PR: detectó y corrigió un bug de paridad en `isPromise` y la pérdida del type-guard en `isValidComponentSize` (ambos verificados contra el source real de `@vue/shared` / `element-plus`)

### Nota de proceso (para los próximos PRs de la cadena)

Los WU de **plomería** (WU-1 acá, WU-2 g-hooks/g-form, WU-4 sub-familia input) se validan con tests unit + que el build de b2b no se rompa. Los WU que **editan componentes** (WU-3: checkbox/radio/switch/segmented; WU-5: input) tienen un gate adicional: **antes de dar por buenos, se levanta b2b (`yarn serve:ci`), se prueban los componentes migrados en el navegador, y la confirmación de "funciona" la da el equipo** — no se publica hasta esa confirmación.

### Baseline de tests

El baseline de esta rama es 139 tests (no 129): los 2 tests DOM eliminados y el hook pre-push viven en otra rama aún sin mergear. No es regresión.

---

Planificación SDD completa (proposal, spec, design, tasks) incluida en `openspec/changes/ep-extraction-v3/`.
