### PR TITLE
fix(g-hooks,components): use Symbol.for for cross-package injection keys

### DIFF
--- a/common/g-hooks/src/composables/useForwardRef.ts
+++ b/common/g-hooks/src/composables/useForwardRef.ts
@@ -20,7 +20,7 @@ export type ForwardRefInjectionContext = {
 };
 
 export const FORWARD_REF_INJECTION_KEY: InjectionKey<ForwardRefInjectionContext> =
-  Symbol('elForwardRef');
+  Symbol.for('elForwardRef');
 
 export const useForwardRef = <T>(forwardRef: Ref<T | null>): void => {
   const setForwardRef = ((el: T) => {

--- a/common/g-hooks/src/composables/useGlobalConfig.ts
+++ b/common/g-hooks/src/composables/useGlobalConfig.ts
@@ -27,7 +27,7 @@ export interface GlobalConfigContext {
 }
 
 export const gConfigProviderContextKey: InjectionKey<Ref<GlobalConfigContext>> =
-  Symbol('gConfigProviderContextKey');
+  Symbol.for('gConfigProviderContextKey');
 
 // Ref de módulo, fiel al fallback de element-plus (`const globalConfig = ref()`).
 const globalConfig = ref<GlobalConfigContext>({});

--- a/common/g-hooks/src/composables/useGlobalSize.ts
+++ b/common/g-hooks/src/composables/useGlobalSize.ts
@@ -14,7 +14,7 @@ export interface SizeInjectionContext {
  * Copiado del algoritmo `SIZE_INJECTION_KEY` de element-plus.
  */
 export const sizeInjectionKey: InjectionKey<SizeInjectionContext> =
-  Symbol('gSizeInjection');
+  Symbol.for('gSizeInjection');
 
 /**
  * Lee el tamaño global inyectado por el proveedor más cercano.

--- a/common/g-hooks/src/composables/useId.ts
+++ b/common/g-hooks/src/composables/useId.ts
@@ -26,7 +26,7 @@ export interface IdInjectionContext {
  * generando exactamente los mismos IDs.
  */
 export const idInjectionKey: InjectionKey<IdInjectionContext> =
-  Symbol('gIdInjection');
+  Symbol.for('gIdInjection');
 
 const defaultIdInjection: IdInjectionContext = {
   prefix: Math.floor(Math.random() * 1e4),

--- a/common/g-hooks/src/composables/useZIndex.ts
+++ b/common/g-hooks/src/composables/useZIndex.ts
@@ -26,10 +26,10 @@ export const defaultInitialZIndex = 2000;
 
 // Para SSR.
 export const ZINDEX_INJECTION_KEY: InjectionKey<ElZIndexInjectionContext> =
-  Symbol('elZIndexContextKey');
+  Symbol.for('elZIndexContextKey');
 
 export const zIndexContextKey: InjectionKey<Ref<number | undefined>> =
-  Symbol('zIndexContextKey');
+  Symbol.for('zIndexContextKey');
 
 export const useZIndex = (zIndexOverrides?: Ref<number>) => {
   const increasingInjection = getCurrentInstance()

--- a/common/g-utils/src/composables/useNamespace.ts
+++ b/common/g-utils/src/composables/useNamespace.ts
@@ -17,7 +17,7 @@ const statePrefix = 'is-';
  * // En el componente proveedor:
  * provide(namespaceContextKey, ref('gui'))
  */
-export const namespaceContextKey: InjectionKey<Ref<string>> = Symbol(
+export const namespaceContextKey: InjectionKey<Ref<string>> = Symbol.for(
   'namespaceContextKey',
 );
 

--- a/components/alert/useProviderAlert.ts
+++ b/components/alert/useProviderAlert.ts
@@ -1,6 +1,11 @@
 import { InjectionKey, reactive, inject, provide, nextTick } from 'vue';
 
-import { IAlertButton, IAlertProvider, IAlert, IAlertAttributesProvider } from './alert.type';
+import {
+  IAlertButton,
+  IAlertProvider,
+  IAlert,
+  IAlertAttributesProvider,
+} from './alert.type';
 
 const defaultValuesAttributes: IAlertAttributesProvider = {
   showAlert: false,
@@ -16,12 +21,12 @@ const defaultValuesAttributes: IAlertAttributesProvider = {
 
 const defaultValuesProvider: IAlertProvider = {
   ...defaultValuesAttributes,
-  onNext: async (action: IAlertButton) => {},
+  onNext: async () => {},
   hideAlert: () => {},
-  openAlert: (params: IAlert, method?: (action: IAlertButton) => Promise<void>) => {},
+  openAlert: () => {},
 };
 
-const alertProvider: InjectionKey<IAlertProvider> = Symbol('alertProvider');
+const alertProvider: InjectionKey<IAlertProvider> = Symbol.for('alertProvider');
 
 export function useAlertProvider() {
   const state = reactive<IAlertProvider>({ ...defaultValuesProvider });
@@ -31,7 +36,10 @@ export function useAlertProvider() {
   }
   state.hideAlert = hideAlert;
 
-  async function openAlert(params: IAlert, method?: (action: IAlertButton) => Promise<void>) {
+  async function openAlert(
+    params: IAlert,
+    method?: (action: IAlertButton) => Promise<void>,
+  ) {
     hideAlert();
 
     await nextTick();

--- a/components/checkbox/src/constants.ts
+++ b/components/checkbox/src/constants.ts
@@ -1,10 +1,12 @@
-import type { InjectionKey, ToRefs, WritableComputedRef } from 'vue'
-import type { CheckboxGroupProps } from './checkbox-group'
+import type { InjectionKey, ToRefs, WritableComputedRef } from 'vue';
+import type { CheckboxGroupProps } from './checkbox-group';
 
 type CheckboxGroupContext = {
-  modelValue?: WritableComputedRef<any>
-  changeEvent?: (...args: any) => any
-} & ToRefs<Pick<CheckboxGroupProps, 'min' | 'max' | 'disabled' | 'validateEvent'>>
+  modelValue?: WritableComputedRef<any>;
+  changeEvent?: (...args: any) => any;
+} & ToRefs<
+  Pick<CheckboxGroupProps, 'min' | 'max' | 'disabled' | 'validateEvent'>
+>;
 
 export const checkboxGroupContextKey: InjectionKey<CheckboxGroupContext> =
-  Symbol('checkboxGroupContextKey')
+  Symbol.for('checkboxGroupContextKey');

--- a/components/collapse/src/constants.ts
+++ b/components/collapse/src/constants.ts
@@ -1,11 +1,11 @@
-import type { InjectionKey, Ref } from 'vue'
-import type { CollapseActiveName } from './collapse'
+import type { InjectionKey, Ref } from 'vue';
+import type { CollapseActiveName } from './collapse';
 
 export interface CollapseContext {
-  activeNames: Ref<CollapseActiveName[]>
-  handleItemClick: (name: CollapseActiveName) => void
-  handleHeaderOnlyClick: (name: CollapseActiveName) => void
+  activeNames: Ref<CollapseActiveName[]>;
+  handleItemClick: (name: CollapseActiveName) => void;
+  handleHeaderOnlyClick: (name: CollapseActiveName) => void;
 }
 
 export const collapseContextKey: InjectionKey<CollapseContext> =
-  Symbol('collapseContextKey')
+  Symbol.for('collapseContextKey');

--- a/components/collection/src/collection.ts
+++ b/components/collection/src/collection.ts
@@ -1,81 +1,92 @@
-import { inject, onBeforeUnmount, onMounted, provide, ref, unref, defineComponent, h } from 'vue'
+import {
+  inject,
+  onBeforeUnmount,
+  onMounted,
+  provide,
+  ref,
+  unref,
+  defineComponent,
+  h,
+} from 'vue';
 
-import type { InjectionKey } from 'vue'
+import type { InjectionKey } from 'vue';
 import type {
   CollectionItem as CollectionItemType,
   GCollectionInjectionContext,
-  GCollectionItemInjectionContext
-} from './tokens'
+  GCollectionItemInjectionContext,
+} from './tokens';
 
-export const COLLECTION_ITEM_SIGN = `data-g-collection-item`
+export const COLLECTION_ITEM_SIGN = `data-g-collection-item`;
 
 export const createCollectionWithScope = (
-  name: string
+  name: string,
 ): {
-  COLLECTION_INJECTION_KEY: InjectionKey<GCollectionInjectionContext>
-  COLLECTION_ITEM_INJECTION_KEY: InjectionKey<GCollectionItemInjectionContext>
-  GCollection: any
-  GCollectionItem: any
+  COLLECTION_INJECTION_KEY: InjectionKey<GCollectionInjectionContext>;
+  COLLECTION_ITEM_INJECTION_KEY: InjectionKey<GCollectionItemInjectionContext>;
+  GCollection: any;
+  GCollectionItem: any;
 } => {
-  const COLLECTION_NAME = `G${name}Collection`
-  const COLLECTION_ITEM_NAME = `${COLLECTION_NAME}Item`
+  const COLLECTION_NAME = `G${name}Collection`;
+  const COLLECTION_ITEM_NAME = `${COLLECTION_NAME}Item`;
   const COLLECTION_INJECTION_KEY: InjectionKey<GCollectionInjectionContext> =
-    Symbol(COLLECTION_NAME)
+    Symbol.for(COLLECTION_NAME);
   const COLLECTION_ITEM_INJECTION_KEY: InjectionKey<GCollectionItemInjectionContext> =
-    Symbol(COLLECTION_ITEM_NAME)
+    Symbol.for(COLLECTION_ITEM_NAME);
 
   // Create GCollection component
   const GCollection = defineComponent({
     name: COLLECTION_NAME,
     setup(_, { slots }) {
-      const collectionRef = ref<HTMLElement>()
-      const itemMap: GCollectionInjectionContext['itemMap'] = new Map()
+      const collectionRef = ref<HTMLElement>();
+      const itemMap: GCollectionInjectionContext['itemMap'] = new Map();
       const getItems = <T>() => {
-        const collectionG = unref(collectionRef)
-        if (!collectionG) return []
-        const orderedNodes = Array.from(collectionG.querySelectorAll(`[${COLLECTION_ITEM_SIGN}]`))
-        const items = [...itemMap.values()]
+        const collectionG = unref(collectionRef);
+        if (!collectionG) return [];
+        const orderedNodes = Array.from(
+          collectionG.querySelectorAll(`[${COLLECTION_ITEM_SIGN}]`),
+        );
+        const items = [...itemMap.values()];
         return items.sort(
-          (a, b) => orderedNodes.indexOf(a.ref!) - orderedNodes.indexOf(b.ref!)
-        ) as CollectionItemType<T>[]
-      }
+          (a, b) => orderedNodes.indexOf(a.ref!) - orderedNodes.indexOf(b.ref!),
+        ) as CollectionItemType<T>[];
+      };
 
       provide(COLLECTION_INJECTION_KEY, {
         itemMap,
         getItems,
-        collectionRef
-      })
+        collectionRef,
+      });
 
-      return () => h('div', { ref: collectionRef }, slots.default?.())
-    }
-  })
+      return () => h('div', { ref: collectionRef }, slots.default?.());
+    },
+  });
 
   // Create GCollectionItem component
   const GCollectionItem = defineComponent({
     name: COLLECTION_ITEM_NAME,
     inheritAttrs: false,
     setup(_, { attrs, slots }) {
-      const collectionItemRef = ref<HTMLElement>()
-      const collectionInjection = inject(COLLECTION_INJECTION_KEY, undefined)!
+      const collectionItemRef = ref<HTMLElement>();
+      const collectionInjection = inject(COLLECTION_INJECTION_KEY, undefined)!;
 
       provide(COLLECTION_ITEM_INJECTION_KEY, {
-        collectionItemRef
-      })
+        collectionItemRef,
+      });
 
       onMounted(() => {
-        const collectionItemG = unref(collectionItemRef)
+        const collectionItemG = unref(collectionItemRef);
         if (collectionItemG) {
           collectionInjection.itemMap.set(collectionItemG, {
             ref: collectionItemG,
-            ...attrs
-          })
+            ...attrs,
+          });
         }
-      })
+      });
 
       onBeforeUnmount(() => {
-        const collectionItemG = unref(collectionItemRef)!
-        collectionInjection.itemMap.delete(collectionItemG)
-      })
+        const collectionItemG = unref(collectionItemRef)!;
+        collectionInjection.itemMap.delete(collectionItemG);
+      });
 
       return () =>
         h(
@@ -83,17 +94,17 @@ export const createCollectionWithScope = (
           {
             ref: collectionItemRef,
             [COLLECTION_ITEM_SIGN]: true,
-            ...attrs
+            ...attrs,
           },
-          slots.default?.()
-        )
-    }
-  })
+          slots.default?.(),
+        );
+    },
+  });
 
   return {
     COLLECTION_INJECTION_KEY,
     COLLECTION_ITEM_INJECTION_KEY,
     GCollection,
-    GCollectionItem
-  }
-}
+    GCollectionItem,
+  };
+};

