### PR TITLE
feat(focus-trap): migrate off element-plus internals [ep-extraction-v4 WU-1]

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -52,7 +52,6 @@ module.exports = {
         'components/popper/**',
         'components/pagination/**',
         'components/input-number/**',
-        'components/focus-trap/**',
         'components/dropdown/**',
         'components/dialog/**',
         'components/date-picker/**',

--- a/common/g-hooks/src/composables/useEscapeKeydown.ts
+++ b/common/g-hooks/src/composables/useEscapeKeydown.ts
@@ -1,0 +1,48 @@
+import { onBeforeUnmount, onMounted } from 'vue';
+import { isClient, EVENT_CODE } from '@flash-global66/g-utils';
+
+/**
+ * Ported byte-exact from element-plus 2.9.7's `useEscapeKeydown`
+ * (`es/hooks/use-escape-keydown/index.mjs`).
+ *
+ * Handlers registered by every currently-mounted consumer share a single
+ * module-level `document` `keydown` listener: the listener is attached once
+ * (when the first handler registers) and detached once the last handler
+ * unregisters. Every registered handler is invoked on each `Escape`
+ * keydown, regardless of which component instance is currently mounted.
+ */
+let registeredEscapeHandlers: ((event: KeyboardEvent) => void)[] = [];
+
+const cachedHandler = (event: KeyboardEvent): void => {
+  if (event.code === EVENT_CODE.esc) {
+    registeredEscapeHandlers.forEach(registeredHandler =>
+      registeredHandler(event),
+    );
+  }
+};
+
+/**
+ * Registers `handler` to run on every `Escape` keydown while the calling
+ * component is mounted. Cleans up automatically on unmount.
+ *
+ * @param handler - Invoked with the `KeyboardEvent` on `Escape` keydown.
+ */
+export const useEscapeKeydown = (
+  handler: (event: KeyboardEvent) => void,
+): void => {
+  onMounted(() => {
+    if (registeredEscapeHandlers.length === 0) {
+      document.addEventListener('keydown', cachedHandler);
+    }
+    if (isClient) registeredEscapeHandlers.push(handler);
+  });
+
+  onBeforeUnmount(() => {
+    registeredEscapeHandlers = registeredEscapeHandlers.filter(
+      registeredHandler => registeredHandler !== handler,
+    );
+    if (registeredEscapeHandlers.length === 0) {
+      if (isClient) document.removeEventListener('keydown', cachedHandler);
+    }
+  });
+};

--- a/common/g-hooks/src/index.ts
+++ b/common/g-hooks/src/index.ts
@@ -15,3 +15,4 @@ export * from './composables/useComposition';
 export * from './composables/useCursor';
 export * from './composables/useFocusController';
 export * from './composables/useAttrs';
+export * from './composables/useEscapeKeydown';

--- a/common/g-hooks/tests/composables/useEscapeKeydown.spec.ts
+++ b/common/g-hooks/tests/composables/useEscapeKeydown.spec.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, vi } from 'vitest';
+import { createApp, defineComponent } from 'vue';
+import { useEscapeKeydown } from '../../src/composables/useEscapeKeydown';
+
+/**
+ * Mounts a component that registers `handler` via `useEscapeKeydown` on
+ * setup. Returns the `unmount` function so tests can assert cleanup.
+ */
+const mountWithEscapeKeydown = (handler: (event: KeyboardEvent) => void) => {
+  const Component = defineComponent({
+    setup() {
+      useEscapeKeydown(handler);
+      return () => null;
+    },
+  });
+  const app = createApp(Component);
+  app.mount(document.createElement('div'));
+  return () => app.unmount();
+};
+
+const dispatchKeydown = (code: string) => {
+  document.dispatchEvent(new KeyboardEvent('keydown', { code }));
+};
+
+describe('useEscapeKeydown', () => {
+  it('invokes the handler when the Escape key is pressed', () => {
+    const handler = vi.fn();
+    mountWithEscapeKeydown(handler);
+
+    dispatchKeydown('Escape');
+
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  it('is a no-op for keys other than Escape', () => {
+    const handler = vi.fn();
+    mountWithEscapeKeydown(handler);
+
+    dispatchKeydown('Enter');
+    dispatchKeydown('Tab');
+
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it('stops invoking the handler after the component unmounts (listener cleanup)', () => {
+    const handler = vi.fn();
+    const unmount = mountWithEscapeKeydown(handler);
+
+    unmount();
+    dispatchKeydown('Escape');
+
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it('invokes every currently-mounted handler on the same Escape keydown', () => {
+    const handlerA = vi.fn();
+    const handlerB = vi.fn();
+    mountWithEscapeKeydown(handlerA);
+    mountWithEscapeKeydown(handlerB);
+
+    dispatchKeydown('Escape');
+
+    expect(handlerA).toHaveBeenCalledTimes(1);
+    expect(handlerB).toHaveBeenCalledTimes(1);
+  });
+});

--- a/common/g-hooks/tests/composables/useEscapeKeydown.spec.ts
+++ b/common/g-hooks/tests/composables/useEscapeKeydown.spec.ts
@@ -63,4 +63,17 @@ describe('useEscapeKeydown', () => {
     expect(handlerA).toHaveBeenCalledTimes(1);
     expect(handlerB).toHaveBeenCalledTimes(1);
   });
+
+  it('keeps invoking remaining handlers when only one of several unmounts (partial teardown of the shared listener)', () => {
+    const handlerA = vi.fn();
+    const handlerB = vi.fn();
+    const unmountA = mountWithEscapeKeydown(handlerA);
+    mountWithEscapeKeydown(handlerB);
+
+    unmountA();
+    dispatchKeydown('Escape');
+
+    expect(handlerA).not.toHaveBeenCalled();
+    expect(handlerB).toHaveBeenCalledTimes(1);
+  });
 });

--- a/common/g-utils/src/utils/dom.util.ts
+++ b/common/g-utils/src/utils/dom.util.ts
@@ -70,3 +70,52 @@ export const rAF = (fn: FrameRequestCallback): number =>
   isClient
     ? window.requestAnimationFrame(fn)
     : (setTimeout(fn, 16) as unknown as number);
+
+/**
+ * Checks whether an element can receive focus (via tab order or
+ * programmatically).
+ *
+ * Byte-exact copy of element-plus's `isFocusable` algorithm
+ * (`es/utils/dom/aria.mjs`, 2.9.7).
+ *
+ * @param element - The element to check.
+ * @returns `true` if the element is focusable.
+ */
+export const isFocusable = (element: HTMLElement): boolean => {
+  if (
+    element.tabIndex > 0 ||
+    (element.tabIndex === 0 && element.getAttribute('tabIndex') !== null)
+  ) {
+    return true;
+  }
+  if (
+    element.tabIndex < 0 ||
+    element.hasAttribute('disabled') ||
+    element.getAttribute('aria-disabled') === 'true'
+  ) {
+    return false;
+  }
+
+  switch (element.nodeName) {
+    case 'A': {
+      return (
+        !!(element as HTMLAnchorElement).href &&
+        (element as HTMLAnchorElement).rel !== 'ignore'
+      );
+    }
+    case 'INPUT': {
+      return !(
+        (element as HTMLInputElement).type === 'hidden' ||
+        (element as HTMLInputElement).type === 'file'
+      );
+    }
+    case 'BUTTON':
+    case 'SELECT':
+    case 'TEXTAREA': {
+      return true;
+    }
+    default: {
+      return false;
+    }
+  }
+};

--- a/common/g-utils/tests/utils/dom.util.spec.ts
+++ b/common/g-utils/tests/utils/dom.util.spec.ts
@@ -6,6 +6,7 @@ import {
   removeClass,
   hasClass,
   rAF,
+  isFocusable,
 } from '../../src/utils/dom.util';
 
 describe('isClient', () => {
@@ -69,5 +70,70 @@ describe('rAF', () => {
     await new Promise<void>(resolve => {
       rAF(() => resolve());
     });
+  });
+});
+
+describe('isFocusable', () => {
+  it('returns true for a link with an href', () => {
+    const link = document.createElement('a');
+    link.setAttribute('href', '/foo');
+    expect(isFocusable(link)).toBe(true);
+  });
+
+  it('returns false for a link without an href', () => {
+    const link = document.createElement('a');
+    expect(isFocusable(link)).toBe(false);
+  });
+
+  it('returns true for an enabled button', () => {
+    expect(isFocusable(document.createElement('button'))).toBe(true);
+  });
+
+  it('returns false for a disabled button', () => {
+    const button = document.createElement('button');
+    button.setAttribute('disabled', '');
+    expect(isFocusable(button)).toBe(false);
+  });
+
+  it('returns true for a text input', () => {
+    const input = document.createElement('input');
+    input.type = 'text';
+    expect(isFocusable(input)).toBe(true);
+  });
+
+  it('returns false for a hidden input', () => {
+    const input = document.createElement('input');
+    input.type = 'hidden';
+    expect(isFocusable(input)).toBe(false);
+  });
+
+  it('returns true for a select element', () => {
+    expect(isFocusable(document.createElement('select'))).toBe(true);
+  });
+
+  it('returns true for a textarea element', () => {
+    expect(isFocusable(document.createElement('textarea'))).toBe(true);
+  });
+
+  it('returns true for a plain div with tabindex="0"', () => {
+    const div = document.createElement('div');
+    div.setAttribute('tabindex', '0');
+    expect(isFocusable(div)).toBe(true);
+  });
+
+  it('returns false for a plain div with no tabindex (defaults to -1)', () => {
+    expect(isFocusable(document.createElement('div'))).toBe(false);
+  });
+
+  it('returns false for an element explicitly set to tabindex="-1"', () => {
+    const div = document.createElement('div');
+    div.setAttribute('tabindex', '-1');
+    expect(isFocusable(div)).toBe(false);
+  });
+
+  it('returns false for an element with aria-disabled="true"', () => {
+    const button = document.createElement('button');
+    button.setAttribute('aria-disabled', 'true');
+    expect(isFocusable(button)).toBe(false);
   });
 });

--- a/common/g-utils/tests/utils/dom.util.spec.ts
+++ b/common/g-utils/tests/utils/dom.util.spec.ts
@@ -107,6 +107,19 @@ describe('isFocusable', () => {
     expect(isFocusable(input)).toBe(false);
   });
 
+  it('returns false for a file input', () => {
+    const input = document.createElement('input');
+    input.type = 'file';
+    expect(isFocusable(input)).toBe(false);
+  });
+
+  it('returns false for a link with href but rel="ignore"', () => {
+    const link = document.createElement('a');
+    link.setAttribute('href', '/foo');
+    link.setAttribute('rel', 'ignore');
+    expect(isFocusable(link)).toBe(false);
+  });
+
   it('returns true for a select element', () => {
     expect(isFocusable(document.createElement('select'))).toBe(true);
   });

--- a/components/focus-trap/package.json
+++ b/components/focus-trap/package.json
@@ -26,12 +26,15 @@
     "registry": "https://npm.pkg.github.com"
   },
   "peerDependencies": {
-    "element-plus": "^2.9.0",
     "lodash-unified": "^1.0.3",
     "vue": "^3.2.0"
   },
   "repository": {
     "url": "https://github.com/Flash-Global66/global-design-system.git"
   },
-  "gitHead": "581df2757ad066a5cdd5a2e64500ab33a68279ad"
+  "gitHead": "581df2757ad066a5cdd5a2e64500ab33a68279ad",
+  "dependencies": {
+    "@flash-global66/g-hooks": "^0.4.1",
+    "@flash-global66/g-utils": "^0.4.0"
+  }
 }

--- a/components/focus-trap/src/focus-trap.vue
+++ b/components/focus-trap/src/focus-trap.vue
@@ -10,11 +10,11 @@ import {
   provide,
   ref,
   unref,
-  watch
-} from 'vue'
-import { isNil } from 'lodash-unified'
-import { EVENT_CODE, useEscapeKeydown } from 'element-plus'
-import { isString } from 'element-plus/es/utils/index'
+  watch,
+} from 'vue';
+import { isNil } from 'lodash-unified';
+import { EVENT_CODE, isString } from '@flash-global66/g-utils';
+import { useEscapeKeydown } from '@flash-global66/g-hooks';
 import {
   createFocusOutPreventedEvent,
   focusFirstDescendant,
@@ -23,19 +23,19 @@ import {
   isFocusCausedByUserEvent,
   obtainAllFocusableElements,
   tryFocus,
-  useFocusReason
-} from './utils'
+  useFocusReason,
+} from './utils';
 import {
   FOCUS_AFTER_RELEASED,
   FOCUS_AFTER_TRAPPED,
   FOCUS_AFTER_TRAPPED_OPTS,
   FOCUS_TRAP_INJECTION_KEY,
   ON_RELEASE_FOCUS_EVT,
-  ON_TRAP_FOCUS_EVT
-} from './tokens'
+  ON_TRAP_FOCUS_EVT,
+} from './tokens';
 
-import type { PropType } from 'vue'
-import type { FocusLayer } from './utils'
+import type { PropType } from 'vue';
+import type { FocusLayer } from './utils';
 
 export default defineComponent({
   name: 'GFocusTrap',
@@ -46,8 +46,8 @@ export default defineComponent({
     focusTrapEl: Object as PropType<HTMLElement>,
     focusStartEl: {
       type: [Object, String] as PropType<'container' | 'first' | HTMLElement>,
-      default: 'first'
-    }
+      default: 'first',
+    },
   },
   emits: [
     ON_TRAP_FOCUS_EVT,
@@ -55,264 +55,281 @@ export default defineComponent({
     'focusin',
     'focusout',
     'focusout-prevented',
-    'release-requested'
+    'release-requested',
   ],
   setup(props, { emit }) {
-    const forwardRef = ref<HTMLElement | undefined>()
-    let lastFocusBeforeTrapped: HTMLElement | null
-    let lastFocusAfterTrapped: HTMLElement | null
+    const forwardRef = ref<HTMLElement | undefined>();
+    let lastFocusBeforeTrapped: HTMLElement | null;
+    let lastFocusAfterTrapped: HTMLElement | null;
 
-    const { focusReason } = useFocusReason()
+    const { focusReason } = useFocusReason();
 
-    useEscapeKeydown((event) => {
+    useEscapeKeydown(event => {
       if (props.trapped && !focusLayer.paused) {
-        emit('release-requested', event)
+        emit('release-requested', event);
       }
-    })
+    });
 
     const focusLayer: FocusLayer = {
       paused: false,
       pause() {
-        this.paused = true
+        this.paused = true;
       },
       resume() {
-        this.paused = false
-      }
-    }
+        this.paused = false;
+      },
+    };
 
     const onKeydown = (e: KeyboardEvent) => {
-      if (!props.loop && !props.trapped) return
-      if (focusLayer.paused) return
+      if (!props.loop && !props.trapped) return;
+      if (focusLayer.paused) return;
 
-      const { code, altKey, ctrlKey, metaKey, currentTarget, shiftKey } = e
-      const { loop } = props
-      const isTabbing = code === EVENT_CODE.tab && !altKey && !ctrlKey && !metaKey
+      const { code, altKey, ctrlKey, metaKey, currentTarget, shiftKey } = e;
+      const { loop } = props;
+      const isTabbing =
+        code === EVENT_CODE.tab && !altKey && !ctrlKey && !metaKey;
 
-      const currentFocusingEl = document.activeElement
+      const currentFocusingEl = document.activeElement;
       if (isTabbing && currentFocusingEl) {
-        const container = currentTarget as HTMLElement
-        const [first, last] = getEdges(container)
-        const isTabbable = first && last
+        const container = currentTarget as HTMLElement;
+        const [first, last] = getEdges(container);
+        const isTabbable = first && last;
         if (!isTabbable) {
           if (currentFocusingEl === container) {
             const focusoutPreventedEvent = createFocusOutPreventedEvent({
-              focusReason: focusReason.value
-            })
-            emit('focusout-prevented', focusoutPreventedEvent)
+              focusReason: focusReason.value,
+            });
+            emit('focusout-prevented', focusoutPreventedEvent);
             if (!focusoutPreventedEvent.defaultPrevented) {
-              e.preventDefault()
+              e.preventDefault();
             }
           }
         } else {
           if (!shiftKey && currentFocusingEl === last) {
             const focusoutPreventedEvent = createFocusOutPreventedEvent({
-              focusReason: focusReason.value
-            })
-            emit('focusout-prevented', focusoutPreventedEvent)
+              focusReason: focusReason.value,
+            });
+            emit('focusout-prevented', focusoutPreventedEvent);
             if (!focusoutPreventedEvent.defaultPrevented) {
-              e.preventDefault()
-              if (loop) tryFocus(first, true)
+              e.preventDefault();
+              if (loop) tryFocus(first, true);
             }
-          } else if (shiftKey && [first, container].includes(currentFocusingEl as HTMLElement)) {
+          } else if (
+            shiftKey &&
+            [first, container].includes(currentFocusingEl as HTMLElement)
+          ) {
             const focusoutPreventedEvent = createFocusOutPreventedEvent({
-              focusReason: focusReason.value
-            })
-            emit('focusout-prevented', focusoutPreventedEvent)
+              focusReason: focusReason.value,
+            });
+            emit('focusout-prevented', focusoutPreventedEvent);
             if (!focusoutPreventedEvent.defaultPrevented) {
-              e.preventDefault()
-              if (loop) tryFocus(last, true)
+              e.preventDefault();
+              if (loop) tryFocus(last, true);
             }
           }
         }
       }
-    }
+    };
 
     provide(FOCUS_TRAP_INJECTION_KEY, {
       focusTrapRef: forwardRef,
-      onKeydown
-    })
+      onKeydown,
+    });
 
     watch(
       () => props.focusTrapEl,
-      (focusTrapEl) => {
+      focusTrapEl => {
         if (focusTrapEl) {
-          forwardRef.value = focusTrapEl
+          forwardRef.value = focusTrapEl;
         }
       },
-      { immediate: true }
-    )
+      { immediate: true },
+    );
 
     watch([forwardRef], ([forwardRef], [oldForwardRef]) => {
       if (forwardRef) {
-        forwardRef.addEventListener('keydown', onKeydown)
-        forwardRef.addEventListener('focusin', onFocusIn)
-        forwardRef.addEventListener('focusout', onFocusOut)
+        forwardRef.addEventListener('keydown', onKeydown);
+        forwardRef.addEventListener('focusin', onFocusIn);
+        forwardRef.addEventListener('focusout', onFocusOut);
       }
       if (oldForwardRef) {
-        oldForwardRef.removeEventListener('keydown', onKeydown)
-        oldForwardRef.removeEventListener('focusin', onFocusIn)
-        oldForwardRef.removeEventListener('focusout', onFocusOut)
+        oldForwardRef.removeEventListener('keydown', onKeydown);
+        oldForwardRef.removeEventListener('focusin', onFocusIn);
+        oldForwardRef.removeEventListener('focusout', onFocusOut);
       }
-    })
+    });
 
     const trapOnFocus = (e: Event) => {
-      emit(ON_TRAP_FOCUS_EVT, e)
-    }
-    const releaseOnFocus = (e: Event) => emit(ON_RELEASE_FOCUS_EVT, e)
+      emit(ON_TRAP_FOCUS_EVT, e);
+    };
+    const releaseOnFocus = (e: Event) => emit(ON_RELEASE_FOCUS_EVT, e);
 
     const onFocusIn = (e: FocusEvent) => {
-      const trapContainer = unref(forwardRef)
-      if (!trapContainer) return
+      const trapContainer = unref(forwardRef);
+      if (!trapContainer) return;
 
-      const target = e.target as HTMLElement | null
-      const relatedTarget = e.relatedTarget as HTMLElement | null
-      const isFocusedInTrap = target && trapContainer.contains(target)
+      const target = e.target as HTMLElement | null;
+      const relatedTarget = e.relatedTarget as HTMLElement | null;
+      const isFocusedInTrap = target && trapContainer.contains(target);
 
       if (!props.trapped) {
-        const isPrevFocusedInTrap = relatedTarget && trapContainer.contains(relatedTarget)
+        const isPrevFocusedInTrap =
+          relatedTarget && trapContainer.contains(relatedTarget);
         if (!isPrevFocusedInTrap) {
-          lastFocusBeforeTrapped = relatedTarget
+          lastFocusBeforeTrapped = relatedTarget;
         }
       }
 
-      if (isFocusedInTrap) emit('focusin', e)
+      if (isFocusedInTrap) emit('focusin', e);
 
-      if (focusLayer.paused) return
+      if (focusLayer.paused) return;
 
       if (props.trapped) {
         if (isFocusedInTrap) {
-          lastFocusAfterTrapped = target
+          lastFocusAfterTrapped = target;
         } else {
-          tryFocus(lastFocusAfterTrapped, true)
+          tryFocus(lastFocusAfterTrapped, true);
         }
       }
-    }
+    };
 
     const onFocusOut = (e: Event) => {
-      const trapContainer = unref(forwardRef)
-      if (focusLayer.paused || !trapContainer) return
+      const trapContainer = unref(forwardRef);
+      if (focusLayer.paused || !trapContainer) return;
 
       if (props.trapped) {
-        const relatedTarget = (e as FocusEvent).relatedTarget as HTMLElement | null
+        const relatedTarget = (e as FocusEvent)
+          .relatedTarget as HTMLElement | null;
         if (!isNil(relatedTarget) && !trapContainer.contains(relatedTarget)) {
           // Give embedded focus layer time to pause this layer before reclaiming focus
           // And only reclaim focus if it should currently be trapping
           setTimeout(() => {
             if (!focusLayer.paused && props.trapped) {
               const focusoutPreventedEvent = createFocusOutPreventedEvent({
-                focusReason: focusReason.value
-              })
-              emit('focusout-prevented', focusoutPreventedEvent)
+                focusReason: focusReason.value,
+              });
+              emit('focusout-prevented', focusoutPreventedEvent);
               if (!focusoutPreventedEvent.defaultPrevented) {
-                tryFocus(lastFocusAfterTrapped, true)
+                tryFocus(lastFocusAfterTrapped, true);
               }
             }
-          }, 0)
+          }, 0);
         }
       } else {
-        const target = e.target as HTMLElement | null
-        const isFocusedInTrap = target && trapContainer.contains(target)
-        if (!isFocusedInTrap) emit('focusout', e)
+        const target = e.target as HTMLElement | null;
+        const isFocusedInTrap = target && trapContainer.contains(target);
+        if (!isFocusedInTrap) emit('focusout', e);
       }
