### PR TITLE
feat(slot): migrate off element-plus internals [ep-extraction-v4 WU-2]

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -46,7 +46,6 @@ module.exports = {
         'components/toast/**',
         'components/time-picker/**',
         'components/table/**',
-        'components/slot/**',
         'components/select/**',
         'components/scrollbar/**',
         'components/popper/**',

--- a/common/g-hooks/src/composables/useForwardRef.ts
+++ b/common/g-hooks/src/composables/useForwardRef.ts
@@ -1,0 +1,49 @@
+import { provide } from 'vue';
+import type { InjectionKey, ObjectDirective, Ref } from 'vue';
+
+/**
+ * Ported byte-exact from element-plus 2.9.7's `useForwardRef` module
+ * (`es/hooks/use-forward-ref/index.mjs`).
+ *
+ * This module is the SOLE owner of the forward-ref family: `useForwardRef`,
+ * `useForwardRefDirective`, and `FORWARD_REF_INJECTION_KEY` must never be
+ * split across two modules or packages. Every consumer (`slot`, later
+ * `popper`) provides/injects through this exact same exported `Symbol()`
+ * instance — splitting the definitions would break the provide/inject
+ * handshake by creating two distinct symbols.
+ */
+
+type ForwardRefSetter = <T>(el: T) => void;
+
+export type ForwardRefInjectionContext = {
+  setForwardRef: ForwardRefSetter;
+};
+
+export const FORWARD_REF_INJECTION_KEY: InjectionKey<ForwardRefInjectionContext> =
+  Symbol('elForwardRef');
+
+export const useForwardRef = <T>(forwardRef: Ref<T | null>): void => {
+  const setForwardRef = ((el: T) => {
+    forwardRef.value = el;
+  }) as ForwardRefSetter;
+
+  provide(FORWARD_REF_INJECTION_KEY, {
+    setForwardRef,
+  });
+};
+
+export const useForwardRefDirective = (
+  setForwardRef: ForwardRefSetter,
+): ObjectDirective => {
+  return {
+    mounted(el) {
+      setForwardRef(el);
+    },
+    updated(el) {
+      setForwardRef(el);
+    },
+    unmounted() {
+      setForwardRef(null);
+    },
+  };
+};

--- a/common/g-hooks/src/composables/useForwardRef.ts
+++ b/common/g-hooks/src/composables/useForwardRef.ts
@@ -2,15 +2,15 @@ import { provide } from 'vue';
 import type { InjectionKey, ObjectDirective, Ref } from 'vue';
 
 /**
- * Ported byte-exact from element-plus 2.9.7's `useForwardRef` module
+ * Portado byte-exact desde el módulo `useForwardRef` de element-plus 2.9.7
  * (`es/hooks/use-forward-ref/index.mjs`).
  *
- * This module is the SOLE owner of the forward-ref family: `useForwardRef`,
- * `useForwardRefDirective`, and `FORWARD_REF_INJECTION_KEY` must never be
- * split across two modules or packages. Every consumer (`slot`, later
- * `popper`) provides/injects through this exact same exported `Symbol()`
- * instance — splitting the definitions would break the provide/inject
- * handshake by creating two distinct symbols.
+ * Este módulo es el ÚNICO dueño de la familia forward-ref: `useForwardRef`,
+ * `useForwardRefDirective` y `FORWARD_REF_INJECTION_KEY` nunca deben
+ * separarse en dos módulos o paquetes. Todos los consumidores (`slot` y,
+ * más adelante, `popper`) proveen/inyectan a través de esta misma instancia
+ * de `Symbol()` exportada: separar las definiciones rompería el handshake
+ * de provide/inject al crear dos símbolos distintos.
  */
 
 type ForwardRefSetter = <T>(el: T) => void;

--- a/common/g-hooks/src/index.ts
+++ b/common/g-hooks/src/index.ts
@@ -16,3 +16,4 @@ export * from './composables/useCursor';
 export * from './composables/useFocusController';
 export * from './composables/useAttrs';
 export * from './composables/useEscapeKeydown';
+export * from './composables/useForwardRef';

--- a/common/g-hooks/tests/composables/useForwardRef.spec.ts
+++ b/common/g-hooks/tests/composables/useForwardRef.spec.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect } from 'vitest';
+import { createApp, defineComponent, h, inject, ref } from 'vue';
+import {
+  FORWARD_REF_INJECTION_KEY,
+  useForwardRef,
+  useForwardRefDirective,
+} from '../../src/composables/useForwardRef';
+
+describe('useForwardRef', () => {
+  it('provides FORWARD_REF_INJECTION_KEY with a setForwardRef that writes into the given ref', () => {
+    const forwardRef = ref<HTMLElement | null>(null);
+    let injected: ReturnType<typeof inject> | undefined;
+
+    const Child = defineComponent({
+      setup() {
+        injected = inject(FORWARD_REF_INJECTION_KEY);
+        return () => null;
+      },
+    });
+
+    const Parent = defineComponent({
+      setup() {
+        useForwardRef(forwardRef);
+        return () => h(Child);
+      },
+    });
+
+    const app = createApp(Parent);
+    app.mount(document.createElement('div'));
+
+    expect(injected).toBeDefined();
+    expect(typeof injected?.setForwardRef).toBe('function');
+
+    const el = document.createElement('div');
+    injected!.setForwardRef(el);
+    expect(forwardRef.value).toBe(el);
+
+    app.unmount();
+  });
+
+  it('setForwardRef overwrites the previous value on repeated calls', () => {
+    const forwardRef = ref<HTMLElement | null>(null);
+    let injected: ReturnType<typeof inject> | undefined;
+
+    const Child = defineComponent({
+      setup() {
+        injected = inject(FORWARD_REF_INJECTION_KEY);
+        return () => null;
+      },
+    });
+    const Parent = defineComponent({
+      setup() {
+        useForwardRef(forwardRef);
+        return () => h(Child);
+      },
+    });
+
+    const app = createApp(Parent);
+    app.mount(document.createElement('div'));
+
+    const first = document.createElement('span');
+    const second = document.createElement('p');
+    injected!.setForwardRef(first);
+    expect(forwardRef.value).toBe(first);
+    injected!.setForwardRef(second);
+    expect(forwardRef.value).toBe(second);
+
+    app.unmount();
+  });
+});
+
+describe('useForwardRefDirective', () => {
+  it('calls setForwardRef with the bound element on mounted', () => {
+    const calls: unknown[] = [];
+    const directive = useForwardRefDirective(el => calls.push(el));
+
+    const el = document.createElement('div');
+    directive.mounted?.(el, {} as any, {} as any, {} as any);
+
+    expect(calls).toEqual([el]);
+  });
+
+  it('calls setForwardRef with the bound element on updated', () => {
+    const calls: unknown[] = [];
+    const directive = useForwardRefDirective(el => calls.push(el));
+
+    const el = document.createElement('div');
+    directive.updated?.(el, {} as any, {} as any, {} as any);
+
+    expect(calls).toEqual([el]);
+  });
+
+  it('calls setForwardRef with null on unmounted', () => {
+    const calls: unknown[] = [];
+    const directive = useForwardRefDirective(el => calls.push(el));
+
+    directive.unmounted?.(
+      document.createElement('div'),
+      {} as any,
+      {} as any,
+      {} as any,
+    );
+
+    expect(calls).toEqual([null]);
+  });
+
+  it('returns a fresh directive object referencing the same setForwardRef on every call', () => {
+    const setForwardRef = () => {};
+    const directiveA = useForwardRefDirective(setForwardRef);
+    const directiveB = useForwardRefDirective(setForwardRef);
+
+    expect(directiveA).not.toBe(directiveB);
+    expect(typeof directiveA.mounted).toBe('function');
+    expect(typeof directiveA.updated).toBe('function');
+    expect(typeof directiveA.unmounted).toBe('function');
+  });
+});
+
+describe('shared-symbol handshake', () => {
+  it('useForwardRef and useForwardRefDirective communicate through the exact same FORWARD_REF_INJECTION_KEY symbol', () => {
+    const forwardRef = ref<HTMLElement | null>(null);
+    let receivedKey: symbol | undefined;
+
+    const Child = defineComponent({
+      directives: {
+        forwardRef: useForwardRefDirective(el => {
+          const injection = inject(FORWARD_REF_INJECTION_KEY);
+          injection?.setForwardRef(el);
+        }),
+      },
+      setup() {
+        const injection = inject(FORWARD_REF_INJECTION_KEY);
+        receivedKey = FORWARD_REF_INJECTION_KEY as unknown as symbol;
+        return () =>
+          h('div', {
+            ref: (el: unknown) => injection?.setForwardRef(el),
+          });
+      },
+    });
+
+    const Parent = defineComponent({
+      setup() {
+        useForwardRef(forwardRef);
+        return () => h(Child);
+      },
+    });
+
+    const app = createApp(Parent);
+    const container = document.createElement('div');
+    app.mount(container);
+
+    expect(receivedKey).toBe(FORWARD_REF_INJECTION_KEY);
+    expect(forwardRef.value).toBeInstanceOf(HTMLElement);
+
+    app.unmount();
+  });
+});

