### PR TITLE
docs(g-hooks,g-utils): write WU-1 ported comments in Spanish

### DIFF
--- a/common/g-hooks/src/composables/useEscapeKeydown.ts
+++ b/common/g-hooks/src/composables/useEscapeKeydown.ts
@@ -2,14 +2,14 @@ import { onBeforeUnmount, onMounted } from 'vue';
 import { isClient, EVENT_CODE } from '@flash-global66/g-utils';
 
 /**
- * Ported byte-exact from element-plus 2.9.7's `useEscapeKeydown`
+ * Portado byte-exact desde `useEscapeKeydown` de element-plus 2.9.7
  * (`es/hooks/use-escape-keydown/index.mjs`).
  *
- * Handlers registered by every currently-mounted consumer share a single
- * module-level `document` `keydown` listener: the listener is attached once
- * (when the first handler registers) and detached once the last handler
- * unregisters. Every registered handler is invoked on each `Escape`
- * keydown, regardless of which component instance is currently mounted.
+ * Los handlers registrados por cada consumidor montado comparten un único
+ * listener `keydown` a nivel de módulo sobre `document`: el listener se agrega
+ * una sola vez (cuando se registra el primer handler) y se remueve cuando se
+ * desregistra el último. Cada handler registrado se invoca en cada keydown de
+ * `Escape`, sin importar qué instancia de componente esté montada.
  */
 let registeredEscapeHandlers: ((event: KeyboardEvent) => void)[] = [];
 
@@ -22,10 +22,10 @@ const cachedHandler = (event: KeyboardEvent): void => {
 };
 
 /**
- * Registers `handler` to run on every `Escape` keydown while the calling
- * component is mounted. Cleans up automatically on unmount.
+ * Registra `handler` para ejecutarse en cada keydown de `Escape` mientras el
+ * componente que lo llama esté montado. Se limpia automáticamente al desmontar.
  *
- * @param handler - Invoked with the `KeyboardEvent` on `Escape` keydown.
+ * @param handler - Se invoca con el `KeyboardEvent` en el keydown de `Escape`.
  */
 export const useEscapeKeydown = (
   handler: (event: KeyboardEvent) => void,

--- a/common/g-utils/src/utils/dom.util.ts
+++ b/common/g-utils/src/utils/dom.util.ts
@@ -72,14 +72,14 @@ export const rAF = (fn: FrameRequestCallback): number =>
     : (setTimeout(fn, 16) as unknown as number);
 
 /**
- * Checks whether an element can receive focus (via tab order or
- * programmatically).
+ * Verifica si un elemento puede recibir foco (por orden de tabulación o
+ * programáticamente).
  *
- * Byte-exact copy of element-plus's `isFocusable` algorithm
+ * Copia byte-exact del algoritmo `isFocusable` de element-plus
  * (`es/utils/dom/aria.mjs`, 2.9.7).
  *
- * @param element - The element to check.
- * @returns `true` if the element is focusable.
+ * @param element - El elemento a verificar.
+ * @returns `true` si el elemento puede recibir foco.
  */
 export const isFocusable = (element: HTMLElement): boolean => {
   if (


### PR DESCRIPTION
Follow-up to WU-1 (#252). Project convention: all code comments / JSDoc are written in Spanish. WU-1 landed `useEscapeKeydown` and `isFocusable` with English JSDoc — this translates them to Spanish.

**Code unchanged** — comments/JSDoc only. No behavior, no API, no test impact.