### PR TITLE
fix(components): declare g-utils/g-hooks deps in migrated form-controls

### DIFF
--- a/components/checkbox/package.json
+++ b/components/checkbox/package.json
@@ -29,11 +29,15 @@
     "url": "https://github.com/Flash-Global66/global-design-system.git"
   },
   "peerDependencies": {
-    "@flash-global66/g-form": "^0.1.0",
+    "@flash-global66/g-form": "^0.2.0",
     "@vueuse/core": "^12.4.0",
     "element-plus": "^2.9.0",
     "lodash-unified": "^1.0.3",
     "vue": "^3.2.0"
   },
-  "gitHead": "581df2757ad066a5cdd5a2e64500ab33a68279ad"
+  "gitHead": "581df2757ad066a5cdd5a2e64500ab33a68279ad",
+  "dependencies": {
+    "@flash-global66/g-utils": "^0.4.0",
+    "@flash-global66/g-hooks": "^0.4.1"
+  }
 }

--- a/components/input/package.json
+++ b/components/input/package.json
@@ -29,12 +29,16 @@
     "url": "https://github.com/Flash-Global66/global-design-system.git"
   },
   "peerDependencies": {
-    "@flash-global66/g-form": "^0.1.0",
+    "@flash-global66/g-form": "^0.2.0",
     "@flash-global66/g-icon-font": "^0.0.8",
     "@vueuse/core": "^12.4.0",
     "element-plus": "^2.9.0",
     "lodash-unified": "^1.0.3",
     "vue": "^3.2.0"
   },
-  "gitHead": "581df2757ad066a5cdd5a2e64500ab33a68279ad"
+  "gitHead": "581df2757ad066a5cdd5a2e64500ab33a68279ad",
+  "dependencies": {
+    "@flash-global66/g-utils": "^0.4.0",
+    "@flash-global66/g-hooks": "^0.4.1"
+  }
 }

--- a/components/radio/package.json
+++ b/components/radio/package.json
@@ -29,10 +29,14 @@
     "url": "https://github.com/Flash-Global66/global-design-system.git"
   },
   "peerDependencies": {
-    "@flash-global66/g-form": "^0.1.0",
+    "@flash-global66/g-form": "^0.2.0",
     "@vueuse/core": "^12.4.0",
     "element-plus": "^2.9.0",
     "vue": "^3.2.0"
   },
-  "gitHead": "581df2757ad066a5cdd5a2e64500ab33a68279ad"
+  "gitHead": "581df2757ad066a5cdd5a2e64500ab33a68279ad",
+  "dependencies": {
+    "@flash-global66/g-utils": "^0.4.0",
+    "@flash-global66/g-hooks": "^0.4.1"
+  }
 }

--- a/components/segmented/package.json
+++ b/components/segmented/package.json
@@ -29,9 +29,13 @@
     "url": "https://github.com/Flash-Global66/global-design-system.git"
   },
   "peerDependencies": {
-    "@flash-global66/g-form": "^0.1.0",
+    "@flash-global66/g-form": "^0.2.0",
     "element-plus": "^2.9.0",
     "vue": "^3.2.0"
   },
-  "gitHead": "581df2757ad066a5cdd5a2e64500ab33a68279ad"
+  "gitHead": "581df2757ad066a5cdd5a2e64500ab33a68279ad",
+  "dependencies": {
+    "@flash-global66/g-utils": "^0.4.0",
+    "@flash-global66/g-hooks": "^0.4.1"
+  }
 }

--- a/components/switch/package.json
+++ b/components/switch/package.json
@@ -23,7 +23,7 @@
     "build:types": "vue-tsc --project tsconfig.json"
   },
   "peerDependencies": {
-    "@flash-global66/g-form": "^0.1.1",
+    "@flash-global66/g-form": "^0.2.0",
     "@flash-global66/g-icon-font": "^0.10.0",
     "element-plus": "^2.9.0",
     "vue": "^3.2.0"
@@ -34,5 +34,9 @@
   "repository": {
     "url": "https://github.com/Flash-Global66/global-design-system.git"
   },
-  "gitHead": "581df2757ad066a5cdd5a2e64500ab33a68279ad"
+  "gitHead": "581df2757ad066a5cdd5a2e64500ab33a68279ad",
+  "dependencies": {
+    "@flash-global66/g-utils": "^0.4.0",
+    "@flash-global66/g-hooks": "^0.4.1"
+  }
 }


### PR DESCRIPTION
## fix: los 5 form-controls migrados declaran g-utils/g-hooks

### Problema

Los componentes migrados en ep-extraction-v3 (checkbox, radio, switch, segmented, input) **importan** de `@flash-global66/g-utils` y `@flash-global66/g-hooks`, pero su `package.json` **no los declaraba** — solo listaba `g-form` (además en rango viejo `^0.1.0`).

Al instalarlos en un consumidor (front-b2b), como no declaran esas deps, el package manager no sabe que necesitan `g-utils@^0.4.0` / `g-hooks@^0.4.1`, y resuelve las versiones viejas hoisteadas (`g-utils@0.3.0` / `g-hooks@0.2.0`) que arrastran otros paquetes. Esas versiones **no tienen** los composables de v3 (`useAriaProps`, `useComposition`, `useCursor`, `useFocusController`, etc.), así que el build/runtime del consumidor falla con `useComposition is not exported from @flash-global66/g-hooks`.

### Fix

En los 5 componentes:
- Agregar a `dependencies`: `@flash-global66/g-utils: ^0.4.0` y `@flash-global66/g-hooks: ^0.4.1` (siguiendo la convención de g-button, que declara `g-utils` en `dependencies`).
- Subir el rango peer de `@flash-global66/g-form`: `^0.1.0` → `^0.2.0` (el actual es 0.2.2).

Cambio solo de `package.json` (sin tocar código). Al mergear+publicar, lerna bumpea los 5 (patch).

### Después de publicar

En front-b2b (`ander/update/version-packages`): actualizar los `@flash-global66/g-*` a las versiones nuevas (exactas, sin `^`); con las deps ya declaradas, `g-utils@0.4.0` / `g-hooks@0.4.1` se resuelven correctos y dedupean a una sola versión.