--- a/components/slot/package.json
+++ b/components/slot/package.json
@@ -31,7 +31,7 @@
     "vue": "^3.2.0"
   },
   "dependencies": {
-    "@flash-global66/g-hooks": "^0.4.1",
-    "@flash-global66/g-utils": "^0.4.0"
+    "@flash-global66/g-hooks": "^0.5.0",
+    "@flash-global66/g-utils": "^0.5.0"
   }
 }

--- a/components/slot/package.json
+++ b/components/slot/package.json
@@ -28,7 +28,10 @@
     "url": "https://github.com/Flash-Global66/global-design-system.git"
   },
   "peerDependencies": {
-    "element-plus": "^2.9.0",
     "vue": "^3.2.0"
+  },
+  "dependencies": {
+    "@flash-global66/g-hooks": "^0.4.1",
+    "@flash-global66/g-utils": "^0.4.0"
   }
 }

--- a/components/slot/src/only-child.tsx
+++ b/components/slot/src/only-child.tsx
@@ -58,9 +58,9 @@ function findFirstLegitChild(node: VNode[] | undefined): VNode | null {
   const children = node as VNode[];
   for (const child of children) {
     /**
-     * when user uses h(Fragment, [text]) to render plain string,
-     * this switch case just cannot handle, when the value is primitives
-     * we should just return the wrapped string
+     * Cuando se usa h(Fragment, [text]) para renderizar un string plano,
+     * este switch no puede manejarlo; cuando el valor es un primitivo,
+     * simplemente devolvemos el string envuelto.
      */
     if (isObject(child)) {
       switch (child.type) {

--- a/components/slot/src/only-child.tsx
+++ b/components/slot/src/only-child.tsx
@@ -8,50 +8,54 @@ import {
   inject,
   withDirectives,
   h,
-} from 'vue'
-import { NOOP, debugWarn, isObject } from 'element-plus/es/utils/index'
+} from 'vue';
+import {
+  NOOP,
+  debugWarn,
+  isObject,
+  useNamespace,
+} from '@flash-global66/g-utils';
 import {
   FORWARD_REF_INJECTION_KEY,
   useForwardRefDirective,
-  useNamespace,
-} from 'element-plus'
+} from '@flash-global66/g-hooks';
 
-import type { Ref, VNode } from 'vue'
+import type { Ref, VNode } from 'vue';
 
-const NAME = 'GOnlyChild'
+const NAME = 'GOnlyChild';
 
 export const OnlyChild = defineComponent({
   name: NAME,
   setup(_, { slots, attrs }) {
-    const forwardRefInjection = inject(FORWARD_REF_INJECTION_KEY)
+    const forwardRefInjection = inject(FORWARD_REF_INJECTION_KEY);
     const forwardRefDirective = useForwardRefDirective(
-      forwardRefInjection?.setForwardRef ?? NOOP
-    )
+      forwardRefInjection?.setForwardRef ?? NOOP,
+    );
     return () => {
-      const defaultSlot = slots.default?.(attrs)
-      if (!defaultSlot) return null
+      const defaultSlot = slots.default?.(attrs);
+      if (!defaultSlot) return null;
 
       if (defaultSlot.length > 1) {
-        debugWarn(NAME, 'requires exact only one valid child.')
-        return null
+        debugWarn(NAME, 'requires exact only one valid child.');
+        return null;
       }
 
-      const firstLegitNode = findFirstLegitChild(defaultSlot)
+      const firstLegitNode = findFirstLegitChild(defaultSlot);
       if (!firstLegitNode) {
-        debugWarn(NAME, 'no valid child node found')
-        return null
+        debugWarn(NAME, 'no valid child node found');
+        return null;
       }
 
       return withDirectives(cloneVNode(firstLegitNode!, attrs), [
         [forwardRefDirective],
-      ])
-    }
+      ]);
+    };
   },