--- a/components/date-picker/src/constants.ts
+++ b/components/date-picker/src/constants.ts
@@ -1,10 +1,10 @@
-import type { InjectionKey, SetupContext } from "vue";
-import type { UseNamespaceReturn } from "element-plus";
+import type { InjectionKey, SetupContext } from 'vue';
+import type { UseNamespaceReturn } from 'element-plus';
 
 interface DatePickerContext {
-  slots: SetupContext["slots"];
+  slots: SetupContext['slots'];
   pickerNs: UseNamespaceReturn;
 }
 
 export const ROOT_PICKER_INJECTION_KEY: InjectionKey<DatePickerContext> =
-  Symbol();
+  Symbol.for('rootPickerInjection');

--- a/components/dialog/src/constants.ts
+++ b/components/dialog/src/constants.ts
@@ -14,4 +14,4 @@ export type DialogContext = {
 };
 
 export const dialogInjectionKey: InjectionKey<DialogContext> =
-  Symbol('dialogInjectionKey');
+  Symbol.for('dialogInjectionKey');

--- a/components/dialog/src/types/types.ts
+++ b/components/dialog/src/types/types.ts
@@ -39,4 +39,4 @@ export interface DialogContext {
 }
 
 export const dialogInjectionKey: InjectionKey<DialogContext> =
