### PR TITLE
ci: add PR checks (lint + unit tests + build) to catch errors before merge

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -1,0 +1,63 @@
+name: PR Checks
+
+# Runs lint + unit tests + full component build on every PR to main.
+# Rationale: the Publish Packages / deploy workflows only trigger `on: push`
+# to main/develop, so build/type errors (e.g. a `build:types` failure) used to
+# reach main undetected and break publishing. This gate catches them in the PR.
+on:
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: pr-checks-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+      packages: read
+    env:
+      GBP_PACKAGE_TOKEN: ${{ secrets.GBP_PACKAGE_TOKEN }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20.x
+
+      - name: Enable Corepack and Install Yarn 4.7.0
+        run: |
+          corepack enable
+          corepack prepare yarn@4.7.0 --activate
+
+      - name: Verify environment variables
+        run: |
+          if [ -z "$GBP_PACKAGE_TOKEN" ]; then
+            echo "::error::GBP_PACKAGE_TOKEN no está configurado"
+            exit 1
+          fi
+          echo "✅ Variables de entorno configuradas correctamente"
+
+      - name: Install dependencies
+        run: yarn install
+
+      - name: Lint (eslint --max-warnings 0)
+        run: yarn lint
+
+      - name: Unit tests (Vitest)
+        run: yarn test:run
+
+      # Full build so `build:types` (vue-tsc) errors are caught in the PR, not
+      # after merge. This is heavier than lint/test (40+ components); if it ever
+      # becomes a bottleneck, scope it to affected packages
+      # (e.g. `lerna run build:types --since origin/main`) instead of the full
+      # `yarn build`. Kept full for now because latent type errors surface when
+      # dependency bumps force dependents to rebuild — a scoped run can miss them.
+      - name: Build all components
+        run: yarn build


### PR DESCRIPTION
## Qué

Nuevo workflow `.github/workflows/pr-checks.yml` que corre en **`pull_request` a main**: `yarn lint` + `yarn test:run` + `yarn build` (build completo).

## Por qué

Los workflows de Publish/deploy solo corren `on: push` a main/develop. Por eso errores de build/tipos llegaban a main sin ser detectados y **rompían el publish** (caso real: el error de `build:types` en `checkbox/use-checkbox-status.ts` — setTimeout `Timeout` vs `number` — entró por #244 y frenó la publicación en 'Build all components'). Este gate los atrapa en el PR.

## Detalle

- Mismo setup que el publish (node 20, corepack yarn@4.7.0, `GBP_PACKAGE_TOKEN`).
- Build **completo** a propósito: los errores latentes de `build:types` aparecen cuando un bump de dependencia fuerza el rebuild de dependientes; un build scopeado podría no verlos. Si se vuelve lento, se puede scopear a `--since origin/main` (comentado en el workflow).
- Este mismo PR ejercita el workflow por primera vez — si el import stale de `components/radio-group` (`../radio/radio.type`, otro latente que flagueó la review) es real, el build de este PR lo destapará.

🤖 Generated with [Claude Code](https://claude.com/claude-code)