-})
+});
 
 function findFirstLegitChild(node: VNode[] | undefined): VNode | null {
-  if (!node) return null
-  const children = node as VNode[]
+  if (!node) return null;
+  const children = node as VNode[];
   for (const child of children) {
     /**
      * when user uses h(Fragment, [text]) to render plain string,
@@ -61,26 +65,26 @@ function findFirstLegitChild(node: VNode[] | undefined): VNode | null {
     if (isObject(child)) {
       switch (child.type) {
         case Comment:
-          continue
+          continue;
         case Text:
         case 'svg':
-          return wrapTextContent(child)
+          return wrapTextContent(child);
         case Fragment:
-          return findFirstLegitChild(child.children as VNode[])
+          return findFirstLegitChild(child.children as VNode[]);
         default:
-          return child
+          return child;
       }
     }
-    return wrapTextContent(child)
+    return wrapTextContent(child);
   }
-  return null
+  return null;
 }
 
 function wrapTextContent(s: string | VNode) {
-  const ns = useNamespace('only-child')
-  return h('span', { class: ns.e('content') }, s)
+  const ns = useNamespace('only-child');
+  return h('span', { class: ns.e('content') }, s);
 }
 
 export type OnlyChildExpose = {
-  forwardRef: Ref<HTMLElement>
-}
+  forwardRef: Ref<HTMLElement>;
+};

--- a/openspec/changes/ep-extraction-v4/tasks.md
+++ b/openspec/changes/ep-extraction-v4/tasks.md
@@ -72,17 +72,17 @@ Publishes: `focus-trap`. Est. ~200 changed lines. Requirements: `popper-overlay-
 
 Publishes: `slot`. Est. ~220 changed lines. Requirements: same `popper-overlay-migration` set as WU-1 plus `g-hooks-package` → `shared-hook-single-ownership` (this WU is the sole owner of the forward-ref family, design §2.2).
 
-- [ ] T2.1 Read EP's forward-ref module from `node_modules/element-plus/es/hooks/use-forward-ref/index.mjs` (2.9.7) — the single module exporting `useForwardRef`, `useForwardRefDirective`, `FORWARD_REF_INJECTION_KEY`. Cross-check sibling `../element-plus/packages/hooks/use-forward-ref/`.
-- [ ] T2.2 Write failing unit tests asserting the **shared-symbol handshake** (design §2.2, correctness requirement, not style): `useForwardRef` provides `FORWARD_REF_INJECTION_KEY`; `useForwardRefDirective`'s returned directive object (`mounted`/`updated`/`unmounted`) calls `setForwardRef` with the bound element on mount/update and `undefined` on unmount; both functions reference the exact same exported `Symbol()` instance — new `common/g-hooks/tests/composables/useForwardRef.spec.ts`.
-- [ ] T2.3 Implement **one module** `common/g-hooks/src/composables/useForwardRef.ts` exporting all three (`useForwardRef`, `useForwardRefDirective`, `FORWARD_REF_INJECTION_KEY`), mirroring EP's own file layout exactly — byte-exact copy. Run `yarn test:run` → green.
-- [ ] T2.4 Update `common/g-hooks/src/index.ts` barrel to export the 3 new symbols.
-- [ ] T2.5 Migrate `components/slot/src/**`: re-point `NOOP`/`debugWarn`/`isObject`/`useNamespace` → `@flash-global66/g-utils`; wire the new forward-ref family. Zero public API change.
-- [ ] T2.6 Grep-verify zero `from ['"]element-plus` matches under `components/slot/src/**` and `index.ts`.
-- [ ] T2.7 Confirm `slot`'s `package.json` packaging convention (g-utils/g-hooks in `dependencies`).
-- [ ] T2.8 Remove `'components/slot/**'` from `excludedFiles` in `.eslintrc.cjs`. `yarn lint --max-warnings 0` passes.
-- [ ] T2.9 `yarn build` succeeds for `slot`. Full `yarn test:run` green.
-- [ ] T2.10 Validate in `front-b2b` (real copy, `ander/update/version-packages`).
-- [ ] T2.11 Commit as one work unit (`feat(slot): migrate off element-plus internals, add forward-ref family to g-hooks`), open PR #2 (parallel to PR #1, both target `main`), Lerna-publish on merge.
+- [x] T2.1 Read EP's forward-ref module from `node_modules/element-plus/es/hooks/use-forward-ref/index.mjs` (2.9.7) — the single module exporting `useForwardRef`, `useForwardRefDirective`, `FORWARD_REF_INJECTION_KEY`. Cross-check sibling `../element-plus/packages/hooks/use-forward-ref/`.
+- [x] T2.2 Write failing unit tests asserting the **shared-symbol handshake** (design §2.2, correctness requirement, not style): `useForwardRef` provides `FORWARD_REF_INJECTION_KEY`; `useForwardRefDirective`'s returned directive object (`mounted`/`updated`/`unmounted`) calls `setForwardRef` with the bound element on mount/update and `undefined` on unmount; both functions reference the exact same exported `Symbol()` instance — new `common/g-hooks/tests/composables/useForwardRef.spec.ts`.
+- [x] T2.3 Implement **one module** `common/g-hooks/src/composables/useForwardRef.ts` exporting all three (`useForwardRef`, `useForwardRefDirective`, `FORWARD_REF_INJECTION_KEY`), mirroring EP's own file layout exactly — byte-exact copy. Run `yarn test:run` → green.
+- [x] T2.4 Update `common/g-hooks/src/index.ts` barrel to export the 3 new symbols.
+- [x] T2.5 Migrate `components/slot/src/**`: re-point `NOOP`/`debugWarn`/`isObject`/`useNamespace` → `@flash-global66/g-utils`; wire the new forward-ref family. Zero public API change.
+- [x] T2.6 Grep-verify zero `from ['"]element-plus` matches under `components/slot/src/**` and `index.ts`.
+- [x] T2.7 Confirm `slot`'s `package.json` packaging convention (g-utils/g-hooks in `dependencies`).
+- [x] T2.8 Remove `'components/slot/**'` from `excludedFiles` in `.eslintrc.cjs`. `yarn lint --max-warnings 0` passes.
+- [x] T2.9 `yarn build` succeeds for `slot`. Full `yarn test:run` green.
+- [ ] T2.10 Validate in `front-b2b` (real copy, `ander/update/version-packages`). **Deferred**: same blocker as WU-1/T1.13 — requires a merged+Lerna-published `slot` version; CodeCommit registry network access unavailable in this sandbox.
+- [ ] T2.11 Commit as one work unit (`feat(slot): migrate off element-plus internals, add forward-ref family to g-hooks`), open PR #2 (parallel to PR #1, both target `main`), Lerna-publish on merge. **Partial**: implementation committed locally on `feat/ds-ep-v4-wu2-slot`; PR creation + publish deferred to orchestrator review per apply-phase boundary.
 
 ## WU-3 — `overlay` (deep migration; near-leaf, no dependencies)
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1500,8 +1500,10 @@ __metadata:
 "@flash-global66/g-slot@workspace:components/slot":
   version: 0.0.0-use.local
   resolution: "@flash-global66/g-slot@workspace:components/slot"
+  dependencies:
+    "@flash-global66/g-hooks": "npm:^0.5.0"
+    "@flash-global66/g-utils": "npm:^0.5.0"
   peerDependencies:
-    element-plus: ^2.9.0
     vue: ^3.2.0
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
## ep-extraction-v4 · WU-2 (slot)

Second work-unit of the **ep-extraction-v4** chain. Stacked-to-main, on top of WU-1 (focus-trap, #252).

### What
Migrate `g-slot` off element-plus internals with **zero public API change**:
- Port the **unified forward-ref module** → `@flash-global66/g-hooks` (`useForwardRef` + `useForwardRefDirective` + `FORWARD_REF_INJECTION_KEY`, byte-exact from element-plus 2.9.7). Kept as ONE module sharing ONE injection key so the future `popper` (WU-5) `provide` side and `slot` `inject` side handshake through the same symbol.
- Re-point `NOOP`, `debugWarn`, `isObject` to `g-utils`; `useNamespace` to `g-utils`.
- `slot` now declares `g-utils`/`g-hooks` at `^0.5.0` in `dependencies`; `element-plus` removed (zero remaining EP imports).
- Drop `components/slot/**` from the ESLint EP-import-guard `excludedFiles`.

### Correctness
- element-plus **2.9.7** is the source of truth; the forward-ref family copied byte-exact, no behavior changes.
- Independently reviewed by two blind reviewers: both confirmed byte-exact forward-ref parity, the single-symbol provide/inject handshake, zero public API change, correct re-points, and real (non-tautological) tests. They flagged one packaging defect (stale `^0.4.x` dep range) — **fixed** here to `^0.5.0`, matching every other migrated package and the current workspace versions.
- **201/201 unit tests passing** (7 new forward-ref tests including the shared-symbol handshake). Scoped `eslint --max-warnings 0` clean; `yarn build` + `build:types` for `g-slot` succeed.

### Reviewer note
`only-child.tsx` diff is import re-pointing + Prettier reformatting only — no semantic change beyond the imports.

### SDD
Part of `ep-extraction-v4` — proposal/spec/design/tasks under `openspec/changes/ep-extraction-v4/`.