-  Symbol('dialogInjectionKey');
+  Symbol.for('dialogInjectionKey');

--- a/components/dropdown/src/tokens.ts
+++ b/components/dropdown/src/tokens.ts
@@ -1,14 +1,14 @@
-import { PopperProps } from '@flash-global66/g-popper'
-import type { ComputedRef, InjectionKey, Ref } from 'vue'
+import { PopperProps } from '@flash-global66/g-popper';
+import type { ComputedRef, InjectionKey, Ref } from 'vue';
 
 export type GDropdownInjectionContext = {
-  contentRef: Ref<HTMLElement | undefined>
-  role: ComputedRef<PopperProps['role']>
-  triggerId: ComputedRef<string>
-  isUsingKeyboard: Ref<boolean>
-  onItemLeave: (e: PointerEvent) => void
-  onItemEnter: (e: PointerEvent) => void
-}
+  contentRef: Ref<HTMLElement | undefined>;
+  role: ComputedRef<PopperProps['role']>;
+  triggerId: ComputedRef<string>;
+  isUsingKeyboard: Ref<boolean>;
+  onItemLeave: (e: PointerEvent) => void;
+  onItemEnter: (e: PointerEvent) => void;
+};
 
 export const DROPDOWN_INJECTION_KEY: InjectionKey<GDropdownInjectionContext> =
