### PR TITLE
fix(ci): build before unit tests in PR Checks

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -71,14 +71,19 @@ jobs:
           echo "$FILES"
           yarn eslint $FILES --max-warnings 0
 
-      - name: Unit tests (Vitest)
-        run: yarn test:run
-
-      # Full build so `build:types` (vue-tsc) errors are caught in the PR, not
-      # after merge. This is heavier than lint/test (40+ components); if it ever
-      # becomes a bottleneck, scope it to affected packages
-      # (e.g. `lerna run build:types --since origin/main`) instead of the full
-      # `yarn build`. Kept full for now because latent type errors surface when
+      # Build BEFORE tests. Several packages are `buildable` and expose their
+      # entry via `exports` → `dist/` (e.g. g-form, g-icon-font). The unit tests
+      # import those packages by their bare specifier, so `dist/` must exist
+      # before Vitest can resolve them — in CI nothing is pre-built, so running
+      # tests first fails with "Failed to resolve entry for package
+      # @flash-global66/g-form". Building first also surfaces build:types
+      # (vue-tsc) errors before tests run. (source-only packages g-utils/g-hooks
+      # resolve from src and don't need this.)
+      #
+      # Full build (not scoped) because latent type errors surface when
       # dependency bumps force dependents to rebuild — a scoped run can miss them.
       - name: Build all components
         run: yarn build
+
+      - name: Unit tests (Vitest)
+        run: yarn test:run


### PR DESCRIPTION
## Problem

PR Checks' **Unit tests** step has been failing (red on #255/#256/#257/#258) with:
```
Error: Failed to resolve entry for package "@flash-global66/g-icon-font" ...
Error: Failed to resolve entry for package "@flash-global66/g-form" ...
4 failed | 30 passed (34)
```
Local `yarn test:run` passes 251/251.

## Root cause

`g-form` and `g-icon-font` are `buildable: true` and expose their entry only via `exports → ./dist/index.mjs`. The steps ran **lint → test → build**, so at test time `dist/` did not exist yet in CI (nothing pre-built) and Vitest couldn't resolve those bare imports. Locally it worked only because `dist/` lingered from earlier builds. (Source-only `g-utils`/`g-hooks` resolve from `src` and are unaffected.)

## Fix

Reorder to **lint → build → test**. `dist/` exists before Vitest resolves the packages. No extra cost (the full build already ran, just later); as a bonus, `build:types` errors now surface before tests.

## Note

Pairs with #258 (buildProps build:types fix): once both land, PR Checks go green again.