### PR TITLE
fix(g-utils): buildProps return type strips readonly (unblocks publish build:types)

### DIFF
--- a/common/g-utils/src/utils/props.util.ts
+++ b/common/g-utils/src/utils/props.util.ts
@@ -100,13 +100,35 @@ export const buildProp = <T>(prop: T, key?: string): T => {
 };
 
 /**
+ * Elimina recursivamente los modificadores `readonly` de un tipo, dejando
+ * intactos los constructores/funciones (p. ej. `StringConstructor`).
+ *
+ * Es necesario porque los componentes definen sus props con `as const`
+ * (mismo patrón que element-plus), lo que vuelve `readonly` los arrays del
+ * campo `type` (p. ej. `readonly [String, Number]`). `defineProps` exige
+ * arrays de props mutables, así que el tipo de retorno de `buildProps` debe
+ * "des-readonly-izar" la entrada. Para props definidas sin `as const` el
+ * mapeo es estructuralmente idéntico a la entrada (no cambia nada).
+ */
+type WritableProps<T> = T extends
+  | ((...args: any[]) => any)
+  | (abstract new (...args: any[]) => any)
+  ? T
+  : T extends readonly (infer U)[]
+    ? WritableProps<U>[]
+    : T extends object
+      ? { -readonly [K in keyof T]: WritableProps<T[K]> }
+      : T;
+
+/**
  * Construye y valida el mapa completo de props de un componente Vue.
  *
  * Aplica `buildProp` a cada entrada del objeto, añadiendo validadores
  * automáticos donde se definen conjuntos de valores permitidos.
  *
  * @param props - Objeto con las definiciones de todas las props del componente.
- * @returns El mismo objeto con cada prop procesada y validada.
+ * @returns El mismo objeto con cada prop procesada y validada, con el tipo
+ *   "des-readonly-izado" para ser compatible con `defineProps`.
  *
  * @example
  * const buttonProps = buildProps({
@@ -114,7 +136,9 @@ export const buildProp = <T>(prop: T, key?: string): T => {
  *   disabled: { type: Boolean, default: false },
  * })
  */
-export const buildProps = <T extends Record<string, any>>(props: T): T =>
+export const buildProps = <T extends Record<string, any>>(
+  props: T,
+): WritableProps<T> =>
   Object.fromEntries(
     Object.entries(props).map(([key, option]) => [key, buildProp(option, key)]),
-  ) as T;
+  ) as unknown as WritableProps<T>;


### PR DESCRIPTION
## Incident

The **Publish** workflow's `Build all components` step has been **failing on every merge** at `g-scrollbar`'s `build:types` (vue-tsc):

```
scrollbar.vue(60): TS2769 ... 'readonly [StringConstructor, NumberConstructor]' cannot be assigned to the mutable type '(PropConstructor|null)[]'
```

g-scrollbar (WU-4) never republished as a result, and the full-build gate blocks all subsequent publishes.

## Root cause

Components declare props with `buildProps({ ... } as const)` (the element-plus pattern). But the DS `buildProps` was typed as an **identity** (`<T>(props: T): T`), so the `as const` `readonly` modifiers leaked into the return type. `defineProps` requires **mutable** prop-option arrays, so any component combining `as const` with a `type: [A, B]` tuple fails `build:types`. (This would also hit `g-popper` next.)

The gap wasn't caught earlier because `build:types` doesn't run in the local sandbox ("vite not found"), and in PR Checks the `test` step fails first (separate issue) so the `build` step never runs — only the Publish workflow exercised it.

## Fix

Type `buildProps`' return as `WritableProps<T>`: recursively strips `readonly` modifiers **while treating call/construct signatures (constructors, `PropType`) as leaves**, so `definePropType<T>()` values are not mangled. It is a **no-op** for props declared without `as const` (structurally identical), so no other component's inferred types change. Runtime is unchanged (type-only).

## Verification

- `g-scrollbar` `build:types` (vue-tsc) now exits **0** (was the failing package).
- Full test suite: **251/251 passing** (runtime unaffected).
- Scoped eslint clean.

## Note

This PR's own `PR Checks` will show red on the **Unit tests** step — that is a *separate* CI issue (vitest can't resolve `@flash-global66/g-icon-font` / `g-form` in CI; local passes 251/251), addressed in a follow-up. This fix is independent and unblocks the publish build.