-  Symbol('gDropdown')
+  Symbol.for('gDropdown');

--- a/components/focus-trap/src/tokens.ts
+++ b/components/focus-trap/src/tokens.ts
@@ -1,24 +1,24 @@
-import type { InjectionKey, Ref } from 'vue'
+import type { InjectionKey, Ref } from 'vue';
 
-export const FOCUS_AFTER_TRAPPED = 'focus-trap.focus-after-trapped'
-export const FOCUS_AFTER_RELEASED = 'focus-trap.focus-after-released'
-export const FOCUSOUT_PREVENTED = 'focus-trap.focusout-prevented'
+export const FOCUS_AFTER_TRAPPED = 'focus-trap.focus-after-trapped';
+export const FOCUS_AFTER_RELEASED = 'focus-trap.focus-after-released';
+export const FOCUSOUT_PREVENTED = 'focus-trap.focusout-prevented';
 export const FOCUS_AFTER_TRAPPED_OPTS: EventInit = {
   cancelable: true,
   bubbles: false,
-}
+};
 export const FOCUSOUT_PREVENTED_OPTS: EventInit = {
   cancelable: true,
   bubbles: false,
-}
+};
 
-export const ON_TRAP_FOCUS_EVT = 'focusAfterTrapped'
-export const ON_RELEASE_FOCUS_EVT = 'focusAfterReleased'
+export const ON_TRAP_FOCUS_EVT = 'focusAfterTrapped';
+export const ON_RELEASE_FOCUS_EVT = 'focusAfterReleased';
 
 export type FocusTrapInjectionContext = {
-  focusTrapRef: Ref<HTMLElement | undefined>
-  onKeydown: (e: KeyboardEvent) => void
-}
+  focusTrapRef: Ref<HTMLElement | undefined>;
+  onKeydown: (e: KeyboardEvent) => void;
+};
 
 export const FOCUS_TRAP_INJECTION_KEY: InjectionKey<FocusTrapInjectionContext> =