-    }
+    };
 
     async function startTrap() {
       // Wait for forwardRef to resolve
-      await nextTick()
-      const trapContainer = unref(forwardRef)
+      await nextTick();
+      const trapContainer = unref(forwardRef);
       if (trapContainer) {
-        focusableStack.push(focusLayer)
-        const prevFocusedElement = trapContainer.contains(document.activeElement)
+        focusableStack.push(focusLayer);
+        const prevFocusedElement = trapContainer.contains(
+          document.activeElement,
+        )
           ? lastFocusBeforeTrapped
-          : document.activeElement
-        lastFocusBeforeTrapped = prevFocusedElement as HTMLElement | null
-        const isPrevFocusContained = trapContainer.contains(prevFocusedElement)
+          : document.activeElement;
+        lastFocusBeforeTrapped = prevFocusedElement as HTMLElement | null;
+        const isPrevFocusContained = trapContainer.contains(prevFocusedElement);
         if (!isPrevFocusContained) {
-          const focusEvent = new Event(FOCUS_AFTER_TRAPPED, FOCUS_AFTER_TRAPPED_OPTS)
-          trapContainer.addEventListener(FOCUS_AFTER_TRAPPED, trapOnFocus)
-          trapContainer.dispatchEvent(focusEvent)
+          const focusEvent = new Event(
+            FOCUS_AFTER_TRAPPED,
+            FOCUS_AFTER_TRAPPED_OPTS,
+          );
+          trapContainer.addEventListener(FOCUS_AFTER_TRAPPED, trapOnFocus);
+          trapContainer.dispatchEvent(focusEvent);
           if (!focusEvent.defaultPrevented) {
             nextTick(() => {
-              let focusStartEl = props.focusStartEl
+              let focusStartEl = props.focusStartEl;
               if (!isString(focusStartEl)) {
-                tryFocus(focusStartEl)
+                tryFocus(focusStartEl);
                 if (document.activeElement !== focusStartEl) {
-                  focusStartEl = 'first'
+                  focusStartEl = 'first';
                 }
               }
               if (focusStartEl === 'first') {
-                focusFirstDescendant(obtainAllFocusableElements(trapContainer), true)
+                focusFirstDescendant(
+                  obtainAllFocusableElements(trapContainer),
+                  true,
+                );
               }
-              if (document.activeElement === prevFocusedElement || focusStartEl === 'container') {
-                tryFocus(trapContainer)
+              if (
+                document.activeElement === prevFocusedElement ||
+                focusStartEl === 'container'
+              ) {
+                tryFocus(trapContainer);
               }
-            })
+            });
           }
         }
       }
     }
 
     function stopTrap() {
-      const trapContainer = unref(forwardRef)
+      const trapContainer = unref(forwardRef);
 
       if (trapContainer) {
-        trapContainer.removeEventListener(FOCUS_AFTER_TRAPPED, trapOnFocus)
+        trapContainer.removeEventListener(FOCUS_AFTER_TRAPPED, trapOnFocus);
 
         const releasedEvent = new CustomEvent(FOCUS_AFTER_RELEASED, {
           ...FOCUS_AFTER_TRAPPED_OPTS,
           detail: {
-            focusReason: focusReason.value
-          }
-        })
-        trapContainer.addEventListener(FOCUS_AFTER_RELEASED, releaseOnFocus)
-        trapContainer.dispatchEvent(releasedEvent)
+            focusReason: focusReason.value,
+          },
+        });
+        trapContainer.addEventListener(FOCUS_AFTER_RELEASED, releaseOnFocus);
+        trapContainer.dispatchEvent(releasedEvent);
         if (
           !releasedEvent.defaultPrevented &&
           (focusReason.value == 'keyboard' ||
             !isFocusCausedByUserEvent() ||
             trapContainer.contains(document.activeElement))
         ) {
-          tryFocus(lastFocusBeforeTrapped ?? document.body)
+          tryFocus(lastFocusBeforeTrapped ?? document.body);
         }
 
-        trapContainer.removeEventListener(FOCUS_AFTER_RELEASED, releaseOnFocus)
-        focusableStack.remove(focusLayer)
+        trapContainer.removeEventListener(FOCUS_AFTER_RELEASED, releaseOnFocus);
+        focusableStack.remove(focusLayer);
       }
     }
 
     onMounted(() => {
       if (props.trapped) {
-        startTrap()
+        startTrap();
       }
 
       watch(
         () => props.trapped,
-        (trapped) => {
+        trapped => {
           if (trapped) {
-            startTrap()
+            startTrap();
           } else {
-            stopTrap()
+            stopTrap();
           }
-        }
-      )
-    })
+        },
+      );
+    });
 
     onBeforeUnmount(() => {
       if (props.trapped) {
-        stopTrap()
+        stopTrap();
       }
 
       if (forwardRef.value) {
-        forwardRef.value.removeEventListener('keydown', onKeydown)
-        forwardRef.value.removeEventListener('focusin', onFocusIn)
-        forwardRef.value.removeEventListener('focusout', onFocusOut)
-        forwardRef.value = undefined
+        forwardRef.value.removeEventListener('keydown', onKeydown);
+        forwardRef.value.removeEventListener('focusin', onFocusIn);
+        forwardRef.value.removeEventListener('focusout', onFocusOut);
+        forwardRef.value = undefined;
       }
-    })
+    });
 
     return {
-      onKeydown
-    }
-  }
-})
+      onKeydown,
+    };
+  },
+});
 </script>

--- a/components/focus-trap/src/utils.ts
+++ b/components/focus-trap/src/utils.ts
@@ -1,190 +1,211 @@
-import { onBeforeUnmount, onMounted, ref } from 'vue'
-import { isElement, isFocusable } from 'element-plus/es/utils/index'
-import { FOCUSOUT_PREVENTED, FOCUSOUT_PREVENTED_OPTS } from './tokens'
+import { onBeforeUnmount, onMounted, ref } from 'vue';
+import { isElement, isFocusable } from '@flash-global66/g-utils';
+import { FOCUSOUT_PREVENTED, FOCUSOUT_PREVENTED_OPTS } from './tokens';
 
-const focusReason = ref<'pointer' | 'keyboard'>()
-const lastUserFocusTimestamp = ref<number>(0)
-const lastAutomatedFocusTimestamp = ref<number>(0)
-let focusReasonUserCount = 0
+const focusReason = ref<'pointer' | 'keyboard'>();
+const lastUserFocusTimestamp = ref<number>(0);
+const lastAutomatedFocusTimestamp = ref<number>(0);
+let focusReasonUserCount = 0;
 
 export type FocusLayer = {
-  paused: boolean
-  pause: () => void
-  resume: () => void
-}
+  paused: boolean;
+  pause: () => void;
+  resume: () => void;
+};
 
-export type FocusStack = FocusLayer[]
+export type FocusStack = FocusLayer[];
 
-export const obtainAllFocusableElements = (element: HTMLElement): HTMLElement[] => {
-  const nodes: HTMLElement[] = []
+export const obtainAllFocusableElements = (
+  element: HTMLElement,
+): HTMLElement[] => {
+  const nodes: HTMLElement[] = [];
   const walker = document.createTreeWalker(element, NodeFilter.SHOW_ELEMENT, {
     acceptNode: (
       node: Element & {
-        disabled: boolean
-        hidden: boolean
-        type: string
-        tabIndex: number
-      }
+        disabled: boolean;
+        hidden: boolean;
+        type: string;
+        tabIndex: number;
+      },
     ) => {
-      const isHiddenInput = node.tagName === 'INPUT' && node.type === 'hidden'
-      if (node.disabled || node.hidden || isHiddenInput) return NodeFilter.FILTER_SKIP
+      const isHiddenInput = node.tagName === 'INPUT' && node.type === 'hidden';
+      if (node.disabled || node.hidden || isHiddenInput)
+        return NodeFilter.FILTER_SKIP;
       return node.tabIndex >= 0 || node === document.activeElement
         ? NodeFilter.FILTER_ACCEPT
-        : NodeFilter.FILTER_SKIP
-    }
-  })
-  while (walker.nextNode()) nodes.push(walker.currentNode as HTMLElement)
+        : NodeFilter.FILTER_SKIP;
+    },
+  });
+  while (walker.nextNode()) nodes.push(walker.currentNode as HTMLElement);
 
-  return nodes
-}
+  return nodes;
+};
 
-export const getVisibleElement = (elements: HTMLElement[], container: HTMLElement) => {
+export const getVisibleElement = (
+  elements: HTMLElement[],
+  container: HTMLElement,
+) => {
   for (const element of elements) {
-    if (!isHidden(element, container)) return element
+    if (!isHidden(element, container)) return element;
   }
-}
+};
 
 export const isHidden = (element: HTMLElement, container: HTMLElement) => {
-  if (getComputedStyle(element).visibility === 'hidden') return true
+  if (getComputedStyle(element).visibility === 'hidden') return true;
 
   while (element) {
-    if (container && element === container) return false
-    if (getComputedStyle(element).display === 'none') return true
-    element = element.parentElement as HTMLElement
+    if (container && element === container) return false;
+    if (getComputedStyle(element).display === 'none') return true;
+    element = element.parentElement as HTMLElement;
   }
 
-  return false
-}
+  return false;
+};
 
 export const getEdges = (container: HTMLElement) => {
-  const focusable = obtainAllFocusableElements(container)
-  const first = getVisibleElement(focusable, container)
-  const last = getVisibleElement(focusable.reverse(), container)
-  return [first, last]
-}
+  const focusable = obtainAllFocusableElements(container);
+  const first = getVisibleElement(focusable, container);
+  const last = getVisibleElement(focusable.reverse(), container);
+  return [first, last];
+};
 
-const isSelectable = (element: any): element is HTMLInputElement & { select: () => void } => {
-  return element instanceof HTMLInputElement && 'select' in element
-}
+const isSelectable = (
+  element: any,
+): element is HTMLInputElement & { select: () => void } => {
+  return element instanceof HTMLInputElement && 'select' in element;
+};
 
 export const tryFocus = (
   element?: HTMLElement | { focus: () => void } | null,
-  shouldSelect?: boolean
+  shouldSelect?: boolean,
 ) => {
   if (element && element.focus) {
-    const prevFocusedElement = document.activeElement
-    let cleanup: boolean = false
+    const prevFocusedElement = document.activeElement;
+    let cleanup: boolean = false;
 
-    if (isElement(element) && !isFocusable(element) && !element.getAttribute('tabindex')) {
-      element.setAttribute('tabindex', '-1')
-      cleanup = true
+    if (
+      isElement(element) &&
+      !isFocusable(element) &&
+      !element.getAttribute('tabindex')
+    ) {
+      element.setAttribute('tabindex', '-1');
+      cleanup = true;
     }
 
-    element.focus({ preventScroll: true })
-    lastAutomatedFocusTimestamp.value = window.performance.now()
+    element.focus({ preventScroll: true });
+    lastAutomatedFocusTimestamp.value = window.performance.now();
 
-    if (element !== prevFocusedElement && isSelectable(element) && shouldSelect) {
-      element.select()
+    if (
+      element !== prevFocusedElement &&
+      isSelectable(element) &&
+      shouldSelect
+    ) {
+      element.select();
     }
     if (isElement(element) && cleanup) {
-      element.removeAttribute('tabindex')
+      element.removeAttribute('tabindex');
     }
   }
-}
+};
 
 function removeFromStack<T>(list: T[], item: T) {
-  const copy = [...list]
+  const copy = [...list];
 
-  const idx = list.indexOf(item)
+  const idx = list.indexOf(item);
 
   if (idx !== -1) {
-    copy.splice(idx, 1)
+    copy.splice(idx, 1);
   }
-  return copy
+  return copy;
 }
 
 const createFocusableStack = () => {
-  let stack = [] as FocusStack
+  let stack = [] as FocusStack;
 
   const push = (layer: FocusLayer) => {
-    const currentLayer = stack[0]
+    const currentLayer = stack[0];
 
     if (currentLayer && layer !== currentLayer) {
-      currentLayer.pause()
+      currentLayer.pause();
     }
 
-    stack = removeFromStack(stack, layer)
-    stack.unshift(layer)
-  }
+    stack = removeFromStack(stack, layer);
+    stack.unshift(layer);
+  };
 
   const remove = (layer: FocusLayer) => {
-    stack = removeFromStack(stack, layer)
-    stack[0]?.resume?.()
-  }
+    stack = removeFromStack(stack, layer);
+    stack[0]?.resume?.();
+  };
 
   return {
     push,
-    remove
-  }
-}
+    remove,
+  };
+};
 
-export const focusFirstDescendant = (elements: HTMLElement[], shouldSelect = false) => {
-  const prevFocusedElement = document.activeElement
+export const focusFirstDescendant = (
+  elements: HTMLElement[],
+  shouldSelect = false,
+) => {
+  const prevFocusedElement = document.activeElement;
   for (const element of elements) {
-    tryFocus(element, shouldSelect)
-    if (document.activeElement !== prevFocusedElement) return
+    tryFocus(element, shouldSelect);
+    if (document.activeElement !== prevFocusedElement) return;
   }
-}
+};
 
-export const focusableStack = createFocusableStack()
+export const focusableStack = createFocusableStack();
 
 export const isFocusCausedByUserEvent = (): boolean => {
-  return lastUserFocusTimestamp.value > lastAutomatedFocusTimestamp.value
-}
+  return lastUserFocusTimestamp.value > lastAutomatedFocusTimestamp.value;
+};
 
 const notifyFocusReasonPointer = () => {
-  focusReason.value = 'pointer'
-  lastUserFocusTimestamp.value = window.performance.now()
-}
+  focusReason.value = 'pointer';
+  lastUserFocusTimestamp.value = window.performance.now();
+};
 
 const notifyFocusReasonKeydown = () => {
-  focusReason.value = 'keyboard'
-  lastUserFocusTimestamp.value = window.performance.now()
-}
+  focusReason.value = 'keyboard';
+  lastUserFocusTimestamp.value = window.performance.now();
+};
 
 export const useFocusReason = (): {
-  focusReason: typeof focusReason
-  lastUserFocusTimestamp: typeof lastUserFocusTimestamp
-  lastAutomatedFocusTimestamp: typeof lastAutomatedFocusTimestamp
+  focusReason: typeof focusReason;
+  lastUserFocusTimestamp: typeof lastUserFocusTimestamp;
+  lastAutomatedFocusTimestamp: typeof lastAutomatedFocusTimestamp;
 } => {
   onMounted(() => {
     if (focusReasonUserCount === 0) {
-      document.addEventListener('mousedown', notifyFocusReasonPointer)
-      document.addEventListener('touchstart', notifyFocusReasonPointer)
-      document.addEventListener('keydown', notifyFocusReasonKeydown)
+      document.addEventListener('mousedown', notifyFocusReasonPointer);
+      document.addEventListener('touchstart', notifyFocusReasonPointer);
+      document.addEventListener('keydown', notifyFocusReasonKeydown);
     }
-    focusReasonUserCount++
-  })
+    focusReasonUserCount++;
+  });
 
   onBeforeUnmount(() => {
-    focusReasonUserCount--
+    focusReasonUserCount--;
     if (focusReasonUserCount <= 0) {
-      document.removeEventListener('mousedown', notifyFocusReasonPointer)
-      document.removeEventListener('touchstart', notifyFocusReasonPointer)
-      document.removeEventListener('keydown', notifyFocusReasonKeydown)
+      document.removeEventListener('mousedown', notifyFocusReasonPointer);
+      document.removeEventListener('touchstart', notifyFocusReasonPointer);
+      document.removeEventListener('keydown', notifyFocusReasonKeydown);
     }
-  })
+  });
 
   return {
     focusReason,
     lastUserFocusTimestamp,
-    lastAutomatedFocusTimestamp
-  }
-}
+    lastAutomatedFocusTimestamp,
+  };
+};
 
-export const createFocusOutPreventedEvent = (detail: CustomEventInit['detail']) => {
+export const createFocusOutPreventedEvent = (
+  detail: CustomEventInit['detail'],
+) => {
   return new CustomEvent(FOCUSOUT_PREVENTED, {
     ...FOCUSOUT_PREVENTED_OPTS,
-    detail
-  })
-}
+    detail,
+  });
+};

