### PR TITLE
feat(overlay): migrate off element-plus internals [ep-extraction-v4 WU-3]

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -23,9 +23,12 @@ module.exports = {
   overrides: [
     {
       // EP Extraction guard: packages already migrated off element-plus must
-      // never re-introduce a direct dependency on it, in either their src/
-      // implementation or their public barrel (index.ts).
-      files: ['components/*/src/**', 'common/*/src/**', 'components/*/index.ts'],
+      // never re-introduce a direct dependency on it. Covers nested-layout
+      // implementations (components/*/src/**, common/*/src/**) AND flat-layout
+      // package roots + barrels (components/*/*.ts, e.g. overlay/overlay.ts,
+      // overlay/index.ts). The flat-layout glob is required because packages
+      // like `overlay` ship implementation at the package root, not under src/.
+      files: ['components/*/src/**', 'common/*/src/**', 'components/*/*.ts'],
       excludedFiles: [
         // Islands: intentionally wrap/re-export a real element-plus component.
         'components/badge/**',

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -55,7 +55,6 @@ module.exports = {
         'components/dialog/**',
         'components/date-picker/**',
         'components/collapse/**',
-        'components/overlay/**',
       ],
       rules: {
         'no-restricted-imports': [

--- a/common/g-hooks/src/composables/useSameTarget.ts
+++ b/common/g-hooks/src/composables/useSameTarget.ts
@@ -1,0 +1,46 @@
+import { NOOP } from '@flash-global66/g-utils';
+
+/**
+ * Portado byte-exact desde `useSameTarget` de element-plus 2.9.7
+ * (`es/hooks/use-same-target/index.mjs`).
+ *
+ * Evita que un click disparado por una selección de texto arrastrada con el
+ * mouse (mousedown en un elemento, mouseup en otro) se interprete como un
+ * click real sobre el `currentTarget`. Solo invoca `handleClick` cuando el
+ * mismo elemento fue el objetivo tanto del `mousedown` como del `mouseup`.
+ *
+ * Referencia: https://javascript.info/mouse-events-basics — los eventos se
+ * disparan en el orden mousedown -> mouseup -> click; el flag de mousedown
+ * se resetea después de cada click.
+ *
+ * @param handleClick - Handler a invocar solo cuando mousedown y mouseup/click
+ * comparten el mismo `currentTarget`. Si se omite, retorna handlers no-op.
+ */
+export const useSameTarget = (handleClick?: (e: MouseEvent) => void) => {
+  if (!handleClick) {
+    return { onClick: NOOP, onMousedown: NOOP, onMouseup: NOOP };
+  }
+
+  let mousedownTarget = false;
+  let mouseupTarget = false;
+
+  const onClick = (e: MouseEvent) => {
+    // Solo si y solo si ambos targets coinciden con el currentTarget.
+    if (mousedownTarget && mouseupTarget) {
+      handleClick(e);
+    }
+    mousedownTarget = mouseupTarget = false;
+  };
+
+  const onMousedown = (e: MouseEvent) => {
+    // Marca el target del mousedown actual.
+    mousedownTarget = e.target === e.currentTarget;
+  };
+
+  const onMouseup = (e: MouseEvent) => {
+    // Marca el target del mouseup actual.
+    mouseupTarget = e.target === e.currentTarget;
+  };
+
+  return { onClick, onMousedown, onMouseup };
+};

--- a/common/g-hooks/src/index.ts
+++ b/common/g-hooks/src/index.ts
@@ -17,3 +17,4 @@ export * from './composables/useFocusController';
 export * from './composables/useAttrs';
 export * from './composables/useEscapeKeydown';
 export * from './composables/useForwardRef';
+export * from './composables/useSameTarget';

--- a/common/g-hooks/tests/composables/useSameTarget.spec.ts
+++ b/common/g-hooks/tests/composables/useSameTarget.spec.ts
@@ -68,7 +68,7 @@ describe('useSameTarget', () => {
     onClick(makeMouseEvent(container, container));
     expect(handler).toHaveBeenCalledTimes(1);
 
-    // Second click without a preceding mousedown/mouseup pair must NOT fire.
+    // Un segundo click sin un par mousedown/mouseup previo NO debe disparar.
     onClick(makeMouseEvent(container, container));
     expect(handler).toHaveBeenCalledTimes(1);
   });

--- a/common/g-hooks/tests/composables/useSameTarget.spec.ts
+++ b/common/g-hooks/tests/composables/useSameTarget.spec.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi } from 'vitest';
+import { useSameTarget } from '../../src/composables/useSameTarget';
+
+const makeMouseEvent = (
+  target: EventTarget,
+  currentTarget: EventTarget,
+): MouseEvent => {
+  const event = new MouseEvent('click');
+  Object.defineProperty(event, 'target', { value: target });
+  Object.defineProperty(event, 'currentTarget', { value: currentTarget });
+  return event;
+};
+
+describe('useSameTarget', () => {
+  it('returns NOOP handlers for click/mousedown/mouseup when no handler is provided', () => {
+    const { onClick, onMousedown, onMouseup } = useSameTarget(undefined);
+
+    expect(() => onClick(makeMouseEvent(document, document))).not.toThrow();
+    expect(() => onMousedown(makeMouseEvent(document, document))).not.toThrow();
+    expect(() => onMouseup(makeMouseEvent(document, document))).not.toThrow();
+  });
+
+  it('invokes the handler when mousedown and mouseup/click both target the currentTarget', () => {
+    const handler = vi.fn();
+    const container = document.createElement('div');
+    const { onClick, onMousedown, onMouseup } = useSameTarget(handler);
+
+    onMousedown(makeMouseEvent(container, container));
+    onMouseup(makeMouseEvent(container, container));
+    onClick(makeMouseEvent(container, container));
+
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  it('does NOT invoke the handler when mousedown started on a different target (drag-selection guard)', () => {
+    const handler = vi.fn();
+    const container = document.createElement('div');
+    const child = document.createElement('span');
+    const { onClick, onMousedown, onMouseup } = useSameTarget(handler);
+
+    onMousedown(makeMouseEvent(child, container));
+    onMouseup(makeMouseEvent(container, container));
+    onClick(makeMouseEvent(container, container));
+
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it('does NOT invoke the handler when mouseup landed on a different target', () => {
+    const handler = vi.fn();
+    const container = document.createElement('div');
+    const child = document.createElement('span');
+    const { onClick, onMousedown, onMouseup } = useSameTarget(handler);
+
+    onMousedown(makeMouseEvent(container, container));
+    onMouseup(makeMouseEvent(child, container));
+    onClick(makeMouseEvent(container, container));
+
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it('resets the same-target flags after each click, requiring a fresh mousedown+mouseup pair', () => {
+    const handler = vi.fn();
+    const container = document.createElement('div');
+    const { onClick, onMousedown, onMouseup } = useSameTarget(handler);
+
+    onMousedown(makeMouseEvent(container, container));
+    onMouseup(makeMouseEvent(container, container));
+    onClick(makeMouseEvent(container, container));
+    expect(handler).toHaveBeenCalledTimes(1);
+
+    // Second click without a preceding mousedown/mouseup pair must NOT fire.
+    onClick(makeMouseEvent(container, container));
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+});

--- a/common/g-utils/src/index.ts
+++ b/common/g-utils/src/index.ts
@@ -19,3 +19,4 @@ export * from './composables/useNamespace';
 export * from './constants/event.constant';
 export * from './types/utils.type';
 export * from './types/component.type';
+export * from './types/vnode.type';

--- a/common/g-utils/src/types/vnode.type.ts
+++ b/common/g-utils/src/types/vnode.type.ts
@@ -1,0 +1,24 @@
+/**
+ * Portado byte-exact desde `PatchFlags` de element-plus 2.9.7
+ * (`es/utils/vue/vnode.mjs`, re-exportado como enum interno de Vue).
+ *
+ * Marca de bits que optimiza el diffing de VNodes creados manualmente con
+ * `createVNode`/`h`: le indica al renderer qué partes del nodo (clase,
+ * estilo, props, eventos, etc.) pueden cambiar en actualizaciones futuras,
+ * evitando comparaciones innecesarias.
+ */
+export enum PatchFlags {
+  TEXT = 1,
+  CLASS = 2,
+  STYLE = 4,
+  PROPS = 8,
+  FULL_PROPS = 16,
+  HYDRATE_EVENTS = 32,
+  STABLE_FRAGMENT = 64,
+  KEYED_FRAGMENT = 128,
+  UNKEYED_FRAGMENT = 256,
+  NEED_PATCH = 512,
+  DYNAMIC_SLOTS = 1024,
+  HOISTED = -1,
+  BAIL = -2,
+}

--- a/common/g-utils/tests/types/vnode.type.spec.ts
+++ b/common/g-utils/tests/types/vnode.type.spec.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest';
+import { PatchFlags } from '../../src/types/vnode.type';
+
+describe('PatchFlags', () => {
+  it('matches element-plus 2.9.7 numeric values exactly', () => {
+    expect(PatchFlags.TEXT).toBe(1);
+    expect(PatchFlags.CLASS).toBe(2);
+    expect(PatchFlags.STYLE).toBe(4);
+    expect(PatchFlags.PROPS).toBe(8);
+    expect(PatchFlags.FULL_PROPS).toBe(16);
+    expect(PatchFlags.HYDRATE_EVENTS).toBe(32);
+    expect(PatchFlags.STABLE_FRAGMENT).toBe(64);
+    expect(PatchFlags.KEYED_FRAGMENT).toBe(128);
+    expect(PatchFlags.UNKEYED_FRAGMENT).toBe(256);
+    expect(PatchFlags.NEED_PATCH).toBe(512);
+    expect(PatchFlags.DYNAMIC_SLOTS).toBe(1024);
+    expect(PatchFlags.HOISTED).toBe(-1);
+    expect(PatchFlags.BAIL).toBe(-2);
+  });
+
+  it('supports bitwise OR composition as used by overlay render flags', () => {
+    const combined = PatchFlags.STYLE | PatchFlags.CLASS | PatchFlags.PROPS;
+
+    expect(combined).toBe(14);
+  });
+});

--- a/components/overlay/overlay.ts
+++ b/components/overlay/overlay.ts
@@ -1,9 +1,14 @@
-import { createVNode, defineComponent, h, renderSlot } from 'vue'
-import { PatchFlags, buildProps, definePropType } from "element-plus/es/utils/index";
-import { useNamespace, useSameTarget } from "element-plus/es/hooks/index";
+import { createVNode, defineComponent, h, renderSlot } from 'vue';
+import {
+  PatchFlags,
+  buildProps,
+  definePropType,
+  useNamespace,
+} from '@flash-global66/g-utils';
+import { useSameTarget } from '@flash-global66/g-hooks';
 
-import type { CSSProperties, ExtractPropTypes } from 'vue'
-import type { Property } from 'csstype'
+import type { CSSProperties, ExtractPropTypes } from 'vue';
+import type { Property } from 'csstype';
 
 export const overlayProps = buildProps({
   mask: {
@@ -21,15 +26,15 @@ export const overlayProps = buildProps({
   zIndex: {
     type: definePropType<Property.ZIndex>([String, Number]),
   },
-} as const)
-export type OverlayProps = ExtractPropTypes<typeof overlayProps>
+} as const);
+export type OverlayProps = ExtractPropTypes<typeof overlayProps>;
 
 export const overlayEmits = {
   click: (evt: MouseEvent) => evt instanceof MouseEvent,
-}
-export type OverlayEmits = typeof overlayEmits
+};
+export type OverlayEmits = typeof overlayEmits;
 
-const BLOCK = 'overlay'
+const BLOCK = 'overlay';
 
 export default defineComponent({
   name: 'GOverlay',
@@ -38,22 +43,23 @@ export default defineComponent({
   emits: overlayEmits,
 
   setup(props, { slots, emit }) {
-    // No reactivity on this prop because when its rendering with a global
-    // component, this will be a constant flag.
-    const ns = useNamespace(BLOCK)
+    // Sin reactividad en esta prop porque, al renderizarse como componente
+    // global, este flag se mantiene constante.
+    const ns = useNamespace(BLOCK);
 
     const onMaskClick = (e: MouseEvent) => {
-      emit('click', e)
-    }
+      emit('click', e);
+    };
 
     const { onClick, onMousedown, onMouseup } = useSameTarget(
-      props.customMaskEvent ? undefined : onMaskClick
-    )
+      props.customMaskEvent ? undefined : onMaskClick,
+    );
 
-    // init here
+    // Inicialización del render.
     return () => {
-      // when the vnode meets the same structure but with different change trigger
-      // it will not automatically update, thus we simply use h function to manage updating
+      // Cuando el vnode mantiene la misma estructura pero cambia el trigger,
+      // no se actualiza automáticamente; por eso usamos `h`/`createVNode`
+      // directamente para gestionar la actualización.
       return props.mask
         ? createVNode(
             'div',
@@ -68,7 +74,7 @@ export default defineComponent({
             },
             [renderSlot(slots, 'default')],
             PatchFlags.STYLE | PatchFlags.CLASS | PatchFlags.PROPS,
-            ['onClick', 'onMouseup', 'onMousedown']
+            ['onClick', 'onMouseup', 'onMousedown'],
           )
         : h(
             'div',
@@ -83,10 +89,8 @@ export default defineComponent({
                 left: '0px',
               } as CSSProperties,
             },
-            [renderSlot(slots, 'default')]
-          )
-    }
+            [renderSlot(slots, 'default')],
+          );
+    };
   },
-})
-
-
+});

--- a/components/overlay/package.json
+++ b/components/overlay/package.json
@@ -13,5 +13,13 @@
   "repository": {
     "url": "https://github.com/Flash-Global66/global-design-system.git"
   },
+  "peerDependencies": {
+    "element-plus": "^2.9.0",
+    "vue": "^3.2.0"
+  },
+  "dependencies": {
+    "@flash-global66/g-hooks": "^0.6.0",
+    "@flash-global66/g-utils": "^0.5.0"
+  },
   "gitHead": "581df2757ad066a5cdd5a2e64500ab33a68279ad"
 }

--- a/openspec/changes/ep-extraction-v4/tasks.md
+++ b/openspec/changes/ep-extraction-v4/tasks.md
@@ -88,20 +88,20 @@ Publishes: `slot`. Est. ~220 changed lines. Requirements: same `popper-overlay-m
 
 Publishes: `overlay`. Est. ~180 changed lines. Requirements: same `popper-overlay-migration`/`g-hooks-package`/`g-utils-extended` set as WU-1; `shared-hook-single-ownership` (owns `useSameTarget`, shared with `dialog`/WU-7).
 
-- [ ] T3.1 Read EP's `useSameTarget` from `node_modules/element-plus/es/hooks/use-same-target/index.mjs` (2.9.7). Cross-check sibling `../element-plus/packages/hooks/use-same-target/`.
-- [ ] T3.2 Write failing unit test for `useSameTarget` (returned `onClick`/`onMousedown`/`onMouseup` only fire the handler when mousedown and mouseup/click targets are the same node — guards against drag-selection-triggered false positives) — new `common/g-hooks/tests/composables/useSameTarget.spec.ts`.
-- [ ] T3.3 Implement `useSameTarget` in `common/g-hooks/src/composables/useSameTarget.ts` — byte-exact copy. Run `yarn test:run` → green.
-- [ ] T3.4 Read EP's `PatchFlags` from `node_modules/element-plus/es/utils/vnode.mjs` (2.9.7 Vue-internal re-export). Cross-check sibling.
-- [ ] T3.5 Write failing unit test for `PatchFlags` (enum/const values match EP's exactly, e.g. `TEXT`, `CLASS`, `STYLE`, `PROPS`, `FULL_PROPS`, `HYDRATE_EVENTS`, `STABLE_FRAGMENT`, `KEYED_FRAGMENT`, `UNKEYED_FRAGMENT`, `NEED_PATCH`, `DYNAMIC_SLOTS`, `DEV_ROOT_FRAGMENT`, `HOISTED`, `BAIL`) — new `common/g-utils/tests/types/vnode.type.spec.ts`.
-- [ ] T3.6 Implement `PatchFlags` in `common/g-utils/src/types/vnode.type.ts` (or equivalent) — byte-exact copy. Run `yarn test:run` → green.
-- [ ] T3.7 Update `common/g-hooks/src/index.ts` and `common/g-utils/src/index.ts` barrels.
-- [ ] T3.8 Migrate `components/overlay/src/**`: re-point `buildProps`/`definePropType` → `@flash-global66/g-utils`; wire `useSameTarget`/`PatchFlags`. Zero public API change.
-- [ ] T3.9 Grep-verify zero `from ['"]element-plus` matches under `components/overlay/src/**` and `index.ts`.
-- [ ] T3.10 Confirm `overlay`'s `package.json` packaging convention.
-- [ ] T3.11 Remove `'components/overlay/**'` from `excludedFiles` in `.eslintrc.cjs`. `yarn lint --max-warnings 0` passes.
-- [ ] T3.12 `yarn build` succeeds for `overlay`. Full `yarn test:run` green.
-- [ ] T3.13 Validate in `front-b2b` (real copy).
-- [ ] T3.14 Commit as one work unit (`feat(overlay): migrate off element-plus internals, add useSameTarget/PatchFlags`), open PR #3 (parallel to PR #1/#2, targets `main`), Lerna-publish on merge.
+- [x] T3.1 Read EP's `useSameTarget` from `node_modules/element-plus/es/hooks/use-same-target/index.mjs` (2.9.7). Cross-check sibling `../element-plus/packages/hooks/use-same-target/`. (Identical algorithm; sibling only differs in `NOOP` import path — no drift.)
+- [x] T3.2 Write failing unit test for `useSameTarget` (returned `onClick`/`onMousedown`/`onMouseup` only fire the handler when mousedown and mouseup/click targets are the same node — guards against drag-selection-triggered false positives) — new `common/g-hooks/tests/composables/useSameTarget.spec.ts`.
+- [x] T3.3 Implement `useSameTarget` in `common/g-hooks/src/composables/useSameTarget.ts` — byte-exact copy. Run `yarn test:run` → green.
+- [x] T3.4 Read EP's `PatchFlags` from `node_modules/element-plus/es/utils/vue/vnode.mjs` (2.9.7; module path is `utils/vue/vnode`, not `utils/vnode` as brief anticipated). Cross-check sibling `packages/utils/vue/vnode.ts` — identical, ported as a real TS `enum` (matches EP's own `.d.ts export declare enum`).
+- [x] T3.5 Write failing unit test for `PatchFlags` (enum values match EP's exactly: `TEXT`, `CLASS`, `STYLE`, `PROPS`, `FULL_PROPS`, `HYDRATE_EVENTS`, `STABLE_FRAGMENT`, `KEYED_FRAGMENT`, `UNKEYED_FRAGMENT`, `NEED_PATCH`, `DYNAMIC_SLOTS`, `HOISTED`, `BAIL`, plus bitwise-OR composition) — new `common/g-utils/tests/types/vnode.type.spec.ts`. (EP 2.9.7 has no `DEV_ROOT_FRAGMENT` member; brief's list included it in error — omitted, matches source exactly.)
+- [x] T3.6 Implement `PatchFlags` in `common/g-utils/src/types/vnode.type.ts` — byte-exact copy. Run `yarn test:run` → green.
+- [x] T3.7 Update `common/g-hooks/src/index.ts` and `common/g-utils/src/index.ts` barrels.
+- [x] T3.8 Migrate `components/overlay/overlay.ts` (flat-layout package, no `src/**` — brief anticipated `src/**` in error): re-point `buildProps`/`definePropType`/`useNamespace` → `@flash-global66/g-utils`; `useSameTarget` → `@flash-global66/g-hooks`. Zero public API change. Comments translated to Spanish.
+- [x] T3.9 Grep-verify zero `from ['"]element-plus` matches under `components/overlay/overlay.ts` and `index.ts` (only a doc-comment URL reference remains in `index.ts`, not an import).
+- [x] T3.10 Confirm `overlay`'s `package.json` packaging convention: added `@flash-global66/g-hooks@^0.6.0` + `@flash-global66/g-utils@^0.5.0` to `dependencies`; added `element-plus@^2.9.0` + `vue@^3.2.0` to `peerDependencies` (package previously had none declared at all — `element-plus` kept/added because `overlay.styles.scss` still `@use`s its theme-chalk mixins, out of scope for this WU). `yarn install` run to sync `yarn.lock` workspace resolution.
+- [x] T3.11 Remove `'components/overlay/**'` from `excludedFiles` in `.eslintrc.cjs`. Scoped `yarn eslint components/overlay common/g-hooks/src common/g-utils/src common/g-hooks/tests common/g-utils/tests .eslintrc.cjs --max-warnings 0` passes (0 errors/warnings).
+- [x] T3.12 `yarn build` — `overlay` has no `buildable: true`/build script (ships raw TS like `g-hooks`/`g-utils`, confirmed via `scripts/build-components.js`), so this is a no-op for this package (consistent with the flat-layout, non-buildable convention). Full `yarn test:run`: 251/251 green across 34 files.
+- [ ] T3.13 Validate in `front-b2b` using a real copy. **Deferred**: same blocker as WU-1/WU-2 — requires a merged + Lerna-published `overlay` version; CodeCommit registry network access unavailable in this sandbox.
+- [ ] T3.14 Commit as one work unit, open PR #3, Lerna-publish on merge. **Partial**: implementation committed locally as 2 work-unit commits (`abadea8` feat g-hooks/g-utils, `860ae98` refactor overlay) on branch `feat/ds-ep-v4-wu3-overlay`, rebased onto `origin/main` @ `e38cd7a`. PR creation + publish deferred to orchestrator/reviewer per this apply phase's explicit instruction to stop after local commit.
 
 ## WU-4 — `scrollbar` (pure re-point; no dependencies)
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1343,6 +1343,12 @@ __metadata:
 "@flash-global66/g-overlay@workspace:components/overlay":
   version: 0.0.0-use.local
   resolution: "@flash-global66/g-overlay@workspace:components/overlay"
+  dependencies:
+    "@flash-global66/g-hooks": "npm:^0.6.0"
+    "@flash-global66/g-utils": "npm:^0.5.0"
+  peerDependencies:
+    element-plus: ^2.9.0
+    vue: ^3.2.0
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## ep-extraction-v4 · WU-3 (overlay)

Third work-unit of the **ep-extraction-v4** chain. Stacked-to-main, after WU-1 (focus-trap) and WU-2 (slot).

### What
Migrate `g-overlay` off element-plus **internal** imports with **zero public API change**:
- Port `useSameTarget` → `@flash-global66/g-hooks` (byte-exact from element-plus 2.9.7). overlay is the first consumer; `dialog` (WU-7) will re-point to it later.
- Port `PatchFlags` → `@flash-global66/g-utils` (`vnode.type.ts`, all 13 members/values matched against EP 2.9.7 `es/utils/vue/vnode.mjs`).
- Re-point `useNamespace`, `buildProps`, `definePropType` to existing `g-utils` exports.
- Declare `g-hooks: ^0.6.0` / `g-utils: ^0.5.0` in `dependencies` (matching current workspace versions).

### element-plus is intentionally KEPT here
`overlay` is a **styled** package: `overlay.styles.scss` does `@use "element-plus/theme-chalk/..."`. That theme coupling is out of scope for v4, so `element-plus` stays in `peerDependencies`. This WU only removes the **JS internal-utility** coupling, not the scss theme.

### Also: fix the EP-import guard for flat-layout packages
overlay is the first **flat-layout** package (implementation at `overlay.ts`, no `src/`) to go through the guard. The guard's `files` glob only covered `components/*/src/**` and `components/*/index.ts`, so it never actually linted `overlay.ts` — removing overlay from `excludedFiles` was a no-op. Broadened the glob to `components/*/*.ts` so flat-layout roots are guarded (verified: an `element-plus` import in `overlay.ts` now trips `no-restricted-imports`). This also covers future flat-layout packages (teleport, loader, …).

### Correctness
- element-plus **2.9.7** is the source of truth; ported byte-exact, no behavior change.
- Reviewed by two independent blind reviewers. They confirmed byte-exact parity (`useSameTarget`, `PatchFlags`), zero public API change, retained EP peer for scss, correct dep ranges, and Spanish comments. One MAJOR (the guard-glob gap above) and one NIT (an English test comment) were **fixed**.
- **251/251 unit tests passing**; scoped `eslint --max-warnings 0` clean.

### SDD
Part of `ep-extraction-v4` — proposal/spec/design/tasks under `openspec/changes/ep-extraction-v4/`.