-  Symbol('elFocusTrap')
+  Symbol.for('elFocusTrap');

--- a/components/form/src/constants.ts
+++ b/components/form/src/constants.ts
@@ -1,7 +1,7 @@
-import type { InjectionKey } from "vue";
-import type { FormContext, FormItemContext } from "./types";
+import type { InjectionKey } from 'vue';
+import type { FormContext, FormItemContext } from './types';
 
 export const formContextKey: InjectionKey<FormContext> =
-  Symbol("formContextKey");
+  Symbol.for('formContextKey');
 export const formItemContextKey: InjectionKey<FormItemContext> =
-  Symbol("formItemContextKey");
+  Symbol.for('formItemContextKey');

--- a/components/loader/loader.provider.ts
+++ b/components/loader/loader.provider.ts
@@ -1,4 +1,4 @@
-import { InjectionKey, Ref, ref } from "vue";
+import { InjectionKey, Ref, ref } from 'vue';
 
 export type LoaderProviderType = {
   isLoading: Ref<boolean>;
@@ -7,7 +7,7 @@ export type LoaderProviderType = {
 };
 
 const showLoader: Ref<boolean> = ref(false);
-const loaderMessage: Ref<string> = ref("");
+const loaderMessage: Ref<string> = ref('');
 const intervalId: Ref<number | undefined> = ref();
 
 const initialValues: LoaderProviderType = {
@@ -20,6 +20,6 @@ const initialValues: LoaderProviderType = {
   },
 };
 
-const LoaderProvider: InjectionKey<LoaderProviderType> = Symbol("loader");
+const LoaderProvider: InjectionKey<LoaderProviderType> = Symbol.for('loader');
 
 export { LoaderProvider, initialValues, showLoader, loaderMessage, intervalId };

--- a/components/pagination/src/constants.ts
+++ b/components/pagination/src/constants.ts
@@ -1,12 +1,12 @@
-import type { ComputedRef, InjectionKey, WritableComputedRef } from 'vue'
+import type { ComputedRef, InjectionKey, WritableComputedRef } from 'vue';
 
 export interface ElPaginationContext {
-  currentPage?: WritableComputedRef<number>
-  pageCount?: ComputedRef<number>
-  disabled?: ComputedRef<boolean>
-  changeEvent?: (val: number) => void
-  handleSizeChange?: (val: number) => void
+  currentPage?: WritableComputedRef<number>;
+  pageCount?: ComputedRef<number>;
+  disabled?: ComputedRef<boolean>;
+  changeEvent?: (val: number) => void;
+  handleSizeChange?: (val: number) => void;
 }
 
 export const elPaginationKey: InjectionKey<ElPaginationContext> =
-  Symbol('gPaginationKey')
+  Symbol.for('gPaginationKey');

--- a/components/popper/src/constants.ts
+++ b/components/popper/src/constants.ts
@@ -1,9 +1,9 @@
-import type { CSSProperties, ComputedRef, InjectionKey, Ref } from 'vue'
-import type { Instance } from '@popperjs/core'
+import type { CSSProperties, ComputedRef, InjectionKey, Ref } from 'vue';
+import type { Instance } from '@popperjs/core';
 
 export type Measurable = {
-  getBoundingClientRect: () => DOMRect
-}
+  getBoundingClientRect: () => DOMRect;
+};
 
 /**
  * triggerRef indicates the element that triggers popper
@@ -11,21 +11,21 @@ export type Measurable = {
  * referenceRef indicates the element that popper content relative with
  */
 export type GPopperInjectionContext = {
-  triggerRef: Ref<Measurable | undefined>
-  contentRef: Ref<HTMLElement | undefined>
-  popperInstanceRef: Ref<Instance | undefined>
-  referenceRef: Ref<Measurable | undefined>
-  role: ComputedRef<string>
-}
+  triggerRef: Ref<Measurable | undefined>;
+  contentRef: Ref<HTMLElement | undefined>;
+  popperInstanceRef: Ref<Instance | undefined>;
+  referenceRef: Ref<Measurable | undefined>;
+  role: ComputedRef<string>;
+};
 
 export type GPopperContentInjectionContext = {
-  arrowRef: Ref<HTMLElement | undefined>
-  arrowOffset: Ref<number | undefined>
-  arrowStyle: ComputedRef<CSSProperties>
-}
+  arrowRef: Ref<HTMLElement | undefined>;
+  arrowOffset: Ref<number | undefined>;
+  arrowStyle: ComputedRef<CSSProperties>;
+};
 
 export const POPPER_INJECTION_KEY: InjectionKey<GPopperInjectionContext> =
