### PR TITLE
fix(build): unblock Publish Packages — fix latent build:types errors (checkbox setTimeout + g-form test)

### DIFF
--- a/components/checkbox/src/composables/use-checkbox-status.ts
+++ b/components/checkbox/src/composables/use-checkbox-status.ts
@@ -1,80 +1,91 @@
-import { computed, isRef, ref, toRaw, watch, onBeforeUnmount } from 'vue'
-import { isEqual } from 'lodash-unified'
-import { isArray, isBoolean, isObject, isPropAbsent } from 'element-plus/es/utils/index.mjs'
+import { computed, isRef, ref, toRaw, watch, onBeforeUnmount } from 'vue';
+import { isEqual } from 'lodash-unified';
+import {
+  isArray,
+  isBoolean,
+  isObject,
+  isPropAbsent,
+} from 'element-plus/es/utils/index.mjs';
 
-import type { ComponentInternalInstance } from 'vue'
-import type { CheckboxProps } from '../checkbox'
-import type { CheckboxModel } from './index'
+import type { ComponentInternalInstance } from 'vue';
+import type { CheckboxProps } from '../checkbox';
+import type { CheckboxModel } from './index';
 
 export const useCheckboxStatus = (
   props: CheckboxProps,
   slots: ComponentInternalInstance['slots'],
-  { model }: Pick<CheckboxModel, 'model'>
+  { model }: Pick<CheckboxModel, 'model'>,
 ) => {
-  const isFocused = ref(false)
-  const currentRipple = ref('')
-  let rippleTimeoutId: number | null = null
+  const isFocused = ref(false);
+  const currentRipple = ref('');
+  let rippleTimeoutId: ReturnType<typeof setTimeout> | null = null;
 
   const actualValue = computed(() => {
     // In version 2.x, if there's no props.value, props.label will act as props.value
     // In version 3.x, remove this computed value, use props.value instead.
     if (!isPropAbsent(props.value)) {
-      return props.value
+      return props.value;
     }
-    return props.label
-  })
+    return props.label;
+  });
 
   // Función helper para manejar lógica de arrays
-  const checkArrayContainsValue = (array: unknown[], targetValue: unknown): boolean => {
-    const rawArray = array.map(toRaw)
-    const rawTarget = isRef(targetValue) ? toRaw(targetValue.value) : targetValue
+  const checkArrayContainsValue = (
+    array: unknown[],
+    targetValue: unknown,
+  ): boolean => {
+    const rawArray = array.map(toRaw);
+    const rawTarget = isRef(targetValue)
+      ? toRaw(targetValue.value)
+      : targetValue;
 
     return isObject(rawTarget)
-      ? rawArray.some((item) => isEqual(item, toRaw(rawTarget)))
-      : rawArray.includes(rawTarget)
-  }
+      ? rawArray.some(item => isEqual(item, toRaw(rawTarget)))
+      : rawArray.includes(rawTarget);
+  };
 
   const hasOwnLabel = computed<boolean>(() => {
-    return !!slots.default || !isPropAbsent(actualValue.value)
-  })
+    return !!slots.default || !isPropAbsent(actualValue.value);
+  });
 
   const isChecked = computed<boolean>(() => {
-    const value = model.value
+    const value = model.value;
 
-    if (isBoolean(value)) return value
-    if (isArray(value)) return checkArrayContainsValue(value, actualValue.value)
-    if (value != null) return value === props.trueValue
+    if (isBoolean(value)) return value;
+    if (isArray(value))
+      return checkArrayContainsValue(value, actualValue.value);
+    if (value != null) return value === props.trueValue;
 
-    return Boolean(value)
-  })
+    return Boolean(value);
+  });
 
-  watch(isChecked, (newValue) => {
+  watch(isChecked, newValue => {
     if (rippleTimeoutId !== null) {
-      clearTimeout(rippleTimeoutId)
+      clearTimeout(rippleTimeoutId);
     }
 
-    currentRipple.value = newValue ? 'expand' : 'contract'
+    currentRipple.value = newValue ? 'expand' : 'contract';
 
     rippleTimeoutId = setTimeout(() => {
-      currentRipple.value = ''
-      rippleTimeoutId = null
-    }, 500)
-  })
+      currentRipple.value = '';
+      rippleTimeoutId = null;
+    }, 500);
+  });
 
   onBeforeUnmount(() => {
     if (rippleTimeoutId !== null) {
-      clearTimeout(rippleTimeoutId)
-      rippleTimeoutId = null
+      clearTimeout(rippleTimeoutId);
+      rippleTimeoutId = null;
     }
-  })
+  });
 
   return {
     actualValue,
     hasOwnLabel,
     isChecked,
     isFocused,
-    currentRipple
-  }
-}
+    currentRipple,
+  };
+};
 
-export type CheckboxStatus = ReturnType<typeof useCheckboxStatus>
+export type CheckboxStatus = ReturnType<typeof useCheckboxStatus>;

--- a/components/form/tests/hooks/use-form-common-props.spec.ts
+++ b/components/form/tests/hooks/use-form-common-props.spec.ts
@@ -13,7 +13,11 @@ import { formContextKey } from '../../src/constants';
  * (Vue's `provide`/`inject` only crosses component boundaries).
  */
 const mountUseFormSize = (options: {
-  sizeProp?: ComponentSize;
+  // '' is a valid runtime componentSizes member (EP validator parity, see
+  // g-utils's componentSizes fidelity note) even though it is not part of
+  // the ComponentSize type union — widened here so the "empty string prop"
+  // regression test below type-checks.
+  sizeProp?: ComponentSize | '';
   globalSize?: ComponentSize;
   fallback?: ComponentSize;
   ignore?: Partial<Record<'prop' | 'global', boolean>>;


### PR DESCRIPTION
## Hotfix: desbloquear el workflow "Publish Packages" (roto en `Build all components`)

El publish en main viene **fallando en el build** desde el merge de #244 (run [29044223714](https://github.com/Flash-Global66/global-design-system/actions/runs/29044223714)). Como el build corre **antes** del publish, ningún paquete se está publicando (incluidos g-hooks/g-form nuevos de #244).

### Causa

Dos errores de **`build:types` (vue-tsc)** latentes en main, destapados cuando el bump de dependencias de #244 forzó el rebuild de los paquetes dependientes:

1. **`components/checkbox/src/composables/use-checkbox-status.ts`** — `let rippleTimeoutId: number | null` no acepta el retorno de `setTimeout` (con los tipos de `node` es `NodeJS.Timeout`). Fix: tipo cross-env `ReturnType<typeof setTimeout> | null`.
2. **`components/form/tests/hooks/use-form-common-props.spec.ts`** — un caso de test asigna `''` a `ComponentSize | undefined` (que no incluye `''`). El `build:types` compila los tests. Fix: ampliar el tipo del helper del test para aceptar `''`.

Ambos son **preexistentes** en main (no los introdujo este PR ni la migración en curso).

### Verificación

- `yarn build` completo local → **✅ OK, los 40+ componentes buildean** (exit 0).
- `yarn test:run` → verde (pre-push hook).

### Nota

Estos errores solo se ven **al pushear a main** porque los workflows corren `on: push`, no en `pull_request`. Vale agregar un check de build/typecheck en PRs para atajarlo antes (flagueado aparte).