--- a/openspec/changes/ep-extraction-v4/design.md
+++ b/openspec/changes/ep-extraction-v4/design.md
@@ -1,0 +1,285 @@
+# Technical Design: EP Extraction v4 — Popper/Overlay Family
+
+> Artifact store: hybrid. Design phase of `ep-extraction-v4`. Reads `proposal.md` (same dir) / engram `sdd/ep-extraction-v4/proposal` (obs #275) and exploration `sdd/ep-extraction-v4/explore` (obs #269).
+> Scope locked by the proposal: migrate 13 packages off EP internals — `focus-trap, slot, overlay, scrollbar, popper, tooltip, select, dropdown, dialog, date-picker, time-picker, input-tag, inline` — building ~19 hooks/directives just-in-time. Table family + `input-number` are out (deferred to v5). The 8 permanent islands are never in scope.
+
+## 1. Technical Approach
+
+Same discipline v3 proved: copy EP algorithms **exactly** (no "improvements") into own-code packages, cover each new symbol with a Vitest unit test **before** wiring it (strict TDD, `yarn test:run`, unit-only), re-point each package's imports mechanically, and delete its `.eslintrc.cjs` `excludedFiles` entry only after it is lint-clean under `eslint --max-warnings 0`. Every migrated package follows the v3 packaging convention: `g-utils`/`g-hooks` in `dependencies`; `g-form`/`g-icon-font`/`element-plus`/`vue` in `peerDependencies` (the v3 packaging-bug root cause).
+
+The layering established by v2/v3 stays strictly one-directional, and every new symbol lands in the **lowest layer that can host it without creating a back-edge** — the single rule that resolves all four open questions below:
+
+```
+g-utils   (leaf — pure helpers/types/constants/directives, useNamespace; no internal DS deps)
+   ▲
+g-hooks   (deps: g-utils) — generic Vue composables, NO form-context coupling
+   ▲
+g-form    (deps: g-hooks, g-utils) — form-context-derived composables only
+   ▲
+components/{focus-trap,slot,overlay,scrollbar,popper,tooltip,select,dropdown,
+            dialog,date-picker,time-picker,input-tag,inline}
+```
+
+Hooks are built **just-in-time** (proposal decision 2): each new hook is authored in the WU of the **first consuming package in topological order**; later consumers re-point. Two mechanically distinct kinds of work run through the slice and are treated differently:
+
+- **Re-point only** — swap an EP specifier for an already-shipped DS symbol. Low risk, still needs a per-package pass (v3 proved untouched packages don't auto-consume existing hooks).
+- **Deep migration** — copy a genuinely-missing EP algorithm into `g-utils`/`g-hooks` with a unit test first, then wire it. This is where the risk lives.
+
+## 2. Resolved Open Questions (the four the proposal deferred to design)
+
+### 2.1 DS-native config shim contract — HIGHEST RISK (proposal decision 1)
+
+**Grounding fact that shrinks the risk dramatically.** `dialog` reads **exactly one** config key through `useGlobalConfig`, verified in `components/dialog/src/hooks/use-dialog.ts:60-61`:
+
+```ts
+const defaultNamespace = 'gui';
+const namespace = useGlobalConfig('namespace', defaultNamespace);
+```
+
+`namespace` is the _only_ key dialog consumes. It does **not** read `locale`, `zIndex`, `size`, `emptyValues`, or message defaults through this channel (zIndex comes from EP's separate `useZIndex`, migrated independently in WU-5). So the shim surface is a single string key with a hard default of `"gui"`.
+
+**How EP's `useGlobalConfig` actually resolves** (`node_modules/element-plus/es/components/config-provider/src/hooks/use-global-config.mjs:12-22`):
+
+```ts
+const globalConfig = ref(); // module-level fallback, empty by default
+function useGlobalConfig(key, defaultValue) {
+  const config = getCurrentInstance()
+    ? inject(configProviderContextKey, globalConfig) // ancestor provider OR module fallback
+    : globalConfig;
+  return computed(() => config.value?.[key] ?? defaultValue);
+}
+```
+
+**What the DS `config-provider` island actually provides.** `components/config-provider/ConfigProvider.vue` wraps EP's `<el-config-provider>` and hardcodes `namespace="gui"` (it comes after `v-bind="{...$attrs, ...$props}"`, so it wins — a consumer cannot override it). Therefore, in EP's world:
+
+- dialog **inside** `GConfigProvider` → injects EP's `configProviderContextKey` → `namespace === "gui"`.
+- dialog **outside** any provider → `globalConfig` is empty → falls back to the call-site default `"gui"`.
+
+**Both paths resolve `namespace` to `"gui"` today.** This is the key that makes the migration safe.
+
+**Decision — build a DS-native shim that establishes its OWN provider + injection key, with a hard fallback default; do NOT read EP's island context.** Reading EP's `configProviderContextKey` cross-boundary would re-introduce exactly the coupling v4 removes (and keep dialog's ESLint exclude alive). Instead:
+
+```ts
+// g-hooks/src/composables/useGlobalConfig.ts
+import { getCurrentInstance, inject, computed, ref, provide, unref } from 'vue';
+import type { InjectionKey, Ref, MaybeRef } from 'vue';
+
+export interface GlobalConfigContext {
+  namespace?: string;
+  // reserved for future keys (locale, zIndex, size); dialog uses only `namespace` today
+}
+
+export const gConfigProviderContextKey: InjectionKey<Ref<GlobalConfigContext>> =
+  Symbol('gConfigProviderContextKey');
+
+const globalConfig = ref<GlobalConfigContext>({}); // module-level fallback, EP-faithful
+
+export function useGlobalConfig<K extends keyof GlobalConfigContext>(
+  key: K,
+  defaultValue: GlobalConfigContext[K],
+): Ref<GlobalConfigContext[K]>;
+export function useGlobalConfig(): Ref<GlobalConfigContext>;
+export function useGlobalConfig(
+  key?: keyof GlobalConfigContext,
+  defaultValue?: unknown,
+) {
+  const config = getCurrentInstance()
+    ? inject(gConfigProviderContextKey, globalConfig)
+    : globalConfig;
+  if (key) return computed(() => config.value?.[key] ?? defaultValue);
+  return config;
+}
+
+// optional companion for future DS providers; NOT used by v4, ships for completeness
+export function provideGlobalConfig(config: MaybeRef<GlobalConfigContext>) {
+  provide(
+    gConfigProviderContextKey,
+    computed(() => unref(config)),
+  );
+}
+```
+
+**Resolution order (precise contract):**
+
+1. Nearest ancestor that called `provideGlobalConfig` (DS-native `gConfigProviderContextKey`).
+2. Else the module-level `globalConfig` ref (empty unless a global `provideGlobalConfig(..., global)` ran — not wired in v4).
+3. Else the call-site `defaultValue` (`"gui"` for dialog).
+
+**Why this cannot regress dialog.** The DS `config-provider` island still provides EP's `configProviderContextKey`, **not** `gConfigProviderContextKey`. So the DS shim's inject always misses the island and falls through to step 3 → `"gui"` — byte-identical to today's resolved value, because the island hardcodes `namespace="gui"` anyway. The shim is behaviorally equivalent in every mounting context (inside island, outside island, SSR/no-instance path preserved via the `getCurrentInstance()` guard). We do **not** modify the permanent `config-provider` island (out of scope), and we do not need to: the default carries the contract.
+
+**Test contract (author first):** `useGlobalConfig('namespace', 'gui')` returns `'gui'` with no provider; returns the provided value when an ancestor `provideGlobalConfig({ namespace: 'x' })` exists; the no-arg overload returns the whole context ref; the no-`getCurrentInstance` path returns the module ref without throwing. Validate `dialog` in `front-b2b` (real copy, never symlink) before removing its ESLint exclude.
+
+**Placement:** `g-hooks` (only Vue + g-utils; no form context → no cycle).
+
+### 2.2 `useForwardRef` vs `useForwardRefDirective` — UNIFY into one g-hooks module (not a preference — a correctness requirement)
+
+The open question framed EP as "splitting" these because `popper/trigger.vue` imports `useForwardRef` while `slot/only-child.tsx` imports `useForwardRefDirective` + `FORWARD_REF_INJECTION_KEY`. That is a **consumption** split, not a **definition** split. In EP all three live in **one module** and share **one symbol** (`node_modules/element-plus/es/hooks/use-forward-ref/index.mjs`):
+
+```ts
+const FORWARD_REF_INJECTION_KEY = Symbol('elForwardRef');
+const useForwardRef = forwardRef => {
+  provide(FORWARD_REF_INJECTION_KEY, { setForwardRef });
+};
+const useForwardRefDirective = setForwardRef => ({
+  mounted,
+  updated,
+  unmounted,
+});
+```
+
+The provide/inject handshake is: `popper/trigger` calls `useForwardRef` (which `provide`s the key) and `slot/only-child` `inject`s the **same** `FORWARD_REF_INJECTION_KEY` to receive `setForwardRef`. **If the two functions did not share the identical symbol instance, the handshake would silently break.** Splitting them across two packages/modules would risk two distinct `Symbol()`s.
+
+**Decision:** one g-hooks module `useForwardRef.ts` exporting all three (`useForwardRef`, `useForwardRefDirective`, `FORWARD_REF_INJECTION_KEY`), mirroring EP's own file layout. `slot` (earlier in topological order) owns building it; `popper` re-points to `@flash-global66/g-hooks`. This guarantees a single shared symbol and matches EP's public shape, so no future consumer API drift.
+
+### 2.3 `useEmptyValues` placement — g-hooks, NOT g-form (the acyclic analysis, and a correction to the open question)
+
+The open question asserted "EP's impl composes with form context." **That is inaccurate** — verified against `node_modules/element-plus/es/hooks/use-empty-values/index.mjs`. `useEmptyValues` injects `emptyValuesContextKey`, which is provided by **config-provider** (`provideGlobalConfig`), **not** by form/form-item context:
+
+```ts
+const emptyValuesContextKey = Symbol('emptyValuesContextKey');
+const useEmptyValues = (props, defaultValue) => {
+  const config = getCurrentInstance()
+    ? inject(emptyValuesContextKey, ref({}))
+    : ref({});
+  const emptyValues = computed(
+    () => props.emptyValues || config.value.emptyValues || DEFAULT_EMPTY_VALUES,
+  );
+  // valueOnClear cascade: prop > config > defaultValue > undefined
+};
+```
+
+Its only real dependencies are `buildProps`, `isFunction`, `debugWarn` (all in **g-utils**) plus Vue primitives. It has **zero form-context coupling**, so — unlike v3's `useFormSize`, which _had_ to sit in `g-form` because it read `formContextKey`/`formItemContextKey` — there is no cycle risk here. `g-hooks → g-utils` only.
+
+**Decision:** `useEmptyValues` + `useEmptyValuesProps` live in **`g-hooks`** (a new `useEmptyValues.ts`), owning a DS-native `gEmptyValuesContextKey`. Exactly like the config shim (§2.1), the DS `config-provider` island provides EP's key, not the DS key, so `inject(gEmptyValuesContextKey, ref({}))` always falls back to `ref({})` → effective resolution is `props.emptyValues || DEFAULT_EMPTY_VALUES`, which is the current behavior. `select` (WU-8, first consumer) owns it; `time-picker` (WU-11) re-points.
+
+> Symmetry note: `useGlobalConfig` (§2.1) and `useEmptyValues` are the two hooks whose EP source of truth is the config-provider island. Both get a DS-owned injection key + hard defaults, both fall through to defaults because the island still wraps EP. Keep their injection keys distinct and co-located conceptually (config family) but do NOT couple dialog to select — they are independent modules.
+
+### 2.4 Stale `radio-group → radio/radio.type` reference — CONFIRMED latent bug; document, do NOT fix in v4
+
+Verified: `components/radio-group/RadioGroup.vue:15` imports `{ TypeRadioSize, EnumRadioSize } from '../radio/radio.type'`. That file **does not exist** (`components/radio/radio.type.*` → no files), and grep for `TypeRadioSize`/`EnumRadioSize` across `components/radio` returns **zero matches** — the v3 radio migration did not carry those symbols forward. This is a genuine broken import. It currently survives only because `radio-group` is a permanent island fully excluded from the ESLint/type gate (`.eslintrc.cjs:35` → `components/radio-group/**`) and is not built/tested in the guarded set.
+
+**Recommendation (fix-where):** this is **out of v4 scope** and v4 naturally does **not** inherit it — v4 touches neither `radio-group` (permanent island) nor re-introduces the reference. Do **NOT** fix it inside any v4 migration WU (that would smuggle an unrelated island change into a popper-family PR and muddy the diff). Action: log it as a standalone tracked defect (separate chore/PR against `radio-group` + `radio`), owner to decide whether `radio` should re-export a `RadioSize` type or `radio-group` should inline its own. Design flags it; design does not fix it.
+
+## 3. Per-Package Migration Classification (drives the task breakdown)
+
+Classification verified against real imports (§Grep of `from 'element-plus'` across the 13 packages, 83 occurrences / 43 files).
+
+| Package         | Class                 | New symbols it must build (JIT owner)                                                                                                                        | Key re-points                                                                                                                                                                                                                                    |
+| --------------- | --------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **scrollbar**   | re-point only         | —                                                                                                                                                            | `useAriaProps`(g-hooks), `useNamespace`/`isClient`/`throwError`/`buildProps`(g-utils)                                                                                                                                                            |
+| **inline**      | re-point only         | —                                                                                                                                                            | `useFormSize`(g-form), `useAriaProps`(g-hooks), `useNamespace`/prop-builders/guards(g-utils) — smallest WU                                                                                                                                       |
+| **input-tag**   | re-point only         | —                                                                                                                                                            | `useCalcInputWidth`(from select), `useComposition`/`useFocusController`(g-hooks), `useNamespace`/`NOOP`/`isUndefined`                                                                                                                            |
+| **focus-trap**  | deep                  | `useEscapeKeydown`(g-hooks), `isFocusable`(g-utils)                                                                                                          | `isString`/`isElement`/`EVENT_CODE`                                                                                                                                                                                                              |
+| **slot**        | deep                  | forward-ref family: `useForwardRef`+`useForwardRefDirective`+`FORWARD_REF_INJECTION_KEY`(g-hooks)                                                            | `NOOP`/`debugWarn`/`isObject`/`useNamespace`                                                                                                                                                                                                     |
+| **overlay**     | deep                  | `useSameTarget`(g-hooks, shared w/ dialog), `PatchFlags`(g-utils)                                                                                            | `buildProps`/`definePropType`                                                                                                                                                                                                                    |
+| **popper**      | deep (core)           | `usePopper`(g-hooks), `useZIndex`(g-hooks)                                                                                                                   | `useForwardRef`(from slot), `useNamespace`/`isClient`/`isNumber`/`isElement`/`isFocusable`(from focus-trap)/`buildProps`/`NOOP`; deps `g-slot`/`g-focus-trap`/`g-form`                                                                           |
+| **tooltip**     | deep                  | `useDelayedToggle`+`useDelayedToggleProps`(g-hooks), `createModelToggleComposable`(g-hooks), `usePopperContainer`+`usePopperContainerId`(g-hooks)            | `useId`(g-hooks), `composeEventHandlers`/`EVENT_CODE`; deps `g-popper`/`g-focus-trap`/`g-teleport`/`g-icon-button`/`g-slot`                                                                                                                      |
+| **select**      | deep + order-hazard   | `useEmptyValues`+`useEmptyValuesProps`(g-hooks), `useCalcInputWidth`(g-hooks, shared w/ input-tag), `ClickOutside`(g-utils directive, shared w/ date-picker) | **re-point `TooltipInstance`/`useTooltipContentProps` to `@flash-global66/g-tooltip`** (currently straight from EP); `EVENT_CODE`/`CHANGE_EVENT`/`UPDATE_MODEL_EVENT`                                                                            |
+| **dropdown**    | deep + widest fan-out | `whenMouse`(g-hooks), `useLocale`(g-hooks, shared w/ date-picker+time-picker)                                                                                | `composeRefs`(from dialog), `composeEventHandlers`/`useId`/`addUnit`/`ensureArray`/`EVENT_CODE`; deps focus-trap/roving-focus-group(clean)/collection(clean)/tooltip/scrollbar/icon-font/slot/popper — **its own WU, never bundled with select** |
+| **dialog**      | deep + highest-risk   | DS config shim `useGlobalConfig`(g-hooks, §2.1), `useDraggable`(g-hooks), `composeRefs`(g-utils, shared w/ dropdown)                                         | `useSameTarget`(from overlay), `useZIndex`/`useId`(from popper family), `addUnit`/`isClient`/`isBoolean`; deps `g-focus-trap`/`g-overlay`/`g-teleport`/`g-icon-font`/`g-button`                                                                  |
+| **date-picker** | deep + lint debt      | `castArray`(g-utils)                                                                                                                                         | `useLocale`(from dropdown), `ClickOutside`(from select), `isArray`/`isFunction`/`useNamespace`/`EVENT_CODE`; **fix pre-existing `no-unused-vars` in-place** (decision 3)                                                                         |
+| **time-picker** | deep                  | `getStyle`(g-utils), `vRepeatClick`(g-utils directive)                                                                                                       | `useEmptyValues`(from select), `useLocale`(from dropdown), `useFocusController`(g-hooks — currently still imported from EP!); deps `g-form`/`g-input`/`g-icon-font`/`g-tooltip`                                                                  |
+
+Constraints honored on every package: **zero public API change** (props/emits/slots untouched — only internal import specifiers move); source-only packages stay `buildable:false`; each migration WU validated in `front-b2b` with **real copies** in `node_modules` (never symlinks — symlinks strip base CSS / Tailwind `@apply`); build via `node scripts/build-components.js`; lint `eslint --max-warnings 0`; env Node v20.19.3 + dummy `GBP_PACKAGE_TOKEN`.
+
+## 4. Hook-by-Hook Design (~19 symbols, EP-faithful signatures, JIT ownership)
+
+Each row: layer, EP source module, owning WU. Signatures mirror EP exactly so migration is import-swap only. `(exists)` symbols are re-points, listed in §3, not rebuilt.
+
+**g-utils additions (pure helpers/types/directives — leaf layer):**
+
+| Symbol                     | EP source                                  | Owner WU    | Notes                                                                 |
+| -------------------------- | ------------------------------------------ | ----------- | --------------------------------------------------------------------- |
+| `isFocusable`              | `utils/dom/aria.mjs`                       | focus-trap  | boolean predicate; distinct from existing `isElement`                 |
+| `PatchFlags`               | Vue-internal re-export (`utils/vnode.mjs`) | overlay     | small enum/const mirror                                               |
+| `composeRefs`              | `utils/vue/refs.mjs`                       | dialog      | distinct from existing `composeEventHandlers`; dropdown re-points     |
+| `castArray`                | `utils/arrays.mjs`                         | date-picker | distinct from existing `ensureArray` (EP semantics differ on nullish) |
+| `getStyle`                 | `utils/dom/style.mjs`                      | time-picker | computed-style reader                                                 |
+| `ClickOutside` (directive) | `directives/click-outside`                 | select      | shared w/ date-picker; unit-testable handler map                      |
+| `vRepeatClick` (directive) | `directives/repeat-click`                  | time-picker | shared w/ input-number (v5)                                           |
+
+**g-hooks additions (generic composables — deps g-utils + Vue only, no form context):**
+
+| Symbol                                                                            | EP source                          | Owner WU   | Signature sketch                                                                                   |
+| --------------------------------------------------------------------------------- | ---------------------------------- | ---------- | -------------------------------------------------------------------------------------------------- |
+| `useEscapeKeydown`                                                                | `hooks/use-escape-keydown`         | focus-trap | `(handler: (e: KeyboardEvent) => void) => void`                                                    |
+| `useForwardRef` + `useForwardRefDirective` + `FORWARD_REF_INJECTION_KEY`          | `hooks/use-forward-ref`            | slot       | one module, one shared symbol (§2.2)                                                               |
+| `useSameTarget`                                                                   | `hooks/use-same-target`            | overlay    | `(handleClick?: (e: MouseEvent) => void) => { onClick, onMousedown, onMouseup }`; dialog re-points |
+| `usePopper`                                                                       | `components/popper/.../use-popper` | popper     | `(refEl, popperEl, opts) => { state, styles, attributes, update, forceUpdate, instanceRef }`       |
+| `useZIndex`                                                                       | `hooks/use-z-index`                | popper     | `(zIndexOverrides?) => { initialZIndex, currentZIndex, nextZIndex }`; dialog re-points             |
+| `usePopperContainer` + `usePopperContainerId`                                     | `hooks/use-popper-container`       | tooltip    | container id + teleport target composables                                                         |
+| `useDelayedToggle` + `useDelayedToggleProps`                                      | `hooks/use-delayed-toggle`         | tooltip    | `({ showAfter, hideAfter, autoClose, open, close }) => { onOpen, onClose }`                        |
+| `createModelToggleComposable`                                                     | `hooks/use-model-toggle`           | tooltip    | factory returning `use<Name>ModelToggle` + props/emits                                             |
+| `useGlobalConfig` (DS shim) + `provideGlobalConfig` + `gConfigProviderContextKey` | reimplemented (§2.1)               | dialog     | single-key overload + whole-context overload                                                       |
+| `useDraggable`                                                                    | `hooks/use-draggable`              | dialog     | `(targetRef, dragRef, draggable, overflow?) => void`                                               |
+| `useEmptyValues` + `useEmptyValuesProps` + `gEmptyValuesContextKey`               | `hooks/use-empty-values` (§2.3)    | select     | `(props, defaultValue?) => { emptyValues, valueOnClear, isEmptyValue }`                            |
+| `useCalcInputWidth`                                                               | `hooks/use-calc-input-width`       | select     | `() => { calculatorRef, inputStyle }`; input-tag re-points                                         |
+| `whenMouse`                                                                       | `hooks/.../when-mouse`             | dropdown   | `(handler) => (e: PointerEvent) => void` guard                                                     |
+| `useLocale`                                                                       | `hooks/use-locale`                 | dropdown   | `(localeOverrides?) => { lang, locale, t }`; date-picker/time-picker re-point                      |
+
+> `usePopper`, `useDraggable`, and `createModelToggleComposable` are the highest-drift copies (largest algorithms). Copy byte-exact, no improvements, dedicated unit test before wiring — the copied-algorithm-drift risk from the proposal lands here.
+
+## 5. Topological Build Order & Work Units (chained PRs, `stacked-to-main`, ≤400 lines, publish per WU)
+
+JIT ownership is folded into each migration WU — no speculative foundation-first hook PR. The earlier package in the order owns any shared hook; later ones re-point (dependencies noted).
+
+| WU    | Deliverable (migrate package + build its JIT hooks + remove its ESLint exclude) | Depends on       | Owns (built here)                                                         | Re-points                                                               |
+| ----- | ------------------------------------------------------------------------------- | ---------------- | ------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
+| WU-1  | **focus-trap**                                                                  | —                | `useEscapeKeydown`, `isFocusable`                                         | —                                                                       |
+| WU-2  | **slot**                                                                        | —                | forward-ref family (one module)                                           | —                                                                       |
+| WU-3  | **overlay**                                                                     | —                | `useSameTarget`, `PatchFlags`                                             | —                                                                       |
+| WU-4  | **scrollbar** (pure re-point)                                                   | —                | —                                                                         | `useAriaProps` etc.                                                     |
+| WU-5  | **popper** (core)                                                               | WU-1, WU-2       | `usePopper`, `useZIndex`                                                  | `useForwardRef`(WU-2), `isFocusable`(WU-1)                              |
+| WU-6  | **tooltip**                                                                     | WU-5             | `useDelayedToggle*`, `createModelToggleComposable`, `usePopperContainer*` | —                                                                       |
+| WU-7  | **dialog** (highest-risk)                                                       | WU-3, WU-5       | config shim `useGlobalConfig`, `useDraggable`, `composeRefs`              | `useSameTarget`(WU-3), `useZIndex`(WU-5)                                |
+| WU-8  | **select**                                                                      | WU-6             | `useEmptyValues*`, `useCalcInputWidth`, `ClickOutside`                    | **`g-tooltip`**(WU-6) for `TooltipInstance`/`useTooltipContentProps`    |
+| WU-9  | **dropdown** (widest fan-out, dedicated)                                        | WU-6, WU-4, WU-7 | `whenMouse`, `useLocale`                                                  | `composeRefs`(WU-7), tooltip/scrollbar                                  |
+| WU-10 | **date-picker** (+ in-place lint-debt fix)                                      | WU-9, WU-8       | `castArray`                                                               | `useLocale`(WU-9), `ClickOutside`(WU-8)                                 |
+| WU-11 | **time-picker**                                                                 | WU-6, WU-9, WU-8 | `getStyle`, `vRepeatClick`                                                | `useEmptyValues`(WU-8), `useLocale`(WU-9), `useFocusController`(exists) |
+| WU-12 | **input-tag** (pure re-point)                                                   | WU-8             | —                                                                         | `useCalcInputWidth`(WU-8)                                               |
+| WU-13 | **inline** (pure re-point, smallest)                                            | —                | —                                                                         | `useFormSize`(g-form, exists)                                           |
+
+**Critical-path chain:** WU-1/WU-2 → WU-5 (popper) → WU-6 (tooltip) → WU-8 (select) / WU-9 (dropdown) → WU-10/WU-11. **dialog (WU-7)** sits on a parallel branch off overlay+popper, independent of the tooltip chain.
+
+**Parallelism:** WU-1..WU-4 (near-leaves) are mutually independent and can be developed concurrently; scrollbar (WU-4) and inline (WU-13) are fully independent of the popper chain and can land any time after their trivial deps. Once popper (WU-5) lands, the tooltip branch (WU-6→WU-8/WU-9), the dialog branch (WU-7), and the picker branch (WU-10/WU-11) proceed in parallel. dropdown (WU-9) stays its own PR and is never bundled with select (proposal risk).
+
+**Chain strategy:** `stacked-to-main` (v3 precedent) — each WU is its own PR merging to `main` in order; each child PR body carries the dependency diagram marking the current PR with a locator and states start/end/prior-deps/out-of-scope (chained-pr skill). Incremental Lerna publish per merged WU; `front-b2b`/`front-admin` consume the migration incrementally with real-copy validation on `ander/update/version-packages`.
+
+**Test strategy:** strict TDD, Vitest, unit-only, `yarn test:run`. Every new symbol lands red→green with its unit test authored first (config shim resolution §2.1; forward-ref shared-symbol handshake §2.2; `useEmptyValues` cascade §2.3; `usePopper`/`useDraggable`/`createModelToggleComposable` byte-exact behavior). No DOM/integration/mounted tests beyond what unit scope allows.
+
+## 6. Design-Level Risks
+
+| Risk                                                                                       | Mitigation                                                                                                                                                                                                                             |
+| ------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Config shim regresses dialog `namespace`                                                   | Only key consumed is `namespace`, default `"gui"`; island hardcodes `"gui"`; shim falls through to default in every context → byte-identical. Unit-test all three resolution branches; validate dialog in b2b before removing exclude. |
+| Forward-ref handshake breaks from a duplicated symbol                                      | Single g-hooks module owns the one shared `FORWARD_REF_INJECTION_KEY`; slot builds, popper re-points to the same export.                                                                                                               |
+| `select` re-point ordering hazard                                                          | Sequence WU-8 strictly after WU-6; re-point `TooltipInstance`/`useTooltipContentProps` to `@flash-global66/g-tooltip`, not an EP subpath.                                                                                              |
+| Copied heavy algorithms drift (`usePopper`, `useDraggable`, `createModelToggleComposable`) | Byte-exact copy, no improvements, dedicated unit test before wiring.                                                                                                                                                                   |
+| date-picker lint-debt widens diff                                                          | Scope `no-unused-vars` cleanup to touched files inside WU-10; keep `--max-warnings 0` green without a separate chore.                                                                                                                  |
+| Already-extracted hooks not auto-consumed (time-picker → `useFocusController` from EP)     | Every WU gets an explicit re-point pass even where no new hook work exists.                                                                                                                                                            |
+| Stale radio-group→radio.type latent bug                                                    | Documented in §2.4; tracked as a standalone defect; NOT fixed inside any v4 WU.                                                                                                                                                        |
+
+## 7. Dependency Graph (final, acyclic)
+
+```
+                         g-utils
+   (isFocusable, PatchFlags, composeRefs, castArray, getStyle,
+    ClickOutside, vRepeatClick  + existing v2/v3 helpers)
+        ▲                                              ▲
+        │                                              │
+     g-hooks                                        g-form
+ (useEscapeKeydown, forward-ref family, useSameTarget,     (useFormSize — exists;
+  usePopper, useZIndex, usePopperContainer*,                inline/time-picker re-point)
+  useDelayedToggle*, createModelToggleComposable,
+  useGlobalConfig(DS shim), useDraggable,
+  useEmptyValues*, useCalcInputWidth, whenMouse, useLocale
+  + existing useId/useFocusController/useAriaProps/...)
+        ▲                                              ▲
+        └──────────────────────┬───────────────────────┘
+                               │
+   components/{focus-trap, slot, overlay, scrollbar, popper, tooltip,
+               select, dropdown, dialog, date-picker, time-picker,
+               input-tag, inline}
+```
+
+No back-edges. The two config-provider-sourced hooks (`useGlobalConfig`, `useEmptyValues`) sit in `g-hooks` with DS-owned injection keys and hard defaults — placeable there precisely because neither reads form context (unlike v3's `useFormSize`). The DS `config-provider` island is untouched and continues wrapping real EP.

--- a/openspec/changes/ep-extraction-v4/proposal.md
+++ b/openspec/changes/ep-extraction-v4/proposal.md
@@ -1,0 +1,96 @@
+# Proposal: EP Extraction v4 — Migrate the Popper/Overlay Family off element-plus Internals
+
+> Artifact store: hybrid. Continues `ep-extraction-v3` (archived 2026-07-10). Primary input: exploration obs #269 (grep-verified dependency graph + hook inventory).
+> This is the **popper/overlay slice**, not the full remaining migration. It migrates 13 packages and builds the hooks/directives they need just-in-time. The table family and `input-number` are deferred to a future `ep-extraction-v5`.
+
+## Intent
+
+After v3, `main` has a clean `g-utils`, `g-hooks`, and `g-form`, plus 5 migrated form-control packages and an ESLint guard whose `excludedFiles` allowlist still masks the EP coupling of every package we have not reached yet. v3 proved the pattern on the light, popper-free controls. The next honest step is the hard middle: the **popper/overlay family** — the packages whose EP dependency is not just utilities but real overlay machinery (positioning, focus-trapping, z-index, forward-ref, model-toggle).
+
+v4 closes that coupling for 13 packages: the near-leaf prerequisites (`focus-trap`, `slot`, `overlay`, `scrollbar`), the `popper` core, its direct dependents (`tooltip`, `select`, `dropdown`, `dialog`), the self-contained picker family (`date-picker`, `time-picker`), and the two remaining light controls (`input-tag`, `inline`). Migrating them removes 13 more entries from the guard's allowlist and lets `front-b2b` / `front-admin` consume the overlay migration incrementally rather than waiting on one large drop.
+
+**Honest non-goal up front:** v4 does **not** remove `element-plus` from `package.json` anywhere. Eight packages are permanent islands that wrap real EP components (see Out of Scope). They keep `element-plus` as a genuine dependency **by design**. v4 removes EP-**internal-utility** coupling from the 13 in-scope packages; it does not attempt to delete element-plus from the monorepo.
+
+## Scope
+
+### In Scope
+
+**(a) New hooks/directives — built JUST-IN-TIME.** We do not front-load a foundation-first hook package. Each of the ~19 discovered hooks/directives is built inside the work-unit of the **first in-scope package that consumes it**, then re-pointed by later consumers. When two packages need the same hook near-simultaneously, the earlier package in the topological order owns building it (and later ones re-point). The build list (all grep-verified missing from `g-utils`/`g-hooks` in obs #269):
+
+- Popper/overlay core: `usePopper`, `usePopperContainer`/`usePopperContainerId`, `useZIndex`, `useForwardRef` + `useForwardRefDirective` + `FORWARD_REF_INJECTION_KEY`, `useEscapeKeydown`, `useSameTarget` (shared by `dialog` + `overlay`), `isFocusable`, `PatchFlags`.
+- Toggle/interaction: `useDelayedToggle`/`useDelayedToggleProps`, `createModelToggleComposable`, `useDraggable` (dialog), `whenMouse` (dropdown).
+- i18n / values: `useLocale` (dropdown, date-picker, time-picker), `useEmptyValues`/`useEmptyValuesProps` (select + time-picker).
+- Widths / refs / arrays / style: `useCalcInputWidth` (select + input-tag), `composeRefs` (dialog + dropdown), `castArray` (date-picker), `getStyle` (time-picker), `iconPropType`.
+- Directives: `ClickOutside` (select + date-picker), plus the DS-native config shim below.
+- **DS-native config shim** replacing `useGlobalConfig` for `dialog` — see Approach decision 1 (highest-effort/highest-risk item).
+
+Every new hook/directive ships with Vitest unit tests (strict TDD active, `yarn test:run`, unit-only policy). EP algorithms are copied exactly (no "improvements") to avoid behavior drift.
+
+**Reused, NOT rebuilt — pure import re-point.** A large fraction of this slice is re-pointing imports to symbols v2/v3 already shipped, not new engineering: `useNamespace`, `useId`/`useIdInjection`, `useGlobalSize`, `useAriaProps`, `useSizeProp`, `useComposition`, `useFocusController`, `useFormSize` (g-form), plus the whole type-guard / prop-builder / event-constant surface (`isBoolean`/`isString`/`isObject`/`buildProps`/`definePropType`/`EVENT_CODE`/`CHANGE_EVENT`/`UPDATE_MODEL_EVENT`, etc.). Each in-scope package still needs its own explicit re-point pass even where no new hook work exists (obs #269 confirmed `time-picker` and `input-tag` still import already-extracted hooks straight from EP).
+
+**(b) Migrate 13 packages off element-plus internals**, dependency-ordered:
+
+- Near-leaves: `focus-trap`, `slot`, `overlay`, `scrollbar`
+- Core: `popper`
+- Popper-dependents: `tooltip`, then `select`, `dropdown`; `dialog` (parallel to the tooltip branch)
+- Picker family: `date-picker`, `time-picker`
+- Remaining light controls: `input-tag`, `inline`
+
+**(c) Shrink the ESLint guard**: remove each migrated package's entry from `excludedFiles` in `.eslintrc.cjs` as it lands, so `--max-warnings 0` always passes. Deferred packages and the 8 islands stay excluded.
+
+**(d) Clean `date-picker`'s pre-existing lint debt** (`no-unused-vars`) inside its migration WU — fix the package as part of migrating it, don't ship it dirty and don't track it separately (Approach decision 3).
+
+**(e) Follow the v3 packaging convention** for every migrated package: declare `g-utils`/`g-hooks` in `dependencies`; keep `g-form`/`g-icon-font`/`element-plus`/`vue` in `peerDependencies`. This was the v3 packaging-bug root cause; new migrated packages must not repeat it.
+
+### Out of Scope (Non-Goals)
+
+- **Table family + `input-number`, deferred to `ep-extraction-v5`:** `table`, `pagination`, `collapse`, `input-number`. Rationale: their combined size and cross-cutting hook needs (`useLocale`, `ClickOutside`/`Mousewheel` directives, `vRepeatClick`, `INPUT_EVENT`, plus `table`'s ~27 EP imports) rival the entire v4 slice. Splitting keeps the review budget sane and each chained PR reviewable, matching the v3 precedent of slicing rather than big-bang. These are technically independent of the popper chain, so v5 can proceed cleanly on top of v4's shared packages.
+- **The 8 permanent islands — never in scope, any vN:** `badge`, `menu`, `config-provider`, `popover`, `radio-group`, `form-item`, `skeleton`, `infinite-scroll`. These wrap whole EP components; they keep `element-plus` as a real dependency by design. v4 does **not** touch them and does **not** remove element-plus from their `package.json`.
+- **Removing `element-plus` from the monorepo or from any island's `peerDependencies`.** Out, by the non-goal above.
+- **Any DOM / integration / mounted test** — unit-only policy stands.
+
+## Approach
+
+Dependency-ordered migration on top of v3's clean shared packages, isolated per work unit so each WU is an independently reviewable, independently publishable chained PR (`stacked-to-main`, incremental Lerna publish per WU — reused from v3). Two mechanically distinct kinds of work run through the slice, and the proposal treats them differently:
+
+- **Re-pointing** — swapping an EP import for an already-extracted DS symbol. Low risk, mostly mechanical; still needs a per-package pass (obs #269 proved untouched packages don't auto-consume existing hooks).
+- **Deep migration** — copying a genuinely missing EP algorithm into `g-utils`/`g-hooks` with unit tests, then wiring it in. This is where the risk lives and where TDD matters.
+
+Ordering follows obs #269's verified topological graph: near-leaves first (they unblock `popper`), then `popper` (the core that gates its dependents), then `tooltip` → `select`/`dropdown` with `dialog` in parallel, then the picker family, then `input-tag`/`inline`. Hooks are built just-in-time inside the first consuming WU (decision 2).
+
+**The three decisions the user made:**
+
+1. **config-provider coupling (`useGlobalConfig`, used by `dialog`): build a DS-native config shim.** `dialog` currently reads global config (locale/zIndex/namespace/message defaults) from the still-EP-backed `config-provider` island via EP's `useGlobalConfig`. We do **not** accept a scoped EP exception. Instead we build a DS-native config hook so `dialog` no longer reaches into the island's EP-provided context. This is the **highest-effort, highest-risk item in v4**: it sits on the boundary of a permanent island, and getting the provide/inject contract wrong risks a silent regression in dialog defaults. It gets its own careful design pass and lets `dialog`'s ESLint exclude be removed fully rather than narrowed per-symbol.
+
+2. **Hook build strategy: just-in-time, not foundation-first.** Each new hook/directive is built in the WU of the first package that consumes it. Shared hooks (e.g. `useSameTarget` for `overlay`+`dialog`, `useCalcInputWidth` for `select`+`input-tag`, `useLocale` for the picker branch) are owned by whichever consumer lands first in the topological order; later consumers re-point. This keeps each WU self-contained and avoids a large speculative foundation PR that would be hard to review and might build hooks we mis-scope.
+
+3. **`date-picker` pre-existing lint debt: fix it in-place.** `date-picker` carries `no-unused-vars` warnings predating this change. We clean them as part of the date-picker migration WU (touched-files hygiene), not as a separate tracked chore and not by excluding them from the diff.
+
+## Impact
+
+| Area                                                                                                                                                  | Impact    | Description                                                                                                                                                                                                                                                                       |
+| ----------------------------------------------------------------------------------------------------------------------------------------------------- | --------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `common/g-utils/src/**`                                                                                                                               | Modified  | New pure helpers/types/directives added just-in-time: `castArray`, `getStyle`, `composeRefs`, `isFocusable`, `iconPropType`, `PatchFlags`, `ClickOutside`                                                                                                                         |
+| `common/g-hooks/src/**`                                                                                                                               | Modified  | New composables added just-in-time: `usePopper*`, `useZIndex`, `useForwardRef*`, `useEscapeKeydown`, `useSameTarget`, `useDelayedToggle*`, `createModelToggleComposable`, `useDraggable`, `useLocale`, `useEmptyValues*`, `useCalcInputWidth`, `whenMouse`, DS-native config shim |
+| `components/{focus-trap,slot,overlay,scrollbar,popper,tooltip,select,dropdown,dialog,date-picker,time-picker,input-tag,inline}/src/**` and `index.ts` | Modified  | EP internal imports replaced with own code / `g-utils` / `g-hooks` / `g-form`                                                                                                                                                                                                     |
+| `.eslintrc.cjs`                                                                                                                                       | Modified  | Remove the 13 migrated packages from `excludedFiles` as each lands                                                                                                                                                                                                                |
+| Consumers: `front-b2b`, `front-admin`                                                                                                                 | Validated | Incremental publish per WU; b2b real-copy validation on branch `ander/update/version-packages` with the exact published versions (never symlinks — symlinks strip base CSS / Tailwind `@apply` processing, documented v3 gotcha)                                                  |
+
+## Risks
+
+| Risk                                                                                                                                                                                                                                       | Likelihood                | Mitigation                                                                                                                                                   |
+| ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **config shim boundary** — the DS-native `useGlobalConfig` replacement must reproduce the EP ConfigProvider provide/inject contract that the permanent `config-provider` island still backs; a mismatch silently regresses dialog defaults | High effort / Medium risk | Dedicated design pass; unit tests for the shim's resolution of locale/zIndex/namespace defaults; validate `dialog` in b2b before removing its ESLint exclude |
+| **`dropdown` fan-out** — widest internal dependency surface in the slice (focus-trap, roving-focus-group, collection, tooltip, scrollbar, icon-font, slot, popper)                                                                         | High (review budget)      | Its own dedicated WU; do NOT bundle with `select`; keep each WU ≤400 lines                                                                                   |
+| **`select` must follow `tooltip`** — `select` currently imports `TooltipInstance`/`useTooltipContentProps` straight from `element-plus`, not from the DS `tooltip`; wrong ordering yields a broken re-point                                | Medium                    | Sequence `select` strictly after `tooltip`; re-point to `@flash-global66/g-tooltip`, not to an EP subpath                                                    |
+| **`date-picker` debt now in-scope** — fixing `no-unused-vars` inside the migration widens the diff                                                                                                                                         | Low                       | Scope the cleanup to touched files; keep it inside the date-picker WU so `--max-warnings 0` stays green without a separate chore                             |
+| **Copied EP algorithms drift** (e.g. `usePopper`, `useDraggable`, `createModelToggleComposable`)                                                                                                                                           | Medium                    | Copy exactly, no improvements; dedicated unit test per hook before wiring                                                                                    |
+| **Already-extracted hooks not auto-consumed** — untouched packages still import existing hooks from EP (`time-picker` → `useFocusController`)                                                                                              | Medium                    | Every in-scope package gets an explicit re-point pass, even where no new hook work exists                                                                    |
+| Symlinked b2b validation hides CSS/`@apply` breakage                                                                                                                                                                                       | High if misused           | Mandatory real-copy validation per migration WU on `ander/update/version-packages`                                                                           |
+
+## Open Questions (for sdd-spec / sdd-design)
+
+- **`useForwardRef` vs `useForwardRefDirective` naming** — EP splits these into two distinct APIs (`useForwardRef` in `popper/trigger`, `useForwardRefDirective` + `FORWARD_REF_INJECTION_KEY` in `slot/only-child`). Design should confirm whether to mirror EP's split or unify into one g-hooks family, to avoid future consumer API drift.
+- **`useEmptyValues` placement** — generic `g-hooks` vs form-context `g-form`? EP's real impl composes with form context for `emptyValues`/`valueOnClear` prop cascading. Needs the same acyclic-placement analysis v3 did for `useFormSize`.
+- **DS-native config shim contract** — exact shape of the provide/inject the shim exposes, and whether it reads from the existing `config-provider` island or establishes its own DS provider. Design decision; flagged as the highest-risk item.
+- **Stale `radio-group` → `radio/radio.type` reference** — `radio-group` is a permanent island but references `components/radio` (migrated in v3). Sanity-check during design so v4 doesn't inherit an unrelated cross-package coupling bug; do not silently fix inside an unrelated WU.

--- a/openspec/changes/ep-extraction-v4/specs/eslint-ep-import-guard/spec.md
+++ b/openspec/changes/ep-extraction-v4/specs/eslint-ep-import-guard/spec.md
@@ -1,0 +1,48 @@
+# Delta for eslint-ep-import-guard
+
+## MODIFIED Requirements
+
+### Requirement: island-override-exclusion
+
+The rule MUST include exclusions for the 8 permanent island packages and the packages not yet migrated off element-plus internals, so their legitimate element-plus imports are not blocked. As of `ep-extraction-v4`, `focus-trap`, `slot`, `overlay`, `scrollbar`, `popper`, `tooltip`, `select`, `dropdown`, `dialog`, `date-picker`, `time-picker`, `input-tag`, and `inline` are migrated and MUST NO LONGER appear in `excludedFiles` — they are guarded like any other component source path. `toast`, `table`, `pagination`, `collapse`, and `input-number` remain excluded (deferred to `ep-extraction-v5` or beyond).
+(Previously: only `checkbox`/`radio`/`switch`/`segmented`/`input` were migrated as of `ep-extraction-v3`; the 13 v4 packages plus `toast`/`table`/`pagination`/`collapse`/`input-number` were all still excluded.)
+
+#### Scenario: island import not blocked
+
+- GIVEN the guard active and exclusions configured for island/deferred packages
+- WHEN a file in `components/badge/index.ts` (island) imports `from 'element-plus'`
+- THEN ESLint reports no error
+
+#### Scenario: v4-migrated packages are no longer excluded
+
+- GIVEN the 13 v4 packages removed from `excludedFiles`
+- WHEN a file under `components/dropdown/src/**` (or any of the other 12) imports `from 'element-plus'`
+- THEN ESLint reports error `'element-plus' import is restricted`
+
+#### Scenario: remaining deferred packages stay excluded
+
+- GIVEN `table`, `pagination`, `collapse`, and `input-number` are deferred to `ep-extraction-v5`, and `toast` remains unscheduled
+- WHEN a file under any of their `src/**` imports `from 'element-plus'`
+- THEN ESLint reports no error
+
+## ADDED Requirements
+
+### Requirement: exclude-removed-per-work-unit
+
+Each of the 13 v4-migrated packages' `excludedFiles` entries MUST be removed individually, at that package's own migration work unit boundary, not batched into one edit at the end of the slice.
+
+#### Scenario: lint passes at each package's guard update
+
+- GIVEN one of the 13 v4 packages finishes migration and its unit tests are green
+- WHEN `.eslintrc.cjs` is updated to remove that package's exclude
+- THEN `yarn lint --max-warnings 0` passes immediately after that update, before the next package's work unit starts
+
+## Non-Goals (v4 delta)
+
+- Guarding SCSS/style imports — unchanged from base spec
+- Removing `toast`, `table`, `pagination`, `collapse`, or `input-number` from `excludedFiles` in this change
+
+## References
+
+- Change: `ep-extraction-v4` (proposal obs #275)
+- Base spec: `openspec/specs/eslint-ep-import-guard/spec.md`

--- a/openspec/changes/ep-extraction-v4/specs/g-hooks-package/spec.md
+++ b/openspec/changes/ep-extraction-v4/specs/g-hooks-package/spec.md
@@ -1,0 +1,54 @@
+# Delta for g-hooks-package
+
+## ADDED Requirements
+
+### Requirement: popper-overlay-composables-added
+
+`g-hooks` MUST export the following composables, added in `ep-extraction-v4`, each replicating its element-plus algorithm exactly: `usePopper`, `usePopperContainer`/`usePopperContainerId`, `useZIndex`, `useForwardRef`/`useForwardRefDirective` (+ `FORWARD_REF_INJECTION_KEY`), `useEscapeKeydown`, `useSameTarget`, `useDelayedToggle`/`useDelayedToggleProps`, `createModelToggleComposable`, `useDraggable`, `whenMouse`, `useLocale`, `useEmptyValues`/`useEmptyValuesProps`, `useCalcInputWidth`.
+
+#### Scenario: popper/overlay composables resolve and behave identically to EP
+
+- GIVEN a consumer importing `usePopper` (or any composable in this set) from `@flash-global66/g-hooks`
+- WHEN called with the same inputs as its pre-migration element-plus call
+- THEN it resolves without a build step and produces identical observable output
+
+### Requirement: shared-hook-single-ownership
+
+Where a composable is shared by more than one in-scope package (e.g. `useSameTarget` by `overlay`+`dialog`, `useCalcInputWidth` by `select`+`input-tag`, `useLocale` by `dropdown`/`date-picker`/`time-picker`), it MUST be built exactly once, owned by the first consumer in the migration's topological order, and re-pointed (not re-implemented) by later consumers.
+
+#### Scenario: second consumer re-points to the existing composable
+
+- GIVEN `useSameTarget` already built and shipped for `overlay`
+- WHEN `dialog` is migrated afterward
+- THEN `dialog` imports the same `useSameTarget` from `@flash-global66/g-hooks` without a second implementation being added
+
+### Requirement: dialog-config-composable-added
+
+`g-hooks` MUST export a DS-native composable that resolves global config (locale/zIndex/namespace/message defaults) without depending on element-plus's `useGlobalConfig`, for exclusive use by `dialog` in this slice.
+
+#### Scenario: config composable resolves defaults with and without a provider ancestor
+
+- GIVEN the DS-native config composable, with and without a DS config provider ancestor present
+- WHEN called in each case
+- THEN it resolves the ancestor's values when present, and the same fallback defaults element-plus used when absent
+
+### Requirement: v4-hooks-unit-tested
+
+Every composable added in `ep-extraction-v4` MUST ship a Vitest unit test file. Tests MUST be unit-only (no DOM/integration), and the full suite MUST pass via `yarn test:run`.
+
+#### Scenario: full suite green after additions
+
+- GIVEN all v4 composables implemented with unit tests
+- WHEN `yarn test:run` executes
+- THEN all tests pass, including the new v4 hook tests
+
+## Non-Goals (v4 delta)
+
+- Building/bundling g-hooks as a distributable artifact (stays source-only) — unchanged from base spec
+- Final placement of `useLocale`/`useEmptyValues` (`g-hooks` vs `g-form`) — decided by design (open question in the proposal); this delta only requires the composables exist and are unit-tested, not their exact host package
+- Table-family composables (`vRepeatClick`, `Mousewheel` directive) — deferred to `ep-extraction-v5`
+
+## References
+
+- Change: `ep-extraction-v4` (proposal obs #275)
+- Base spec: `openspec/specs/g-hooks-package/spec.md`

--- a/openspec/changes/ep-extraction-v4/specs/g-utils-extended/spec.md
+++ b/openspec/changes/ep-extraction-v4/specs/g-utils-extended/spec.md
@@ -1,0 +1,39 @@
+# Delta for g-utils-extended
+
+## ADDED Requirements
+
+### Requirement: popper-overlay-utils-added
+
+`g-utils` MUST export the following pure helpers/types/directives, added in `ep-extraction-v4`, each replicating its element-plus algorithm exactly: `castArray`, `getStyle`, `composeRefs`, `isFocusable`, `iconPropType`, `PatchFlags`, and the `ClickOutside` directive.
+
+#### Scenario: new utils resolve and behave identically to EP
+
+- GIVEN a consumer importing one of the new v4 utilities from `@flash-global66/g-utils`
+- WHEN called with the same inputs as its pre-migration element-plus call
+- THEN it resolves without a build step and returns/behaves identically
+
+#### Scenario: ClickOutside directive fires on outside interaction only
+
+- GIVEN `ClickOutside` bound to an element inside a mounted component
+- WHEN a click occurs outside the bound element versus inside it
+- THEN the directive's callback fires only for the outside click
+
+### Requirement: v4-utils-unit-tested
+
+Every utility/directive added in `ep-extraction-v4` MUST ship a Vitest unit test file. Tests MUST be unit-only (no DOM/integration beyond directive-local assertions), and the full suite MUST pass via `yarn test:run`.
+
+#### Scenario: full suite green after additions
+
+- GIVEN all v4 utilities implemented with unit tests
+- WHEN `yarn test:run` executes
+- THEN all tests pass, including the new v4 utility tests
+
+## Non-Goals (v4 delta)
+
+- Depending on g-hooks or g-form from g-utils — unchanged from base spec
+- Table-family utilities — deferred to `ep-extraction-v5`
+
+## References
+
+- Change: `ep-extraction-v4` (proposal obs #275)
+- Base spec: `openspec/specs/g-utils-extended/spec.md`

--- a/openspec/changes/ep-extraction-v4/specs/popper-overlay-migration/spec.md
+++ b/openspec/changes/ep-extraction-v4/specs/popper-overlay-migration/spec.md
@@ -1,0 +1,124 @@
+# Spec: popper-overlay-migration
+
+> Artifact store: hybrid. Change: `ep-extraction-v4`. New capability (v3's `form-control-migration` covers the light form controls; this covers the popper/overlay family).
+
+## Purpose
+
+Migrate 13 popper/overlay-family packages — `focus-trap`, `slot`, `overlay`, `scrollbar`, `popper`, `tooltip`, `select`, `dropdown`, `dialog`, `date-picker`, `time-picker`, `input-tag`, `inline` — off `element-plus` internal imports onto the design system's own code, `g-utils`, `g-hooks`, and `g-form`, with zero public API change. `table`, `pagination`, `collapse`, and `input-number` are explicitly excluded (deferred to `ep-extraction-v5`).
+
+## Requirements
+
+### Requirement: zero-ep-imports-per-migrated-package
+
+For each of the 13 in-scope packages, no file under `components/<pkg>/src/**` nor `components/<pkg>/index.ts` MUST import any specifier starting with `element-plus`.
+
+#### Scenario: grep audit passes per package
+
+- GIVEN a migrated package from the 13 in-scope list
+- WHEN `grep -r "from ['\"]element-plus" components/<pkg>/src/ components/<pkg>/index.ts` runs
+- THEN zero matches are returned
+
+### Requirement: public-api-and-styles-preserved
+
+Each migrated package's props, emits, slots, and exported types MUST be identical before and after migration. The package's SCSS styles export path (e.g. `/styles.scss`) MUST resolve unchanged. This is an internal refactor, not a breaking change for `front-b2b`/`front-admin`.
+
+#### Scenario: consumers compile and render unchanged
+
+- GIVEN a fixed set of props/emits/slots usage for a migrated component, exercised before and after migration
+- WHEN compared
+- THEN no prop/emit/slot/exported type is added, removed, renamed, or retyped, and rendered output is unchanged
+
+#### Scenario: styles import path unaffected
+
+- GIVEN a consumer importing `@flash-global66/g-<pkg>/styles.scss`
+- WHEN resolved before and after migration
+- THEN the same path resolves to equivalent compiled CSS
+
+### Requirement: barrel-exports-stable
+
+Each migrated package's `index.ts` public barrel MUST export the exact same set of symbols (components, types, constants) before and after migration.
+
+#### Scenario: barrel export diff is empty
+
+- GIVEN a migrated package's `index.ts` before and after migration
+- WHEN the exported symbol names are diffed
+- THEN the sets are identical
+
+### Requirement: reused-composables-repointed
+
+Each in-scope package MUST import already-extracted composables/utilities (`useNamespace`, `useId`, `useIdInjection`, `useGlobalSize`, `useAriaProps`, `useSizeProp`, `useComposition`, `useFocusController`, `useFormSize`, type guards, prop builders, event constants) from `@flash-global66/g-utils`/`@flash-global66/g-hooks`/`@flash-global66/g-form`, not from `element-plus` — even where no new hook is built for that package.
+
+#### Scenario: pre-extracted hook re-pointed without new hook work
+
+- GIVEN `time-picker` or `input-tag`, which import already-extracted hooks straight from `element-plus`
+- WHEN migrated
+- THEN they import the same hooks from `@flash-global66/g-hooks`/`@flash-global66/g-utils` with unchanged observable behavior
+
+### Requirement: new-hook-algorithms-copied-exactly
+
+Every newly-built hook/directive consumed by an in-scope package (see `g-hooks-package` and `g-utils-extended` deltas) MUST replicate the element-plus algorithm's observable behavior exactly — no behavioral "improvements".
+
+#### Scenario: hook behavior parity with EP original
+
+- GIVEN a newly-built hook (e.g. `usePopper`, `useDraggable`, `createModelToggleComposable`) wired into its first consumer package
+- WHEN exercised with the same inputs as the pre-migration element-plus call
+- THEN the observable output/behavior matches the pre-migration implementation
+
+### Requirement: dialog-config-shim-adopted
+
+`dialog` MUST NOT import `useGlobalConfig` from `element-plus`. It MUST resolve global config (locale/zIndex/namespace/message defaults) via a DS-native composable (exact contract defined by design), reproducing the observable defaults element-plus's `ConfigProvider` produced.
+
+#### Scenario: dialog defaults resolve with an ancestor provider
+
+- GIVEN a DS-native config provider ancestor supplying a non-default locale/zIndex
+- WHEN `dialog` reads its defaults via the DS-native composable
+- THEN it resolves the ancestor's locale/zIndex, matching pre-migration `useGlobalConfig` behavior
+
+#### Scenario: dialog defaults resolve without an ancestor provider
+
+- GIVEN no DS-native config provider ancestor
+- WHEN `dialog` reads its defaults
+- THEN it falls back to the same defaults element-plus's `ConfigProvider` used absent an ancestor
+
+### Requirement: packaging-convention-followed
+
+Each of the 13 migrated packages MUST declare `@flash-global66/g-utils` and `@flash-global66/g-hooks` in `dependencies`, and keep `g-form`, `g-icon-font`, `element-plus`, and `vue` in `peerDependencies`.
+
+#### Scenario: package.json matches convention
+
+- GIVEN a migrated package's `package.json`
+- WHEN inspected
+- THEN `g-utils`/`g-hooks` are listed under `dependencies` and the peer set is unchanged from the v3 convention
+
+### Requirement: date-picker-lint-debt-resolved
+
+`date-picker`'s migration work unit MUST also resolve its pre-existing `no-unused-vars` warnings, scoped to files touched by the migration.
+
+#### Scenario: lint clean after migration
+
+- GIVEN `date-picker` migrated
+- WHEN `yarn lint --max-warnings 0` runs scoped to `components/date-picker`
+- THEN no `no-unused-vars` warnings remain
+
+### Requirement: migration-gated-by-green-tests
+
+For each of the 13 packages, all relevant unit tests (existing plus new hook/util tests) MUST pass via `yarn test:run` before that package's ESLint exclude is removed.
+
+#### Scenario: tests green gates exclude removal
+
+- GIVEN a migration work unit for one of the 13 packages
+- WHEN `yarn test:run` executes as part of that work unit
+- THEN it passes with no failing tests before `.eslintrc.cjs` is updated to remove that package's exclude
+
+## Non-Goals
+
+- Migrating `table`, `pagination`, `collapse`, or `input-number` (deferred to `ep-extraction-v5`)
+- Touching any of the 8 permanent islands (`badge`, `menu`, `config-provider`, `popover`, `radio-group`, `form-item`, `skeleton`, `infinite-scroll`) — they keep `element-plus` as a genuine dependency by design
+- Removing `element-plus` from any package's `package.json`/`peerDependencies`, anywhere in the monorepo
+- Any DOM/integration/mounted test (unit-only policy)
+
+## References
+
+- Depends on: `openspec/specs/g-utils-extended/spec.md`, `openspec/specs/g-hooks-package/spec.md`, `openspec/specs/g-form/spec.md`, `openspec/specs/eslint-ep-import-guard/spec.md`
+- Change: `ep-extraction-v4` (proposal obs #275 / `openspec/changes/ep-extraction-v4/proposal.md`)
+- Precedent: `openspec/specs/form-control-migration/spec.md` (v3, same pattern for the light form controls)

--- a/openspec/changes/ep-extraction-v4/tasks.md
+++ b/openspec/changes/ep-extraction-v4/tasks.md
@@ -53,20 +53,20 @@ Every child PR body must include this diagram with the current PR marked `📍`,
 
 Publishes: `focus-trap`. Est. ~200 changed lines. Requirements: `popper-overlay-migration` → `zero-ep-imports-per-migrated-package`, `public-api-and-styles-preserved`, `barrel-exports-stable`, `new-hook-algorithms-copied-exactly`, `packaging-convention-followed`, `migration-gated-by-green-tests`; `g-hooks-package` → `popper-overlay-composables-added`, `v4-hooks-unit-tested`; `g-utils-extended` → `popper-overlay-utils-added`, `v4-utils-unit-tested`; `eslint-ep-import-guard` → `exclude-removed-per-work-unit`.
 
-- [ ] T1.1 Read EP's `useEscapeKeydown` from `node_modules/element-plus/es/hooks/use-escape-keydown/index.mjs` (2.9.7, source of truth). Cross-check against `../element-plus/packages/hooks/use-escape-keydown/` (sibling, 2.8.3-1908) — diff any signature/behavior drift before proceeding.
-- [ ] T1.2 Write failing unit test for `useEscapeKeydown` (invokes handler only on `Escape` keydown; no-op for other keys; cleans up listener on unmount) — new `common/g-hooks/tests/composables/useEscapeKeydown.spec.ts`.
-- [ ] T1.3 Implement `useEscapeKeydown` in `common/g-hooks/src/composables/useEscapeKeydown.ts` — byte-exact copy of the 2.9.7 algorithm. Run `yarn test:run` → green.
-- [ ] T1.4 Read EP's `isFocusable` from `node_modules/element-plus/es/utils/dom/aria.mjs` (2.9.7). Cross-check sibling `../element-plus/packages/utils/dom/aria.ts`.
-- [ ] T1.5 Write failing unit test for `isFocusable` (true for links/buttons/inputs/tabindex>=0 elements; false for disabled/tabindex=-1/plain divs) — new `common/g-utils/tests/utils/dom.util.spec.ts` (or existing dom-utils spec file).
-- [ ] T1.6 Implement `isFocusable` in `common/g-utils/src/utils/dom.util.ts` (or equivalent existing dom-utils module) — byte-exact copy. Run `yarn test:run` → green.
-- [ ] T1.7 Update `common/g-hooks/src/index.ts` and `common/g-utils/src/index.ts` barrels to export the 2 new symbols.
-- [ ] T1.8 Migrate `components/focus-trap/src/**`: re-point `isString`/`isElement`/`EVENT_CODE` → `@flash-global66/g-utils`; wire the new `useEscapeKeydown`/`isFocusable`. Zero public API change (props/emits/slots/types + `/styles.scss` path untouched).
-- [ ] T1.9 Grep-verify zero `from ['"]element-plus` matches under `components/focus-trap/src/**` and `index.ts` (SCSS `@use` theme imports and comments excluded).
-- [ ] T1.10 Confirm `focus-trap`'s `package.json` declares `g-utils`/`g-hooks` in `dependencies` (not `peerDependencies`); `element-plus`/`vue` (if referenced) stay in `peerDependencies` — packaging convention.
-- [ ] T1.11 Remove `'components/focus-trap/**'` from `excludedFiles` in `.eslintrc.cjs`. Run `yarn lint --max-warnings 0` — must pass with the exclude removed.
-- [ ] T1.12 `yarn build` succeeds for `focus-trap`. Full `yarn test:run` green, no regressions.
-- [ ] T1.13 Validate in `front-b2b` using a **real copy** in `node_modules` (never a symlink) on `ander/update/version-packages` with the exact published version.
-- [ ] T1.14 Commit as one work unit (`feat(focus-trap): migrate off element-plus internals`), open PR #1 (stacked-to-main, target `main`), Lerna-publish `focus-trap` (+ `g-hooks`/`g-utils` if their new exports warrant a publish) on merge.
+- [x] T1.1 Read EP's `useEscapeKeydown` from `node_modules/element-plus/es/hooks/use-escape-keydown/index.mjs` (2.9.7, source of truth). Cross-check against `../element-plus/packages/hooks/use-escape-keydown/` (sibling, 2.8.3-1908) — diff any signature/behavior drift before proceeding.
+- [x] T1.2 Write failing unit test for `useEscapeKeydown` (invokes handler only on `Escape` keydown; no-op for other keys; cleans up listener on unmount) — new `common/g-hooks/tests/composables/useEscapeKeydown.spec.ts`.
+- [x] T1.3 Implement `useEscapeKeydown` in `common/g-hooks/src/composables/useEscapeKeydown.ts` — byte-exact copy of the 2.9.7 algorithm. Run `yarn test:run` → green.
+- [x] T1.4 Read EP's `isFocusable` from `node_modules/element-plus/es/utils/dom/aria.mjs` (2.9.7). Cross-check sibling `../element-plus/packages/utils/dom/aria.ts`.
+- [x] T1.5 Write failing unit test for `isFocusable` (true for links/buttons/inputs/tabindex>=0 elements; false for disabled/tabindex=-1/plain divs) — new `common/g-utils/tests/utils/dom.util.spec.ts` (or existing dom-utils spec file).
+- [x] T1.6 Implement `isFocusable` in `common/g-utils/src/utils/dom.util.ts` (or equivalent existing dom-utils module) — byte-exact copy. Run `yarn test:run` → green.
+- [x] T1.7 Update `common/g-hooks/src/index.ts` and `common/g-utils/src/index.ts` barrels to export the 2 new symbols.
+- [x] T1.8 Migrate `components/focus-trap/src/**`: re-point `isString`/`isElement`/`EVENT_CODE` → `@flash-global66/g-utils`; wire the new `useEscapeKeydown`/`isFocusable`. Zero public API change (props/emits/slots/types + `/styles.scss` path untouched).
+- [x] T1.9 Grep-verify zero `from ['"]element-plus` matches under `components/focus-trap/src/**` and `index.ts` (SCSS `@use` theme imports and comments excluded).
+- [x] T1.10 Confirm `focus-trap`'s `package.json` declares `g-utils`/`g-hooks` in `dependencies` (not `peerDependencies`); `element-plus`/`vue` (if referenced) stay in `peerDependencies` — packaging convention. (element-plus dropped entirely from peerDependencies — focus-trap has zero remaining EP imports and no SCSS theme dependency on it; `vue`/`lodash-unified` stay in peerDependencies.)
+- [x] T1.11 Remove `'components/focus-trap/**'` from `excludedFiles` in `.eslintrc.cjs`. Run `yarn lint --max-warnings 0` — must pass with the exclude removed. (Scoped lint on focus-trap/g-hooks/g-utils: 0 errors. Full-repo lint has 129 pre-existing errors in unrelated files — table/time-picker/stories — confirmed present before this WU and untouched by it.)
+- [x] T1.12 `yarn build` succeeds for `focus-trap`. Full `yarn test:run` green, no regressions. (234/234 tests green across 31 files, monorepo-wide.)
+- [ ] T1.13 Validate in `front-b2b` using a **real copy** in `node_modules` (never a symlink) on `ander/update/version-packages` with the exact published version. **Deferred**: requires a merged + Lerna-published `focus-trap` version and CodeCommit network access to `front-b2b`, neither available during `sdd-apply`. Do after merge/publish.
+- [ ] T1.14 Commit as one work unit (`feat(focus-trap): migrate off element-plus internals`), open PR #1 (stacked-to-main, target `main`), Lerna-publish `focus-trap` (+ `g-hooks`/`g-utils` if their new exports warrant a publish) on merge. **Partially done**: implementation committed locally as 3 work-unit commits (`16f1316`, `6be043e`, `6f0ca2f`) on branch `feat/ds-ep-v4-wu1-focus-trap`, plus a docs commit (`b58b869`) for the SDD planning artifacts. PR creation and Lerna publish are deferred to the orchestrator/reviewer per this apply phase's explicit instruction to stop after local commit.
 
 ## WU-2 — `slot` (deep migration; near-leaf, no dependencies)
 

--- a/openspec/changes/ep-extraction-v4/tasks.md
+++ b/openspec/changes/ep-extraction-v4/tasks.md
@@ -1,0 +1,327 @@
+# Tasks: ep-extraction-v4
+
+> Artifact store: hybrid. Depends on `spec.md` files under `specs/**` + `design.md` (same dir; engram `sdd/ep-extraction-v4/spec` #276, `sdd/ep-extraction-v4/design` #277).
+> Strict TDD is ACTIVE. Test runner: `yarn test:run` (Vitest, unit-only, no DOM/integration). Env: node v20.19.3 + dummy `GBP_PACKAGE_TOKEN` for yarn/npx.
+> Chain strategy: **stacked-to-main** (v3 precedent) — each WU is its own PR merging to `main` in dependency order (proposal §Approach, design §5). Incremental Lerna publish per merged WU. `front-b2b` real-copy validation (never symlinks) on `ander/update/version-packages` after each migration WU.
+>
+> **CRITICAL correctness mandate — bake into every hook task below:** element-plus is the source of truth. VERSION-OF-RECORD is `node_modules/element-plus@2.9.7` (the version actually consumed by this monorepo). The sibling checkout `../element-plus/packages/**` is at `2.8.3-1908-gcbc55c730d`, NOT pinned to 2.9.7 — read the sibling TypeScript source for readability, but before copying any algorithm, diff it against the compiled output under `node_modules/element-plus/es/hooks/<hook>/` (or `es/components/<pkg>/src/hooks/...`) to confirm 2.9.7 behavior matches. Copy EP byte-exact, no "improvements". Every ported hook/directive gets a Vitest unit test asserting behavior parity with the EP original, authored **before** the implementation (red → green).
+>
+> Radio-group's stale `radio/radio.type` import (design §2.4) is a confirmed latent bug — **out of scope for every WU below**. Do not fix it inside any task in this file.
+
+## Dependency graph (WU level)
+
+```
+WU-1 (focus-trap)   WU-2 (slot)   WU-3 (overlay)   WU-4 (scrollbar)
+   │  useEscapeKeydown  │  forward-ref     │  useSameTarget    (pure re-point,
+   │  isFocusable        │  family          │  PatchFlags        independent)
+   │                    │                  │
+   └─────────┬──────────┘                  │
+             ▼                             │
+          WU-5 (popper) ◄───────────────────
+          usePopper, useZIndex
+             │
+             ▼
+          WU-6 (tooltip)
+          useDelayedToggle*, createModelToggleComposable, usePopperContainer*
+             │
+        ┌────┴─────────────────┐
+        ▼                      ▼
+   WU-8 (select)          WU-9 (dropdown) ◄── WU-4, WU-7
+   useEmptyValues*,       whenMouse, useLocale
+   useCalcInputWidth,     (own WU — never bundled with select,
+   ClickOutside            widest fan-out, design §3/§6)
+        │                      │
+        └──────────┬───────────┘
+                    ▼
+            WU-10 (date-picker)          WU-11 (time-picker) ◄── WU-6, WU-9, WU-8
+            castArray + lint-debt fix    getStyle, vRepeatClick
+                    │
+                    ▼
+            WU-12 (input-tag) ◄── WU-8
+
+WU-13 (inline) — fully independent, no popper-chain dependency, smallest WU
+WU-7 (dialog) ◄── WU-3, WU-5 — parallel branch off overlay+popper, independent of the tooltip chain
+```
+
+Every child PR body must include this diagram with the current PR marked `📍`, plus start/end state, prior dependencies, follow-up work, and out-of-scope items (chained-pr skill Output Contract).
+
+**Parallelism:** WU-1..WU-4 are mutually independent (near-leaves) and may be developed concurrently. Once WU-5 (popper) lands, the tooltip branch (WU-6→WU-8/WU-9), the dialog branch (WU-7), and — after WU-8/WU-9 — the picker branch (WU-10/WU-11) proceed in parallel. WU-13 (inline) has no dependency on the popper chain at all and can land any time. WU-9 (dropdown) is never bundled with WU-8 (select) — its own PR, per design §3/§6 risk table.
+
+---
+
+## WU-1 — `focus-trap` (deep migration; near-leaf, no dependencies)
+
+Publishes: `focus-trap`. Est. ~200 changed lines. Requirements: `popper-overlay-migration` → `zero-ep-imports-per-migrated-package`, `public-api-and-styles-preserved`, `barrel-exports-stable`, `new-hook-algorithms-copied-exactly`, `packaging-convention-followed`, `migration-gated-by-green-tests`; `g-hooks-package` → `popper-overlay-composables-added`, `v4-hooks-unit-tested`; `g-utils-extended` → `popper-overlay-utils-added`, `v4-utils-unit-tested`; `eslint-ep-import-guard` → `exclude-removed-per-work-unit`.
+
+- [ ] T1.1 Read EP's `useEscapeKeydown` from `node_modules/element-plus/es/hooks/use-escape-keydown/index.mjs` (2.9.7, source of truth). Cross-check against `../element-plus/packages/hooks/use-escape-keydown/` (sibling, 2.8.3-1908) — diff any signature/behavior drift before proceeding.
+- [ ] T1.2 Write failing unit test for `useEscapeKeydown` (invokes handler only on `Escape` keydown; no-op for other keys; cleans up listener on unmount) — new `common/g-hooks/tests/composables/useEscapeKeydown.spec.ts`.
+- [ ] T1.3 Implement `useEscapeKeydown` in `common/g-hooks/src/composables/useEscapeKeydown.ts` — byte-exact copy of the 2.9.7 algorithm. Run `yarn test:run` → green.
+- [ ] T1.4 Read EP's `isFocusable` from `node_modules/element-plus/es/utils/dom/aria.mjs` (2.9.7). Cross-check sibling `../element-plus/packages/utils/dom/aria.ts`.
+- [ ] T1.5 Write failing unit test for `isFocusable` (true for links/buttons/inputs/tabindex>=0 elements; false for disabled/tabindex=-1/plain divs) — new `common/g-utils/tests/utils/dom.util.spec.ts` (or existing dom-utils spec file).
+- [ ] T1.6 Implement `isFocusable` in `common/g-utils/src/utils/dom.util.ts` (or equivalent existing dom-utils module) — byte-exact copy. Run `yarn test:run` → green.
+- [ ] T1.7 Update `common/g-hooks/src/index.ts` and `common/g-utils/src/index.ts` barrels to export the 2 new symbols.
+- [ ] T1.8 Migrate `components/focus-trap/src/**`: re-point `isString`/`isElement`/`EVENT_CODE` → `@flash-global66/g-utils`; wire the new `useEscapeKeydown`/`isFocusable`. Zero public API change (props/emits/slots/types + `/styles.scss` path untouched).
+- [ ] T1.9 Grep-verify zero `from ['"]element-plus` matches under `components/focus-trap/src/**` and `index.ts` (SCSS `@use` theme imports and comments excluded).
+- [ ] T1.10 Confirm `focus-trap`'s `package.json` declares `g-utils`/`g-hooks` in `dependencies` (not `peerDependencies`); `element-plus`/`vue` (if referenced) stay in `peerDependencies` — packaging convention.
+- [ ] T1.11 Remove `'components/focus-trap/**'` from `excludedFiles` in `.eslintrc.cjs`. Run `yarn lint --max-warnings 0` — must pass with the exclude removed.
+- [ ] T1.12 `yarn build` succeeds for `focus-trap`. Full `yarn test:run` green, no regressions.
+- [ ] T1.13 Validate in `front-b2b` using a **real copy** in `node_modules` (never a symlink) on `ander/update/version-packages` with the exact published version.
+- [ ] T1.14 Commit as one work unit (`feat(focus-trap): migrate off element-plus internals`), open PR #1 (stacked-to-main, target `main`), Lerna-publish `focus-trap` (+ `g-hooks`/`g-utils` if their new exports warrant a publish) on merge.
+
+## WU-2 — `slot` (deep migration; near-leaf, no dependencies)
+
+Publishes: `slot`. Est. ~220 changed lines. Requirements: same `popper-overlay-migration` set as WU-1 plus `g-hooks-package` → `shared-hook-single-ownership` (this WU is the sole owner of the forward-ref family, design §2.2).
+
+- [ ] T2.1 Read EP's forward-ref module from `node_modules/element-plus/es/hooks/use-forward-ref/index.mjs` (2.9.7) — the single module exporting `useForwardRef`, `useForwardRefDirective`, `FORWARD_REF_INJECTION_KEY`. Cross-check sibling `../element-plus/packages/hooks/use-forward-ref/`.
+- [ ] T2.2 Write failing unit tests asserting the **shared-symbol handshake** (design §2.2, correctness requirement, not style): `useForwardRef` provides `FORWARD_REF_INJECTION_KEY`; `useForwardRefDirective`'s returned directive object (`mounted`/`updated`/`unmounted`) calls `setForwardRef` with the bound element on mount/update and `undefined` on unmount; both functions reference the exact same exported `Symbol()` instance — new `common/g-hooks/tests/composables/useForwardRef.spec.ts`.
+- [ ] T2.3 Implement **one module** `common/g-hooks/src/composables/useForwardRef.ts` exporting all three (`useForwardRef`, `useForwardRefDirective`, `FORWARD_REF_INJECTION_KEY`), mirroring EP's own file layout exactly — byte-exact copy. Run `yarn test:run` → green.
+- [ ] T2.4 Update `common/g-hooks/src/index.ts` barrel to export the 3 new symbols.
+- [ ] T2.5 Migrate `components/slot/src/**`: re-point `NOOP`/`debugWarn`/`isObject`/`useNamespace` → `@flash-global66/g-utils`; wire the new forward-ref family. Zero public API change.
+- [ ] T2.6 Grep-verify zero `from ['"]element-plus` matches under `components/slot/src/**` and `index.ts`.
+- [ ] T2.7 Confirm `slot`'s `package.json` packaging convention (g-utils/g-hooks in `dependencies`).
+- [ ] T2.8 Remove `'components/slot/**'` from `excludedFiles` in `.eslintrc.cjs`. `yarn lint --max-warnings 0` passes.
+- [ ] T2.9 `yarn build` succeeds for `slot`. Full `yarn test:run` green.
+- [ ] T2.10 Validate in `front-b2b` (real copy, `ander/update/version-packages`).
+- [ ] T2.11 Commit as one work unit (`feat(slot): migrate off element-plus internals, add forward-ref family to g-hooks`), open PR #2 (parallel to PR #1, both target `main`), Lerna-publish on merge.
+
+## WU-3 — `overlay` (deep migration; near-leaf, no dependencies)
+
+Publishes: `overlay`. Est. ~180 changed lines. Requirements: same `popper-overlay-migration`/`g-hooks-package`/`g-utils-extended` set as WU-1; `shared-hook-single-ownership` (owns `useSameTarget`, shared with `dialog`/WU-7).
+
+- [ ] T3.1 Read EP's `useSameTarget` from `node_modules/element-plus/es/hooks/use-same-target/index.mjs` (2.9.7). Cross-check sibling `../element-plus/packages/hooks/use-same-target/`.
+- [ ] T3.2 Write failing unit test for `useSameTarget` (returned `onClick`/`onMousedown`/`onMouseup` only fire the handler when mousedown and mouseup/click targets are the same node — guards against drag-selection-triggered false positives) — new `common/g-hooks/tests/composables/useSameTarget.spec.ts`.
+- [ ] T3.3 Implement `useSameTarget` in `common/g-hooks/src/composables/useSameTarget.ts` — byte-exact copy. Run `yarn test:run` → green.
+- [ ] T3.4 Read EP's `PatchFlags` from `node_modules/element-plus/es/utils/vnode.mjs` (2.9.7 Vue-internal re-export). Cross-check sibling.
+- [ ] T3.5 Write failing unit test for `PatchFlags` (enum/const values match EP's exactly, e.g. `TEXT`, `CLASS`, `STYLE`, `PROPS`, `FULL_PROPS`, `HYDRATE_EVENTS`, `STABLE_FRAGMENT`, `KEYED_FRAGMENT`, `UNKEYED_FRAGMENT`, `NEED_PATCH`, `DYNAMIC_SLOTS`, `DEV_ROOT_FRAGMENT`, `HOISTED`, `BAIL`) — new `common/g-utils/tests/types/vnode.type.spec.ts`.
+- [ ] T3.6 Implement `PatchFlags` in `common/g-utils/src/types/vnode.type.ts` (or equivalent) — byte-exact copy. Run `yarn test:run` → green.
+- [ ] T3.7 Update `common/g-hooks/src/index.ts` and `common/g-utils/src/index.ts` barrels.
+- [ ] T3.8 Migrate `components/overlay/src/**`: re-point `buildProps`/`definePropType` → `@flash-global66/g-utils`; wire `useSameTarget`/`PatchFlags`. Zero public API change.
+- [ ] T3.9 Grep-verify zero `from ['"]element-plus` matches under `components/overlay/src/**` and `index.ts`.
+- [ ] T3.10 Confirm `overlay`'s `package.json` packaging convention.
+- [ ] T3.11 Remove `'components/overlay/**'` from `excludedFiles` in `.eslintrc.cjs`. `yarn lint --max-warnings 0` passes.
+- [ ] T3.12 `yarn build` succeeds for `overlay`. Full `yarn test:run` green.
+- [ ] T3.13 Validate in `front-b2b` (real copy).
+- [ ] T3.14 Commit as one work unit (`feat(overlay): migrate off element-plus internals, add useSameTarget/PatchFlags`), open PR #3 (parallel to PR #1/#2, targets `main`), Lerna-publish on merge.
+
+## WU-4 — `scrollbar` (pure re-point; no dependencies)
+
+Publishes: `scrollbar`. Est. ~80 changed lines. Requirements: `popper-overlay-migration` → `zero-ep-imports-per-migrated-package`, `public-api-and-styles-preserved`, `reused-composables-repointed`, `packaging-convention-followed`, `migration-gated-by-green-tests`; `eslint-ep-import-guard` → `exclude-removed-per-work-unit`.
+
+- [ ] T4.1 Re-point `components/scrollbar/src/**` imports: `useAriaProps` → `@flash-global66/g-hooks`; `useNamespace`/`isClient`/`throwError`/`buildProps` → `@flash-global66/g-utils`. No new hooks built (pure re-point). Zero public API change.
+- [ ] T4.2 Grep-verify zero `from ['"]element-plus` matches under `components/scrollbar/src/**` and `index.ts`.
+- [ ] T4.3 Confirm `scrollbar`'s `package.json` packaging convention.
+- [ ] T4.4 Remove `'components/scrollbar/**'` from `excludedFiles` in `.eslintrc.cjs`. `yarn lint --max-warnings 0` passes.
+- [ ] T4.5 `yarn build` succeeds for `scrollbar`. Full `yarn test:run` green (no new tests expected — pure re-point).
+- [ ] T4.6 Validate in `front-b2b` (real copy).
+- [ ] T4.7 Commit as one work unit (`refactor(scrollbar): re-point imports off element-plus internals`), open PR #4 (parallel to PR #1/#2/#3, targets `main`), Lerna-publish on merge.
+
+## WU-5 — `popper` (deep migration, core; depends on WU-1, WU-2)
+
+Publishes: `popper`. Est. ~380–400 changed lines (highest-drift copy — `usePopper` is the largest ported algorithm; watch the 400-line budget, see Review Workload Forecast). Requirements: `popper-overlay-migration` full set; `g-hooks-package` → `popper-overlay-composables-added`, `shared-hook-single-ownership` (re-points `useForwardRef` from WU-2, `isFocusable` from WU-1), `v4-hooks-unit-tested`.
+
+- [ ] T5.1 Read EP's `usePopper` from `node_modules/element-plus/es/components/popper/src/composables/use-popper.mjs` (2.9.7 — confirm exact path, may differ from sibling's `packages/components/popper/src/composables/`). Cross-check sibling `../element-plus/packages/components/popper/src/composables/use-popper.ts` line-by-line; this is the single highest-drift-risk copy in the whole slice — do not skip the diff.
+- [ ] T5.2 Write failing unit tests for `usePopper` covering: initial `state`/`styles`/`attributes` shape from `@popperjs/core` (or the DS's underlying Popper dependency, whichever `usePopper` wraps per the real EP source), `update()`/`forceUpdate()` trigger a Popper instance re-position, `instanceRef` exposes the underlying instance, and teardown destroys the instance on unmount — new `common/g-hooks/tests/composables/usePopper.spec.ts`.
+- [ ] T5.3 Implement `usePopper` in `common/g-hooks/src/composables/usePopper.ts` — byte-exact copy, no improvements. Run `yarn test:run` → green.
+- [ ] T5.4 Read EP's `useZIndex` from `node_modules/element-plus/es/hooks/use-z-index/index.mjs` (2.9.7). Cross-check sibling.
+- [ ] T5.5 Write failing unit test for `useZIndex` (`initialZIndex` starts from a base constant; `nextZIndex()` increments a shared module-level counter across calls; `currentZIndex` reflects the latest allocated value) — new `common/g-hooks/tests/composables/useZIndex.spec.ts`.
+- [ ] T5.6 Implement `useZIndex` in `common/g-hooks/src/composables/useZIndex.ts` — byte-exact copy. Run `yarn test:run` → green.
+- [ ] T5.7 Update `common/g-hooks/src/index.ts` barrel to export `usePopper`, `useZIndex`.
+- [ ] T5.8 Migrate `components/popper/src/**`: re-point `useForwardRef` → `@flash-global66/g-slot` re-export or `@flash-global66/g-hooks` per WU-2's final export location; `isFocusable` → from WU-1 (`@flash-global66/g-utils`); `useNamespace`/`isClient`/`isNumber`/`isElement`/`buildProps`/`NOOP` → `@flash-global66/g-utils`. Declare `g-slot`/`g-focus-trap`/`g-form` as real dependencies per design §3. Zero public API change.
+- [ ] T5.9 Grep-verify zero `from ['"]element-plus` matches under `components/popper/src/**` and `index.ts`.
+- [ ] T5.10 Confirm `popper`'s `package.json` packaging convention (g-utils/g-hooks/g-slot/g-focus-trap in `dependencies`; g-form/element-plus/vue in `peerDependencies` per its actual usage).
+- [ ] T5.11 Remove `'components/popper/**'` from `excludedFiles` in `.eslintrc.cjs`. `yarn lint --max-warnings 0` passes.
+- [ ] T5.12 `yarn build` succeeds for `popper`. Full `yarn test:run` green.
+- [ ] T5.13 Validate in `front-b2b` (real copy) — this gates every WU downstream (tooltip, dialog, select, dropdown, date-picker, time-picker all depend transitively on popper).
+- [ ] T5.14 **Line-budget checkpoint**: if the actual diff exceeds ~400 lines, split into two sequential commits (e.g. `usePopper`+test, then `useZIndex`+test+package wiring) within the same PR, per the WU-4-in-v3 precedent — do not open a new WU.
+- [ ] T5.15 Commit as one work unit or the split from T5.14 (`feat(popper): migrate off element-plus internals, add usePopper/useZIndex`), open PR #5 (depends on PR #1 + PR #2 merged), Lerna-publish on merge.
+
+## WU-6 — `tooltip` (deep migration; depends on WU-5)
+
+Publishes: `tooltip`. Est. ~350–400 changed lines (3 new hook groups; watch budget). Requirements: `popper-overlay-migration` full set; `g-hooks-package` → `popper-overlay-composables-added`, `v4-hooks-unit-tested`.
+
+- [ ] T6.1 Read EP's `useDelayedToggle`/`useDelayedToggleProps` from `node_modules/element-plus/es/hooks/use-delayed-toggle/index.mjs` (2.9.7). Cross-check sibling.
+- [ ] T6.2 Write failing unit tests for `useDelayedToggle` (`onOpen` waits `showAfter` ms before invoking `open`; `onClose` waits `hideAfter` ms before invoking `close`; `autoClose` triggers `close` after the configured duration once open; rapid open/close cancels pending timers — no double-invoke) — new `common/g-hooks/tests/composables/useDelayedToggle.spec.ts`. Use Vitest fake timers.
+- [ ] T6.3 Implement `useDelayedToggle` + `useDelayedToggleProps` in `common/g-hooks/src/composables/useDelayedToggle.ts` — byte-exact copy. Run `yarn test:run` → green.
+- [ ] T6.4 Read EP's `createModelToggleComposable` from `node_modules/element-plus/es/hooks/use-model-toggle/index.mjs` (2.9.7 — highest-drift copy along with `usePopper`). Cross-check sibling line-by-line.
+- [ ] T6.5 Write failing unit tests for `createModelToggleComposable` (factory returns `use<Name>ModelToggle` + prop/emit definitions; toggling updates the model value; emits fire with correct event names derived from the factory's name argument) — new `common/g-hooks/tests/composables/useModelToggle.spec.ts`.
+- [ ] T6.6 Implement `createModelToggleComposable` in `common/g-hooks/src/composables/useModelToggle.ts` — byte-exact copy. Run `yarn test:run` → green.
+- [ ] T6.7 Read EP's `usePopperContainer`/`usePopperContainerId` from `node_modules/element-plus/es/hooks/use-popper-container/index.mjs` (2.9.7). Cross-check sibling.
+- [ ] T6.8 Write failing unit test for `usePopperContainer`/`usePopperContainerId` (generates/reuses a stable teleport container id; container element is created once and reused across calls) — new `common/g-hooks/tests/composables/usePopperContainer.spec.ts`.
+- [ ] T6.9 Implement `usePopperContainer` + `usePopperContainerId` in `common/g-hooks/src/composables/usePopperContainer.ts` — byte-exact copy. Run `yarn test:run` → green.
+- [ ] T6.10 Update `common/g-hooks/src/index.ts` barrel to export the 3 new hook groups.
+- [ ] T6.11 Migrate `components/tooltip/src/**`: re-point `useId` → `@flash-global66/g-hooks`; `composeEventHandlers`/`EVENT_CODE` → `@flash-global66/g-utils`; wire the 3 new hook groups. Declare `g-popper`/`g-focus-trap`/`g-teleport`/`g-icon-button`/`g-slot` as real dependencies per design §3. Zero public API change.
+- [ ] T6.12 Grep-verify zero `from ['"]element-plus` matches under `components/tooltip/src/**` and `index.ts`.
+- [ ] T6.13 Confirm `tooltip`'s `package.json` packaging convention.
+- [ ] T6.14 Remove `'components/tooltip/**'` from `excludedFiles` in `.eslintrc.cjs`. `yarn lint --max-warnings 0` passes.
+- [ ] T6.15 `yarn build` succeeds for `tooltip`. Full `yarn test:run` green.
+- [ ] T6.16 Validate in `front-b2b` (real copy) — gates WU-8/select's `@flash-global66/g-tooltip` re-point.
+- [ ] T6.17 **Line-budget checkpoint**: split into sequential commits per hook group if the diff exceeds ~400 lines (same fallback pattern as T5.14).
+- [ ] T6.18 Commit as one work unit or the split from T6.17 (`feat(tooltip): migrate off element-plus internals, add delayed-toggle/model-toggle/popper-container hooks`), open PR #6 (depends on PR #5 merged), Lerna-publish on merge.
+
+## WU-7 — `dialog` (deep migration, highest-risk; depends on WU-3, WU-5; parallel branch, independent of the tooltip chain)
+
+Publishes: `dialog`. Est. ~350 changed lines. Requirements: `popper-overlay-migration` → full set plus `dialog-config-shim-adopted` (the highest-risk requirement in the slice, design §2.1); `g-hooks-package` → `dialog-config-composable-added`, `popper-overlay-composables-added`, `v4-hooks-unit-tested`.
+
+- [ ] T7.1 Re-read design §2.1's grounded contract before writing any code: `dialog` reads **exactly one** config key, `namespace`, default `"gui"` (`components/dialog/src/hooks/use-dialog.ts:60-61` in the current EP-coupled source). Confirm this against `node_modules/element-plus/es/components/config-provider/src/hooks/use-global-config.mjs` (2.9.7) — verify the resolution chain (`inject(configProviderContextKey, globalConfig)` → computed with `?? defaultValue`) matches design's transcription exactly; flag any 2.9.7 drift from the sibling checkout before proceeding.
+- [ ] T7.2 Write failing unit tests for the DS-native config shim **first**, per design §2.1's test contract: (a) `useGlobalConfig('namespace', 'gui')` returns `'gui'` with no ancestor provider; (b) returns the provided value when an ancestor called `provideGlobalConfig({ namespace: 'x' })`; (c) the no-arg overload returns the whole context ref; (d) the no-`getCurrentInstance()` path (SSR-like, no active component instance) returns the module-level `globalConfig` ref without throwing — new `common/g-hooks/tests/composables/useGlobalConfig.spec.ts`.
+- [ ] T7.3 Implement `common/g-hooks/src/composables/useGlobalConfig.ts` exactly per design §2.1's code block: `GlobalConfigContext` interface (single `namespace?: string` key, reserved slots commented for future keys), `gConfigProviderContextKey` (own `Symbol`, NOT EP's `configProviderContextKey`), module-level `globalConfig` ref, `useGlobalConfig` single-key + whole-context overloads, `provideGlobalConfig` companion (ships for completeness, not wired by any v4 consumer). Run `yarn test:run` → green.
+- [ ] T7.4 Read EP's `useDraggable` from `node_modules/element-plus/es/hooks/use-draggable/index.mjs` (2.9.7 — highest-drift copy along with `usePopper`/`createModelToggleComposable`). Cross-check sibling line-by-line.
+- [ ] T7.5 Write failing unit tests for `useDraggable` (mousedown on the drag handle attaches move/up listeners; drag updates the target's transform/position within the configured `overflow` bounds; mouseup detaches listeners; disabled when `draggable` is falsy) — new `common/g-hooks/tests/composables/useDraggable.spec.ts`.
+- [ ] T7.6 Implement `useDraggable` in `common/g-hooks/src/composables/useDraggable.ts` — byte-exact copy. Run `yarn test:run` → green.
+- [ ] T7.7 Read EP's `composeRefs` from `node_modules/element-plus/es/utils/vue/refs.mjs` (2.9.7). Cross-check sibling. Confirm it is distinct from the existing `composeEventHandlers` (do not conflate).
+- [ ] T7.8 Write failing unit test for `composeRefs` (merges multiple ref setters/refs into one callback ref; each target ref receives the same element; function refs and ref objects both supported) — new `common/g-utils/tests/utils/refs.util.spec.ts`.
+- [ ] T7.9 Implement `composeRefs` in `common/g-utils/src/utils/refs.util.ts` (or equivalent) — byte-exact copy. Run `yarn test:run` → green.
+- [ ] T7.10 Update `common/g-hooks/src/index.ts` and `common/g-utils/src/index.ts` barrels for the 3 new symbols.
+- [ ] T7.11 Migrate `components/dialog/src/**`: re-point `useSameTarget` from WU-3 (`@flash-global66/g-overlay` or `g-hooks` per its final export location), `useZIndex`/`useId` from WU-5 (`@flash-global66/g-hooks`); `addUnit`/`isClient`/`isBoolean` → `@flash-global66/g-utils`. Wire the new config shim (replacing `useGlobalConfig` from EP entirely — no scoped exception), `useDraggable`, `composeRefs`. Declare `g-focus-trap`/`g-overlay`/`g-teleport`/`g-icon-font`/`g-button` as real dependencies. Zero public API change.
+- [ ] T7.12 Grep-verify zero `from ['"]element-plus` matches under `components/dialog/src/**` and `index.ts` — including confirming `useGlobalConfig` is no longer imported from `element-plus`/`@element-plus/*` anywhere in `dialog`.
+- [ ] T7.13 Confirm `dialog`'s `package.json` packaging convention.
+- [ ] T7.14 Remove `'components/dialog/**'` from `excludedFiles` in `.eslintrc.cjs` **fully** (not narrowed per-symbol, per proposal decision 1). `yarn lint --max-warnings 0` passes.
+- [ ] T7.15 `yarn build` succeeds for `dialog`. Full `yarn test:run` green.
+- [ ] T7.16 Validate `dialog` in `front-b2b` (real copy) **before** relying on the exclude removal from T7.14 — specifically exercise the config shim: mount `dialog` (a) with no ancestor DS config provider, (b) nested inside the existing `GConfigProvider` island, confirming `namespace` resolves to `"gui"` in both cases (design §2.1's byte-identical claim).
+- [ ] T7.17 Commit as one work unit (`feat(dialog): migrate off element-plus internals, add DS-native config shim + useDraggable/composeRefs`), open PR #7 (depends on PR #3 + PR #5 merged; independent of PR #6), Lerna-publish on merge.
+
+## WU-8 — `select` (deep migration + order-hazard; depends on WU-6)
+
+Publishes: `select`. Est. ~380 changed lines (watch budget). Requirements: `popper-overlay-migration` full set; `g-hooks-package` → `popper-overlay-composables-added`, `shared-hook-single-ownership` (owns `useEmptyValues`, shared with WU-11 time-picker; owns `useCalcInputWidth`, shared with WU-12 input-tag), `v4-hooks-unit-tested`; `g-utils-extended` → `popper-overlay-utils-added` (`ClickOutside` directive, shared with WU-10 date-picker), `v4-utils-unit-tested`.
+
+- [ ] T8.1 **Sequencing guard (mandatory, per proposal/design risk table)**: confirm PR #6 (tooltip) is merged and published before starting this WU. `select` currently imports `TooltipInstance`/`useTooltipContentProps` straight from `element-plus`, not from the DS `tooltip` — the whole point of this WU is re-pointing to `@flash-global66/g-tooltip`, never to an EP subpath. Do not proceed if tooltip hasn't landed.
+- [ ] T8.2 Read EP's `useEmptyValues`/`useEmptyValuesProps` from `node_modules/element-plus/es/hooks/use-empty-values/index.mjs` (2.9.7). Cross-check sibling `../element-plus/packages/hooks/use-empty-values/`. Per design §2.3, confirm the injection key it reads (`emptyValuesContextKey`) is provided by config-provider, NOT form context — verify this against the 2.9.7 compiled source, not just the sibling, since this corrects the proposal's open question.
+- [ ] T8.3 Write failing unit tests for `useEmptyValues` (design §2.3's cascade: `props.emptyValues` wins when set; falls back to `config.value.emptyValues` when an ancestor DS config context provides it; falls back to `DEFAULT_EMPTY_VALUES` when neither is set; `valueOnClear` cascade: prop > config > defaultValue > `undefined`; `isEmptyValue` correctly classifies against the resolved `emptyValues` set) — new `common/g-hooks/tests/composables/useEmptyValues.spec.ts`.
+- [ ] T8.4 Implement `useEmptyValues` + `useEmptyValuesProps` + `gEmptyValuesContextKey` in `common/g-hooks/src/composables/useEmptyValues.ts` — own DS-native injection key (distinct `Symbol()` from `useGlobalConfig`'s, per design §2.3's symmetry note — do NOT couple `select` to `dialog`), byte-exact algorithm otherwise. Run `yarn test:run` → green.
+- [ ] T8.5 Read EP's `useCalcInputWidth` from `node_modules/element-plus/es/hooks/use-calc-input-width/index.mjs` (2.9.7). Cross-check sibling.
+- [ ] T8.6 Write failing unit test for `useCalcInputWidth` (`inputStyle` reflects the measured width of the hidden calculator element; `calculatorRef` is exposed for template binding) — new `common/g-hooks/tests/composables/useCalcInputWidth.spec.ts`.
+- [ ] T8.7 Implement `useCalcInputWidth` in `common/g-hooks/src/composables/useCalcInputWidth.ts` — byte-exact copy. Run `yarn test:run` → green.
+- [ ] T8.8 Read EP's `ClickOutside` directive from `node_modules/element-plus/es/directives/click-outside/index.mjs` (2.9.7). Cross-check sibling.
+- [ ] T8.9 Write failing unit test for the `ClickOutside` directive (fires the bound handler only for clicks/pointerdowns outside the bound element; does NOT fire for clicks inside; unbinds cleanly on `unmounted`) — new `common/g-utils/tests/directives/clickOutside.directive.spec.ts`.
+- [ ] T8.10 Implement `ClickOutside` in `common/g-utils/src/directives/clickOutside.directive.ts` — byte-exact copy, unit-testable handler map per spec's edge-case requirement. Run `yarn test:run` → green.
+- [ ] T8.11 Update `common/g-hooks/src/index.ts` and `common/g-utils/src/index.ts` barrels for the 3 new symbols.
+- [ ] T8.12 Migrate `components/select/src/**`: re-point `TooltipInstance`/`useTooltipContentProps` → `@flash-global66/g-tooltip` (NOT an EP subpath — the risk this WU exists to close); `EVENT_CODE`/`CHANGE_EVENT`/`UPDATE_MODEL_EVENT` → `@flash-global66/g-utils`; wire `useEmptyValues`/`useCalcInputWidth`/`ClickOutside`. Zero public API change.
+- [ ] T8.13 Grep-verify zero `from ['"]element-plus` matches under `components/select/src/**` and `index.ts`, including zero direct `TooltipInstance`/`useTooltipContentProps` imports from `element-plus`/`@element-plus/*`.
+- [ ] T8.14 Confirm `select`'s `package.json` packaging convention, including `g-tooltip` as a real dependency (not peer).
+- [ ] T8.15 Remove `'components/select/**'` from `excludedFiles` in `.eslintrc.cjs`. `yarn lint --max-warnings 0` passes.
+- [ ] T8.16 `yarn build` succeeds for `select`. Full `yarn test:run` green.
+- [ ] T8.17 Validate in `front-b2b` (real copy) — specifically confirm the tooltip re-point renders/positions correctly (the ordering hazard this WU is designed to avoid).
+- [ ] T8.18 **Line-budget checkpoint**: split into sequential commits by hook group if the diff exceeds ~400 lines.
+- [ ] T8.19 Commit as one work unit or the split from T8.18 (`feat(select): migrate off element-plus internals, re-point to g-tooltip, add useEmptyValues/useCalcInputWidth/ClickOutside`), open PR #8 (depends on PR #6 merged), Lerna-publish on merge.
+
+## WU-9 — `dropdown` (deep migration, widest fan-out; own WU, never bundled with select; depends on WU-6, WU-4, WU-7)
+
+Publishes: `dropdown`. Est. ~400 changed lines (widest internal dependency surface in the slice per design §3/§6 — treat as the review-budget risk item). Requirements: `popper-overlay-migration` full set; `g-hooks-package` → `popper-overlay-composables-added`, `shared-hook-single-ownership` (owns `useLocale`, shared with WU-10 date-picker + WU-11 time-picker), `v4-hooks-unit-tested`.
+
+- [ ] T9.1 Confirm PR #6 (tooltip), PR #4 (scrollbar), and PR #7 (dialog) are merged before starting — `dropdown`'s fan-out touches focus-trap, roving-focus-group, collection, tooltip, scrollbar, icon-font, slot, popper (per design §3, most already clean or migrated by this point).
+- [ ] T9.2 Read EP's `whenMouse` from `node_modules/element-plus/es/components/dropdown/src/utils.mjs` (or wherever the 2.9.7 compiled path places it — confirm exact module). Cross-check sibling `../element-plus/packages/components/dropdown/src/utils.ts`.
+- [ ] T9.3 Write failing unit test for `whenMouse` (wraps a handler so it only fires for `PointerEvent`s where `pointerType === 'mouse'`; touch/pen pointer events are ignored) — new `common/g-hooks/tests/composables/whenMouse.spec.ts`.
+- [ ] T9.4 Implement `whenMouse` in `common/g-hooks/src/composables/whenMouse.ts` — byte-exact copy. Run `yarn test:run` → green.
+- [ ] T9.5 Read EP's `useLocale` from `node_modules/element-plus/es/hooks/use-locale/index.mjs` (2.9.7). Cross-check sibling.
+- [ ] T9.6 Write failing unit test for `useLocale` (returns `{ lang, locale, t }`; `locale` reflects an ancestor-provided override when present; falls back to a default locale/translation table when no override exists; `t()` resolves a translation key against the resolved locale) — new `common/g-hooks/tests/composables/useLocale.spec.ts`.
+- [ ] T9.7 Implement `useLocale` in `common/g-hooks/src/composables/useLocale.ts` — byte-exact copy. Run `yarn test:run` → green.
+- [ ] T9.8 Update `common/g-hooks/src/index.ts` barrel for `whenMouse`, `useLocale`.
+- [ ] T9.9 Migrate `components/dropdown/src/**`: re-point `composeRefs` from WU-7 (`@flash-global66/g-utils`); `composeEventHandlers`/`useId`/`addUnit`/`ensureArray`/`EVENT_CODE` → `@flash-global66/g-utils`/`g-hooks`; re-point remaining focus-trap/roving-focus-group/collection/tooltip/scrollbar/icon-font/slot/popper imports to their DS packages; wire `whenMouse`/`useLocale`. Zero public API change.
+- [ ] T9.10 Grep-verify zero `from ['"]element-plus` matches under `components/dropdown/src/**` and `index.ts`.
+- [ ] T9.11 Confirm `dropdown`'s `package.json` packaging convention across its wide dependency set.
+- [ ] T9.12 Remove `'components/dropdown/**'` from `excludedFiles` in `.eslintrc.cjs`. `yarn lint --max-warnings 0` passes.
+- [ ] T9.13 `yarn build` succeeds for `dropdown`. Full `yarn test:run` green.
+- [ ] T9.14 Validate in `front-b2b` (real copy).
+- [ ] T9.15 **Line-budget checkpoint (high-probability trigger)**: given the widest fan-out in the slice, this WU is the most likely to exceed 400 lines. If so, split into sequential commits by concern (hook additions first, then package re-point wiring) within the same PR — do NOT bundle any part of this WU with `select`'s PR (design/proposal explicit constraint).
+- [ ] T9.16 Commit as one work unit or the split from T9.15 (`feat(dropdown): migrate off element-plus internals, add whenMouse/useLocale`), open PR #9 (depends on PR #6 + PR #4 + PR #7 merged; its own dedicated PR), Lerna-publish on merge.
+
+## WU-10 — `date-picker` (deep migration + in-place lint-debt fix; depends on WU-9, WU-8)
+
+Publishes: `date-picker`. Est. ~250 changed lines (includes the lint-debt cleanup — scope it to touched files, per proposal decision 3). Requirements: `popper-overlay-migration` full set plus `date-picker-lint-debt-resolved`; `g-utils-extended` → `popper-overlay-utils-added`, `v4-utils-unit-tested`.
+
+- [ ] T10.1 Confirm PR #9 (dropdown) and PR #8 (select) are merged before starting.
+- [ ] T10.2 Read EP's `castArray` from `node_modules/element-plus/es/utils/arrays.mjs` (2.9.7). Cross-check sibling. Confirm its semantics on `null`/`undefined` differ from the existing `ensureArray` (per design §4 — distinct symbol, not a rename).
+- [ ] T10.3 Write failing unit test for `castArray` (wraps a non-array value in a single-element array; returns an array input unchanged; explicitly assert the `null`/`undefined` edge-case behavior that differs from `ensureArray`) — new `common/g-utils/tests/utils/arrays.util.spec.ts` (or extend existing).
+- [ ] T10.4 Implement `castArray` in `common/g-utils/src/utils/arrays.util.ts` — byte-exact copy, do not conflate with `ensureArray`. Run `yarn test:run` → green.
+- [ ] T10.5 Update `common/g-utils/src/index.ts` barrel to export `castArray`.
+- [ ] T10.6 Migrate `components/date-picker/src/**`: re-point `useLocale` from WU-9, `ClickOutside` from WU-8, `isArray`/`isFunction`/`useNamespace`/`EVENT_CODE` → `@flash-global66/g-utils`/`g-hooks`; wire `castArray`. Zero public API change.
+- [ ] T10.7 **In the same touched files**, fix the pre-existing `no-unused-vars` lint debt (proposal decision 3) — remove genuinely-dead imports/bindings discovered while migrating; do NOT widen the diff beyond files this migration already touches, and do NOT open a separate tracked chore for it.
+- [ ] T10.8 Grep-verify zero `from ['"]element-plus` matches under `components/date-picker/src/**` and `index.ts`.
+- [ ] T10.9 Confirm `date-picker`'s `package.json` packaging convention.
+- [ ] T10.10 Remove `'components/date-picker/**'` from `excludedFiles` in `.eslintrc.cjs`. `yarn lint --max-warnings 0` passes (this is the requirement gating T10.7 — the lint-debt fix must land in the same WU for this to be achievable).
+- [ ] T10.11 `yarn build` succeeds for `date-picker`. Full `yarn test:run` green.
+- [ ] T10.12 Validate in `front-b2b` (real copy).
+- [ ] T10.13 Commit as one work unit (`feat(date-picker): migrate off element-plus internals, add castArray, fix pre-existing no-unused-vars debt`), open PR #10 (depends on PR #9 + PR #8 merged), Lerna-publish on merge.
+
+## WU-11 — `time-picker` (deep migration; depends on WU-6, WU-9, WU-8)
+
+Publishes: `time-picker`. Est. ~220 changed lines. Requirements: `popper-overlay-migration` full set; `g-utils-extended` → `popper-overlay-utils-added`, `v4-utils-unit-tested`.
+
+- [ ] T11.1 Confirm PR #6 (tooltip), PR #9 (dropdown), and PR #8 (select) are merged before starting.
+- [ ] T11.2 Read EP's `getStyle` from `node_modules/element-plus/es/utils/dom/style.mjs` (2.9.7). Cross-check sibling.
+- [ ] T11.3 Write failing unit test for `getStyle` (reads a computed style property from an element via `getComputedStyle`, with the same fallback/normalization EP applies for cross-browser `float`/vendor-prefixed properties) — new `common/g-utils/tests/utils/dom.util.spec.ts` (extend WU-1's file if already created).
+- [ ] T11.4 Implement `getStyle` in `common/g-utils/src/utils/dom.util.ts` — byte-exact copy. Run `yarn test:run` → green.
+- [ ] T11.5 Read EP's `vRepeatClick` directive from `node_modules/element-plus/es/directives/repeat-click/index.mjs` (2.9.7). Cross-check sibling. Note per design §4 this directive is also needed by `input-number` in the deferred v5 slice — build it EP-faithful so v5 can re-point cleanly.
+- [ ] T11.6 Write failing unit test for `vRepeatClick` (mousedown starts a repeating interval invoking the bound handler after an initial delay; mouseup/mouseleave clears the interval; single click without hold still fires once) — new `common/g-utils/tests/directives/repeatClick.directive.spec.ts`.
+- [ ] T11.7 Implement `vRepeatClick` in `common/g-utils/src/directives/repeatClick.directive.ts` — byte-exact copy. Run `yarn test:run` → green.
+- [ ] T11.8 Update `common/g-utils/src/index.ts` barrel for `getStyle`, `vRepeatClick`.
+- [ ] T11.9 Migrate `components/time-picker/src/**`: re-point `useEmptyValues` from WU-8, `useLocale` from WU-9, `useFocusController` (already exists in g-hooks per v3 — currently `time-picker` still imports it straight from EP per obs #269, per the proposal's "already-extracted hooks not auto-consumed" risk); wire `getStyle`/`vRepeatClick`. Zero public API change.
+- [ ] T11.10 Grep-verify zero `from ['"]element-plus` matches under `components/time-picker/src/**` and `index.ts`, including confirming `useFocusController` now resolves from `@flash-global66/g-hooks`, not EP.
+- [ ] T11.11 Confirm `time-picker`'s `package.json` packaging convention, including `g-form`/`g-input`/`g-icon-font`/`g-tooltip` as real dependencies where used per design §3.
+- [ ] T11.12 Remove `'components/time-picker/**'` from `excludedFiles` in `.eslintrc.cjs`. `yarn lint --max-warnings 0` passes.
+- [ ] T11.13 `yarn build` succeeds for `time-picker`. Full `yarn test:run` green.
+- [ ] T11.14 Validate in `front-b2b` (real copy).
+- [ ] T11.15 Commit as one work unit (`feat(time-picker): migrate off element-plus internals, add getStyle/vRepeatClick, re-point useFocusController`), open PR #11 (depends on PR #6 + PR #9 + PR #8 merged), Lerna-publish on merge.
+
+## WU-12 — `input-tag` (pure re-point; depends on WU-8)
+
+Publishes: `input-tag`. Est. ~100 changed lines. Requirements: `popper-overlay-migration` → `zero-ep-imports-per-migrated-package`, `public-api-and-styles-preserved`, `reused-composables-repointed`, `packaging-convention-followed`, `migration-gated-by-green-tests`.
+
+- [ ] T12.1 Confirm PR #8 (select) is merged before starting — this WU re-points `useCalcInputWidth` from `select`'s new export.
+- [ ] T12.2 Re-point `components/input-tag/src/**` imports: `useCalcInputWidth` → `@flash-global66/g-hooks` (built in WU-8); `useComposition`/`useFocusController` → `@flash-global66/g-hooks` (already exist per v3); `useNamespace`/`NOOP`/`isUndefined` → `@flash-global66/g-utils`. No new hooks built. Zero public API change.
+- [ ] T12.3 Grep-verify zero `from ['"]element-plus` matches under `components/input-tag/src/**` and `index.ts`.
+- [ ] T12.4 Confirm `input-tag`'s `package.json` packaging convention.
+- [ ] T12.5 Remove `'components/input-tag/**'` from `excludedFiles` in `.eslintrc.cjs`. `yarn lint --max-warnings 0` passes.
+- [ ] T12.6 `yarn build` succeeds for `input-tag`. Full `yarn test:run` green.
+- [ ] T12.7 Validate in `front-b2b` (real copy).
+- [ ] T12.8 Commit as one work unit (`refactor(input-tag): re-point imports off element-plus internals`), open PR #12 (depends on PR #8 merged), Lerna-publish on merge.
+
+## WU-13 — `inline` (pure re-point, smallest; no dependencies, fully independent of the popper chain)
+
+Publishes: `inline`. Est. ~60 changed lines. Requirements: `popper-overlay-migration` → `zero-ep-imports-per-migrated-package`, `public-api-and-styles-preserved`, `reused-composables-repointed`, `packaging-convention-followed`, `migration-gated-by-green-tests`.
+
+- [ ] T13.1 Re-point `components/inline/src/**` imports: `useFormSize` → `@flash-global66/g-form` (exists per v3); `useAriaProps` → `@flash-global66/g-hooks`; `useNamespace`/prop-builders/type guards → `@flash-global66/g-utils`. No new hooks built. Zero public API change.
+- [ ] T13.2 Grep-verify zero `from ['"]element-plus` matches under `components/inline/src/**` and `index.ts`.
+- [ ] T13.3 Confirm `inline`'s `package.json` packaging convention.
+- [ ] T13.4 Remove `'components/inline/**'` from `excludedFiles` in `.eslintrc.cjs`. `yarn lint --max-warnings 0` passes.
+- [ ] T13.5 `yarn build` succeeds for `inline`. Full `yarn test:run` green.
+- [ ] T13.6 Validate in `front-b2b` (real copy).
+- [ ] T13.7 Commit as one work unit (`refactor(inline): re-point imports off element-plus internals`), open PR #13 (no dependency, may merge any time), Lerna-publish on merge.
+
+## Cross-cutting (apply to every WU)
+
+- [ ] X.1 Every WU PR body includes: the dependency diagram (this file's header) with the current PR marked `📍`, start state, finished state, prior dependencies, follow-up work, and out-of-scope items (chained-pr skill Output Contract).
+- [ ] X.2 Every WU is verified independently before merge: `yarn test:run` green, `yarn lint --max-warnings 0`, `yarn build` for the touched package(s), and `front-b2b` real-copy validation on `ander/update/version-packages`.
+- [ ] X.3 No WU introduces a `g-icon-font`, `g-form`, or component-layer dependency into `g-utils` (leaf-layer purity) or a form-context coupling into `g-hooks` (design §1's layering rule — every new symbol lands in the lowest layer that can host it without a back-edge).
+- [ ] X.4 `useGlobalConfig` (WU-7) and `useEmptyValues` (WU-8) each get their own distinct DS-owned injection key (`gConfigProviderContextKey` vs `gEmptyValuesContextKey`) and are NOT coupled to each other, even though both are config-provider-sourced (design §2.3 symmetry note guard).
+- [ ] X.5 The forward-ref family (WU-2) is never split across two modules/packages — `useForwardRef` and `useForwardRefDirective` must keep sharing the exact same `FORWARD_REF_INJECTION_KEY` symbol instance through every downstream re-point (design §2.2 correctness guard).
+- [ ] X.6 Radio-group's stale `radio/radio.type` import (design §2.4) is untouched by every WU above — confirm via `git diff --stat` after each WU that `components/radio-group/**` and `components/radio/**` never appear in the changed-files list.
+- [ ] X.7 After all 13 WUs merge, confirm the slice-level success criteria from `proposal.md`: zero EP imports across the 13 packages (grep-verified), all ~19 new hooks/utils/directives unit-tested with the full suite green, `excludedFiles` no longer lists any of the 13 packages (only the 8 permanent islands + `toast`/`table`/`pagination`/`collapse`/`input-number` remain excluded), `yarn build`/`yarn lint --max-warnings 0` pass repo-wide, every migration WU validated in `front-b2b` via real copies, `element-plus` still present in every island's `package.json` (non-goal preserved).
+
+---
+
+## Review Workload Forecast
+
+| WU    | Deliverable                                     | Est. changed lines | Chained PR recommended             | 400-line budget risk                                                                                      | Decision needed before apply                                                 |
+| ----- | ----------------------------------------------- | -----------------: | ---------------------------------- | --------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
+| WU-1  | focus-trap (deep)                               |               ~200 | Yes (pre-decided: stacked-to-main) | Low                                                                                                       | No                                                                           |
+| WU-2  | slot (deep, forward-ref family)                 |               ~220 | Yes                                | Low                                                                                                       | No                                                                           |
+| WU-3  | overlay (deep)                                  |               ~180 | Yes                                | Low                                                                                                       | No                                                                           |
+| WU-4  | scrollbar (pure re-point)                       |                ~80 | Yes                                | Low                                                                                                       | No                                                                           |
+| WU-5  | popper (deep, core — `usePopper` highest-drift) |           ~380–400 | Yes                                | **Medium–High** — closest single-hook risk; T5.14 fallback split pre-authorized                           | No — flag if actual diff exceeds ~400                                        |
+| WU-6  | tooltip (deep, 3 hook groups)                   |           ~350–400 | Yes                                | **Medium** — T6.17 fallback split pre-authorized                                                          | No — flag if actual diff exceeds ~400                                        |
+| WU-7  | dialog (deep, highest-risk config shim)         |               ~350 | Yes                                | Low–Medium                                                                                                | No                                                                           |
+| WU-8  | select (deep + order-hazard)                    |               ~380 | Yes                                | **Medium** — T8.18 fallback split pre-authorized                                                          | No — flag if actual diff exceeds ~400                                        |
+| WU-9  | dropdown (deep, widest fan-out)                 |               ~400 | Yes                                | **High** — most likely WU to exceed budget; T9.15 fallback split pre-authorized; never bundle with select | No — flag if actual diff exceeds ~400, but do not merge with WU-8 regardless |
+| WU-10 | date-picker (deep + lint-debt fix)              |               ~250 | Yes                                | Low                                                                                                       | No                                                                           |
+| WU-11 | time-picker (deep)                              |               ~220 | Yes                                | Low                                                                                                       | No                                                                           |
+| WU-12 | input-tag (pure re-point)                       |               ~100 | Yes                                | Low                                                                                                       | No                                                                           |
+| WU-13 | inline (pure re-point, smallest)                |                ~60 | Yes                                | Low                                                                                                       | No                                                                           |
+
+**Overall**: 13 chained PRs, `stacked-to-main` (pre-decided in proposal/design). Total estimated changed lines across the slice: ~3,170. All WUs individually estimated at or under the ~400-line budget, but **WU-5 (popper)**, **WU-6 (tooltip)**, **WU-8 (select)**, and especially **WU-9 (dropdown)** sit close to or at the ceiling — each has a pre-authorized within-PR commit-split fallback (mirroring the v3 WU-4 precedent) rather than spawning a new WU if the real diff creeps over. No `size:exception` anticipated up front, but the orchestrator should watch these four during `sdd-apply` and only escalate if a split-commit fallback still doesn't bring an individual PR under budget.
+
+**Chained PRs recommended: Yes.**
+**400-line budget risk: Medium** (four WUs — popper, tooltip, select, dropdown — sit near the ceiling; the rest are Low).
+**Decision needed before apply: No** — chain strategy (`stacked-to-main`) and per-WU split fallbacks are pre-authorized in this file; only escalate to the orchestrator if a WU exceeds budget even after its commit-split fallback.
+
+**Parallelism summary**: WU-1/WU-2/WU-3/WU-4 (near-leaves) are mutually independent and can be developed concurrently. WU-13 (inline) has zero dependency on the popper chain and can land at any point. Once WU-5 (popper) merges, the tooltip branch (WU-6 → WU-8/WU-9), the dialog branch (WU-7, parallel off WU-3+WU-5), and eventually the picker branch (WU-10/WU-11, after WU-8+WU-9) proceed in parallel. WU-9 (dropdown) is always its own PR — never bundled with WU-8 (select), per the explicit proposal/design risk-table constraint.


### PR DESCRIPTION
## ep-extraction-v4 · WU-1 (focus-trap)

First work-unit of the **ep-extraction-v4** chain (popper/overlay family migration off element-plus). Stacked-to-main.

### What
Migrate `g-focus-trap` off element-plus internals with **zero public API change**:
- Port `useEscapeKeydown` → `@flash-global66/g-hooks` (byte-exact from element-plus 2.9.7)
- Port `isFocusable` → `@flash-global66/g-utils`
- Re-point `isElement`, `isString`, `EVENT_CODE` to existing `g-utils` exports
- `focus-trap` now declares `g-utils`/`g-hooks` in `dependencies`; **`element-plus` removed from `peerDependencies`** (zero remaining EP imports, no scss theme file)
- Drop `components/focus-trap/**` from the ESLint EP-import-guard `excludedFiles` (the guard now actively blocks any EP re-introduction here)

### Correctness
- element-plus **2.9.7** is the source of truth; hooks copied byte-exact, no behavior changes.
- Behavior parity independently confirmed byte-exact by two blind reviewers (registration/cleanup of the shared document keydown listener; the full `isFocusable` predicate).
- **237/237 unit tests passing** (16 new across `useEscapeKeydown` + `isFocusable`, including shared-listener partial-teardown and the `INPUT[type=file]` / `A[rel=ignore]` negative branches).
- `eslint --ext .vue,.ts,.js --max-warnings 0` clean on touched files; `yarn build` succeeds.

### Reviewer notes
- The `focus-trap.vue` diff looks large only because the repo pre-commit hook (prettier) reformatted the whole file — the **semantic change is just the import lines**.
- Pre-existing, not introduced here: `focus-trap/src/utils.ts` `isHidden` lacks element-plus's `NODE_ENV === 'test'` short-circuit. Out of scope for this WU; flagged for a follow-up.

### SDD
Part of `ep-extraction-v4` — proposal/spec/design/tasks under `openspec/changes/ep-extraction-v4/`.