-  Symbol('popper')
+  Symbol.for('popper');
 
 export const POPPER_CONTENT_INJECTION_KEY: InjectionKey<GPopperContentInjectionContext> =
-  Symbol('popperContent')
+  Symbol.for('popperContent');

--- a/components/radio/src/constants.ts
+++ b/components/radio/src/constants.ts
@@ -1,9 +1,9 @@
-import type { InjectionKey } from 'vue'
-import type { RadioGroupProps } from './radio-group'
+import type { InjectionKey } from 'vue';
+import type { RadioGroupProps } from './radio-group';
 
 export interface RadioGroupContext extends RadioGroupProps {
-  changeEvent: (val: RadioGroupProps['modelValue']) => void
+  changeEvent: (val: RadioGroupProps['modelValue']) => void;
 }
 
 export const radioGroupKey: InjectionKey<RadioGroupContext> =
-  Symbol('radioGroupKey')
+  Symbol.for('radioGroupKey');

--- a/components/roving-focus-group/src/tokens.ts
+++ b/components/roving-focus-group/src/tokens.ts
@@ -1,33 +1,33 @@
-import type { InjectionKey, Ref, StyleValue } from 'vue'
-import type { GRovingFocusGroupProps } from './roving-focus-group'
+import type { InjectionKey, Ref, StyleValue } from 'vue';
+import type { GRovingFocusGroupProps } from './roving-focus-group';
 
-type EventHandler<T = Event> = (e: T) => void
+type EventHandler<T = Event> = (e: T) => void;
 
 export type RovingGroupInjectionContext = {
-  currentTabbedId: Ref<string | null>
-  dir: Ref<GRovingFocusGroupProps['dir']>
-  loop: Ref<GRovingFocusGroupProps['loop']>
-  orientation: Ref<GRovingFocusGroupProps['orientation']>
-  tabIndex: Ref<number>
-  rovingFocusGroupRef: Ref<HTMLElement | undefined>
-  rovingFocusGroupRootStyle: Ref<StyleValue>
-  onBlur: EventHandler
-  onFocus: EventHandler<FocusEvent>
-  onMousedown: EventHandler
-  onItemFocus: (id: string) => void
-  onItemShiftTab: () => void
-}
+  currentTabbedId: Ref<string | null>;
+  dir: Ref<GRovingFocusGroupProps['dir']>;
+  loop: Ref<GRovingFocusGroupProps['loop']>;
+  orientation: Ref<GRovingFocusGroupProps['orientation']>;
+  tabIndex: Ref<number>;
+  rovingFocusGroupRef: Ref<HTMLElement | undefined>;
+  rovingFocusGroupRootStyle: Ref<StyleValue>;
+  onBlur: EventHandler;
+  onFocus: EventHandler<FocusEvent>;
+  onMousedown: EventHandler;
+  onItemFocus: (id: string) => void;
+  onItemShiftTab: () => void;
+};
 
 export type RovingFocusGroupItemInjectionContext = {
-  rovingFocusGroupItemRef: Ref<HTMLElement | undefined>
-  tabIndex: Ref<number>
-  handleMousedown: EventHandler
-  handleFocus: EventHandler
-  handleKeydown: EventHandler
-}
+  rovingFocusGroupItemRef: Ref<HTMLElement | undefined>;
+  tabIndex: Ref<number>;
+  handleMousedown: EventHandler;
+  handleFocus: EventHandler;
+  handleKeydown: EventHandler;
+};
 
 export const ROVING_FOCUS_GROUP_INJECTION_KEY: InjectionKey<RovingGroupInjectionContext> =
-  Symbol('gRovingFocusGroup')
+  Symbol.for('gRovingFocusGroup');
 
 export const ROVING_FOCUS_GROUP_ITEM_INJECTION_KEY: InjectionKey<RovingFocusGroupItemInjectionContext> =
-  Symbol('gRovingFocusGroupItem')
+  Symbol.for('gRovingFocusGroupItem');

--- a/components/scrollbar/src/constants.ts
+++ b/components/scrollbar/src/constants.ts
@@ -1,10 +1,10 @@
-import type { InjectionKey } from "vue";
+import type { InjectionKey } from 'vue';
 
 export interface ScrollbarContext {
   scrollbarElement: HTMLDivElement;
   wrapElement: HTMLDivElement;
 }
 
-export const scrollbarContextKey: InjectionKey<ScrollbarContext> = Symbol(
-  "scrollbarContextKey"
+export const scrollbarContextKey: InjectionKey<ScrollbarContext> = Symbol.for(
+  'scrollbarContextKey',
 );

--- a/components/select/src/types/token.ts
+++ b/components/select/src/types/token.ts
@@ -1,17 +1,19 @@
-import type { IOptionProps, ISelectProps } from '../defaults'
-import type { InjectionKey, Ref } from 'vue'
-import type { Option } from './select.types'
-import type { TooltipInstance } from 'element-plus'
+import type { IOptionProps, ISelectProps } from '../defaults';
+import type { InjectionKey, Ref } from 'vue';
+import type { Option } from './select.types';
+import type { TooltipInstance } from 'element-plus';
 
 export interface SelectV2Context {
-  props: ISelectProps
-  expanded: Ref<boolean>
-  tooltipRef: Ref<TooltipInstance | undefined>
-  onSelect: (option: Option) => void
-  onHover: (idx?: number) => void
-  onKeyboardNavigate: (direction: 'forward' | 'backward') => void
-  onKeyboardSelect: () => void
+  props: ISelectProps;
+  expanded: Ref<boolean>;
+  tooltipRef: Ref<TooltipInstance | undefined>;
+  onSelect: (option: Option) => void;
+  onHover: (idx?: number) => void;
+  onKeyboardNavigate: (direction: 'forward' | 'backward') => void;
+  onKeyboardSelect: () => void;
 }
 
-export const selectV2InjectionKey: InjectionKey<SelectV2Context> = Symbol('ElSelectV2Injection')
-export type { ISelectProps, IOptionProps }
+export const selectV2InjectionKey: InjectionKey<SelectV2Context> = Symbol.for(
+  'ElSelectV2Injection',
+);
+export type { ISelectProps, IOptionProps };

--- a/components/table/src/tokens.ts
+++ b/components/table/src/tokens.ts
@@ -1,5 +1,5 @@
-import type { InjectionKey } from 'vue'
-import type { DefaultRow, Table } from './table/defaults'
+import type { InjectionKey } from 'vue';
+import type { DefaultRow, Table } from './table/defaults';
 
 export const TABLE_INJECTION_KEY: InjectionKey<Table<DefaultRow>> =
-  Symbol('GTable')
+  Symbol.for('GTable');

--- a/components/tooltip/src/constants.ts
+++ b/components/tooltip/src/constants.ts
@@ -18,4 +18,4 @@ export type GTooltipInjectionContext = {
 };
 
 export const TOOLTIP_INJECTION_KEY: InjectionKey<GTooltipInjectionContext> =
-  Symbol('elTooltip');
+  Symbol.for('elTooltip');


### PR DESCRIPTION
## fix: cross-package injection keys use `Symbol.for` (fixes duplication breakage)

### Problem (proven in front-b2b)
Every DS Vue provide/inject key was a module-level `Symbol('x')`. When a defining package (g-hooks/g-utils, or a duplicated component package) is installed in **multiple versions** in a consumer — which happens because the migrated packages declare fragmented `^0.x` g-hooks/g-utils ranges — each physical copy owns a **distinct** `Symbol` instance. So a `provide` from one copy and an `inject` from another use different symbols and never match.

Observed live in b2b (`/home`, Navbar dropdown/tooltip):
- `[Vue warn]: injection "Symbol(elForwardRef)" not found` (forward-ref handshake broken)
- `TypeError: Cannot destructure property 'focusTrapRef' of 'inject(...)' as it is undefined` → `Maximum recursive updates exceeded in <GDropdown>` (focus-trap / collection keys broken → setup throws → render loop)

element-plus never hit this because it ships as **one** package (single Symbol instance). Splitting into per-component packages that share g-hooks defeats module-level `Symbol` keys under duplication.

`resolutions` in the consumer did **not** fix it (yarn can't fully dedupe incompatible `0.x` ranges). Patching `Symbol('elForwardRef')` → `Symbol.for('elForwardRef')` **did** — verified in b2b (warning gone).

### Fix
Convert **all cross-package injection keys** from `Symbol('x')` to `Symbol.for('x')` (same string). `Symbol.for` uses the global registry, so the key is the **identical instance across every duplicated module copy** — the handshake works regardless of how many versions are installed.

25 files across g-hooks, g-utils, and the component packages: forward-ref, config-provider, z-index, id, size, namespace, focus-trap, popper (+ content), dropdown, roving-focus-group (+ item), collection (dynamic keys), tooltip, pagination, form (+ item), radio, checkbox, collapse, dialog (unifies its duplicate key), table, alert, loader, select-v2, scrollbar, date-picker.

### Verification
- `yarn test:run` → **297/297 passing** (44 files); existing key tests (forward-ref handshake, config-provider key-distinct-from-EP) still green.
- `vue-tsc --noEmit` clean on focus-trap/popper/tooltip/dialog/select/collection/form/pagination/radio/checkbox/scrollbar; pre-existing (unrelated, git-stash-confirmed) type errors on dropdown/roving-focus/collapse/table/date-picker unchanged.
- Scoped `eslint --max-warnings 0` clean on all changed files.

### Follow-ups (not in this PR)
- **Fix B**: reduce the duplication at the source (g-hooks/g-utils → `1.0.0` so `^1.x` dedupes across minors, or align ranges) — also fixes shared module *state* (z-index counter, escape-listener registry) that `Symbol.for` doesn't cover.
- Optional hardening: namespace the `Symbol.for` strings (e.g. `@flash-global66/...`) to eliminate any theoretical global-registry collision.
- When the ep-extraction-v4 `select` WU lands, its new `useLocale`/`useEmptyValues` keys must also use `Symbol.for`.
