### PR TITLE
feat(dropdown): migrate off element-plus internals, add whenMouse (ep-extraction-v4 WU-9)

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -52,7 +52,6 @@ module.exports = {
         'components/table/**',
         'components/pagination/**',
         'components/input-number/**',
-        'components/dropdown/**',
         'components/date-picker/**',
         'components/collapse/**',
       ],

--- a/common/g-utils/src/types/utils.type.ts
+++ b/common/g-utils/src/types/utils.type.ts
@@ -28,6 +28,13 @@ export type EmitFn<E extends EmitsOptions> = SetupContext<E>['emit'];
 export type Arrayable<T> = T | T[];
 
 /**
+ * Representa un valor que puede ser `T` o `null`.
+ *
+ * Copiado del tipo `Nullable<T>` de element-plus (`packages/utils/typescript`).
+ */
+export type Nullable<T> = T | null;
+
+/**
  * Elimina el modificador `readonly` de todas las propiedades de `T`.
  *
  * Copiado del tipo helper `Mutable<T>` de element-plus.

--- a/common/g-utils/src/utils/function.util.ts
+++ b/common/g-utils/src/utils/function.util.ts
@@ -55,3 +55,22 @@ export const composeEventHandlers = <E>(
   };
   return handleEvent;
 };
+
+/** Manejador de eventos de puntero envuelto por `whenMouse`. */
+type WhenMouseHandler = (e: PointerEvent) => unknown;
+
+/**
+ * Envuelve un manejador de `PointerEvent` para que solo se ejecute cuando el
+ * puntero es un mouse (`pointerType === 'mouse'`). Para punteros táctiles o de
+ * lápiz (`touch`/`pen`) el handler se ignora y retorna `undefined`.
+ *
+ * Copiado del algoritmo exacto de element-plus para mantener paridad de
+ * comportamiento con los consumidores migrados (ej: `dropdown`).
+ *
+ * @param handler - Handler a ejecutar únicamente para eventos de mouse.
+ * @returns Un manejador de `PointerEvent` con el filtrado aplicado.
+ */
+export const whenMouse = (handler: WhenMouseHandler): WhenMouseHandler => {
+  return (e: PointerEvent) =>
+    e.pointerType === 'mouse' ? handler(e) : undefined;
+};

--- a/common/g-utils/tests/utils/function.util.spec.ts
+++ b/common/g-utils/tests/utils/function.util.spec.ts
@@ -3,6 +3,7 @@ import {
   NOOP,
   isFunction,
   composeEventHandlers,
+  whenMouse,
 } from '../../src/utils/function.util';
 
 describe('NOOP', () => {
@@ -59,5 +60,31 @@ describe('composeEventHandlers', () => {
   it('tolerates missing handlers', () => {
     const handler = composeEventHandlers<Event>(undefined, undefined);
     expect(() => handler({} as Event)).not.toThrow();
+  });
+});
+
+describe('whenMouse', () => {
+  it('invokes the handler for mouse pointer events', () => {
+    const inner = vi.fn(() => 'ok');
+    const wrapped = whenMouse(inner);
+    const event = { pointerType: 'mouse' } as PointerEvent;
+    const result = wrapped(event);
+    expect(inner).toHaveBeenCalledWith(event);
+    expect(result).toBe('ok');
+  });
+
+  it('ignores touch pointer events (returns undefined, does not call the handler)', () => {
+    const inner = vi.fn();
+    const wrapped = whenMouse(inner);
+    const result = wrapped({ pointerType: 'touch' } as PointerEvent);
+    expect(inner).not.toHaveBeenCalled();
+    expect(result).toBeUndefined();
+  });
+
+  it('ignores pen pointer events', () => {
+    const inner = vi.fn();
+    const wrapped = whenMouse(inner);
+    wrapped({ pointerType: 'pen' } as PointerEvent);
+    expect(inner).not.toHaveBeenCalled();
   });
 });

--- a/components/dropdown/index.ts
+++ b/components/dropdown/index.ts
@@ -1,24 +1,26 @@
-import { withInstall, withNoopInstall } from 'element-plus/es/utils/index'
+import { withInstall, withNoopInstall } from '@flash-global66/g-utils';
 
-import Dropdown from './src/dropdown.vue'
-import DropdownItem from './src/dropdown-item.vue'
-import DropdownMenu from './src/dropdown-menu.vue'
-import type { SFCWithInstall } from 'element-plus/es/utils/index'
+import Dropdown from './src/dropdown.vue';
+import DropdownItem from './src/dropdown-item.vue';
+import DropdownMenu from './src/dropdown-menu.vue';
+import type { SFCWithInstall } from '@flash-global66/g-utils';
 
 export const GDropdown: SFCWithInstall<typeof Dropdown> & {
-  DropdownItem: typeof DropdownItem
-  DropdownMenu: typeof DropdownMenu
+  DropdownItem: typeof DropdownItem;
+  DropdownMenu: typeof DropdownMenu;
 } = withInstall(Dropdown, {
   DropdownItem,
-  DropdownMenu
-})
-export default GDropdown
+  DropdownMenu,
+});
+export default GDropdown;
 
-export type GDropdownInstance = InstanceType<typeof Dropdown>
+export type GDropdownInstance = InstanceType<typeof Dropdown>;
 
-export const GDropdownItem: SFCWithInstall<typeof DropdownItem> = withNoopInstall(DropdownItem)
-export const GDropdownMenu: SFCWithInstall<typeof DropdownMenu> = withNoopInstall(DropdownMenu)
-export * from './src/dropdown'
-export * from './src/instance'
-export * from './src/tokens'
-export * from './src/dropdown.types'
+export const GDropdownItem: SFCWithInstall<typeof DropdownItem> =
+  withNoopInstall(DropdownItem);
+export const GDropdownMenu: SFCWithInstall<typeof DropdownMenu> =
+  withNoopInstall(DropdownMenu);
+export * from './src/dropdown';
+export * from './src/instance';
+export * from './src/tokens';
+export * from './src/dropdown.types';

--- a/components/dropdown/package.json
+++ b/components/dropdown/package.json
@@ -22,15 +22,19 @@
     "build": "vite build",
     "build:types": "vue-tsc --project tsconfig.json"
   },
+  "dependencies": {
+    "@flash-global66/g-collection": "^0.1.4",
+    "@flash-global66/g-focus-trap": "^0.1.9",
+    "@flash-global66/g-hooks": "^0.11.0",
+    "@flash-global66/g-icon-font": "^0.25.11",
+    "@flash-global66/g-popper": "^0.0.17",
+    "@flash-global66/g-roving-focus-group": "^0.1.17",
+    "@flash-global66/g-scrollbar": "^0.1.6",
+    "@flash-global66/g-slot": "^0.0.11",
+    "@flash-global66/g-tooltip": "^0.1.5",
+    "@flash-global66/g-utils": "^0.8.0"
+  },
   "peerDependencies": {
-    "@flash-global66/g-collection": "^0.1.1",
-    "@flash-global66/g-focus-trap": "^0.0.9",
-    "@flash-global66/g-icon-font": "^0.13.0",
-    "@flash-global66/g-popper": "^0.0.10",
-    "@flash-global66/g-roving-focus-group": "^0.1.1",
-    "@flash-global66/g-scrollbar": "^0.1.0",
-    "@flash-global66/g-slot": "^0.0.2",
-    "@flash-global66/g-tooltip": "^0.1.0",
     "@popperjs/core": "^2.11.6",
     "element-plus": "^2.9.0",
     "vue": "^3.2.0"

--- a/components/dropdown/src/dropdown-item-impl.vue
+++ b/components/dropdown/src/dropdown-item-impl.vue
@@ -1,5 +1,9 @@
 <template>
-  <li v-if="divided" role="separator" :class="ns.bem('menu', 'item', 'divided')" />
+  <li
+    v-if="divided"
+    role="separator"
+    :class="ns.bem('menu', 'item', 'divided')"
+  />
   <li
     :ref="itemRef"
     v-bind="{ ...dataset, ...$attrs }"
@@ -9,24 +13,31 @@
     :role="role"
     :data-test="attrs['data-test'] ?? `dropdown-item:${title}`"
     @click="
-      (e) => {
+      e => {
         if (action) {
-          action?.(e)
+          action?.(e);
         }
-        $emit('clickimpl', e)
+        $emit('clickimpl', e);
       }
     "
     @focus="handleFocus"
     @keydown.self="handleKeydown"
     @mousedown="handleMousedown"
-    @pointermove="(e) => $emit('pointermove', e)"
-    @pointerleave="(e) => $emit('pointerleave', e)"
+    @pointermove="e => $emit('pointermove', e)"
+    @pointerleave="e => $emit('pointerleave', e)"
   >
     <slot name="default">
-      <g-icon-font v-if="Boolean(icon)" :name="icon" :class="ns.bem('menu', 'item', 'icon')" />
+      <g-icon-font
+        v-if="Boolean(icon)"
+        :name="icon"
+        :class="ns.bem('menu', 'item', 'icon')"
+      />
       <div :class="ns.bem('menu', 'item', 'content')">
         <span :class="ns.bem('menu', 'item', 'title')">{{ title }}</span>
-        <span v-if="Boolean(description)" :class="ns.bem('menu', 'item', 'description')">
+        <span
+          v-if="Boolean(description)"
+          :class="ns.bem('menu', 'item', 'description')"
+        >
           {{ description }}
         </span>
       </div>
@@ -35,77 +46,88 @@
 </template>
 
 <script lang="ts">
-import { computed, defineComponent, inject } from 'vue'
+import { computed, defineComponent, inject } from 'vue';
 import {
   ROVING_FOCUS_GROUP_ITEM_INJECTION_KEY,
-  ROVING_FOCUS_ITEM_COLLECTION_INJECTION_KEY
-} from '@flash-global66/g-roving-focus-group'
-import { COLLECTION_ITEM_SIGN } from '@flash-global66/g-collection'
-import { GIconFont } from '@flash-global66/g-icon-font'
-import { useNamespace, EVENT_CODE } from 'element-plus'
-import { composeEventHandlers, composeRefs } from 'element-plus/es/utils/index'
-import { DROPDOWN_COLLECTION_ITEM_INJECTION_KEY, dropdownItemProps } from './dropdown'
-import { DROPDOWN_INJECTION_KEY } from './tokens'
+  ROVING_FOCUS_ITEM_COLLECTION_INJECTION_KEY,
+} from '@flash-global66/g-roving-focus-group';
+import { COLLECTION_ITEM_SIGN } from '@flash-global66/g-collection';
+import { GIconFont } from '@flash-global66/g-icon-font';
+import {
+  useNamespace,
+  EVENT_CODE,
+  composeEventHandlers,
+  composeRefs,
+} from '@flash-global66/g-utils';
+import {
+  DROPDOWN_COLLECTION_ITEM_INJECTION_KEY,
+  dropdownItemProps,
+} from './dropdown';
+import { DROPDOWN_INJECTION_KEY } from './tokens';
 
 export default defineComponent({
   name: 'DropdownItemImpl',
   components: {
-    GIconFont
+    GIconFont,
   },
   props: dropdownItemProps,
   emits: ['pointermove', 'pointerleave', 'click', 'clickimpl'],
   setup(_, { emit, attrs }) {
-    const ns = useNamespace('dropdown')
+    const ns = useNamespace('dropdown');
 
-    const { role: menuRole } = inject(DROPDOWN_INJECTION_KEY, undefined)!
+    const { role: menuRole } = inject(DROPDOWN_INJECTION_KEY, undefined)!;
 
     const { collectionItemRef: dropdownCollectionItemRef } = inject(
       DROPDOWN_COLLECTION_ITEM_INJECTION_KEY,
-      undefined
-    )!
+      undefined,
+    )!;
 
     const { collectionItemRef: rovingFocusCollectionItemRef } = inject(
       ROVING_FOCUS_ITEM_COLLECTION_INJECTION_KEY,
-      undefined
-    )!
+      undefined,
+    )!;
 
     const {
       rovingFocusGroupItemRef,
       tabIndex,
       handleFocus,
       handleKeydown: handleItemKeydown,
-      handleMousedown
-    } = inject(ROVING_FOCUS_GROUP_ITEM_INJECTION_KEY, undefined)!
+      handleMousedown,
+    } = inject(ROVING_FOCUS_GROUP_ITEM_INJECTION_KEY, undefined)!;
 
     const itemRef = composeRefs(
       dropdownCollectionItemRef,
       rovingFocusCollectionItemRef,
-      rovingFocusGroupItemRef
-    )
+      rovingFocusGroupItemRef,
+    );
 
     const role = computed<string>(() => {
       if (menuRole.value === 'menu') {
-        return 'menuitem'
+        return 'menuitem';
       } else if (menuRole.value === 'navigation') {
-        return 'link'
+        return 'link';
       }
-      return 'button'
-    })
+      return 'button';
+    });
 
     const handleKeydown = composeEventHandlers((e: KeyboardEvent) => {
-      if ([EVENT_CODE.enter, EVENT_CODE.numpadEnter, EVENT_CODE.space].includes(e.code)) {
-        e.preventDefault()
-        e.stopImmediatePropagation()
-        emit('clickimpl', e)
-        return true
+      if (
+        [EVENT_CODE.enter, EVENT_CODE.numpadEnter, EVENT_CODE.space].includes(
+          e.code,
+        )
+      ) {
+        e.preventDefault();
+        e.stopImmediatePropagation();
+        emit('clickimpl', e);
+        return true;
       }
-    }, handleItemKeydown)
+    }, handleItemKeydown);
 
     return {
       ns,
       itemRef,
       dataset: {
-        [COLLECTION_ITEM_SIGN]: ''
+        [COLLECTION_ITEM_SIGN]: '',
       },
 
       role,
@@ -113,8 +135,8 @@ export default defineComponent({
       handleFocus,
       handleKeydown,
       handleMousedown,
-      attrs
-    }
-  }
-})
+      attrs,
+    };
+  },
+});
 </script>

--- a/components/dropdown/src/dropdown-item.vue
+++ b/components/dropdown/src/dropdown-item.vue
@@ -1,5 +1,8 @@
 <template>
-  <g-dropdown-collection-item :disabled="disabled" :text-value="title ?? textContent">
+  <g-dropdown-collection-item
+    :disabled="disabled"
+    :text-value="title ?? textContent"
+  >
     <g-roving-focus-item :focusable="!disabled">
       <g-dropdown-item-impl
         v-bind="propsAndAttrs"
@@ -14,43 +17,56 @@
 </template>
 
 <script lang="ts">
-import { computed, defineComponent, getCurrentInstance, inject, ref, unref } from 'vue'
-import { GRovingFocusItem } from '@flash-global66/g-roving-focus-group'
-import { composeEventHandlers, whenMouse } from 'element-plus/es/utils/index'
-import GDropdownItemImpl from './dropdown-item-impl.vue'
-import { useDropdown } from './useDropdown'
-import { GCollectionItem as GDropdownCollectionItem, dropdownItemProps } from './dropdown'
-import { DROPDOWN_INJECTION_KEY } from './tokens'
+import {
+  computed,
+  defineComponent,
+  getCurrentInstance,
+  inject,
+  ref,
+  unref,
+} from 'vue';
+import { GRovingFocusItem } from '@flash-global66/g-roving-focus-group';
+import { composeEventHandlers, whenMouse } from '@flash-global66/g-utils';
+import GDropdownItemImpl from './dropdown-item-impl.vue';
+import { useDropdown } from './useDropdown';
+import {
+  GCollectionItem as GDropdownCollectionItem,
+  dropdownItemProps,
+} from './dropdown';
+import { DROPDOWN_INJECTION_KEY } from './tokens';
 
 export default defineComponent({
   name: 'GDropdownItem',
   components: {
     GDropdownCollectionItem,
     GRovingFocusItem,
-    GDropdownItemImpl
+    GDropdownItemImpl,
   },
   inheritAttrs: false,
   props: dropdownItemProps,
   emits: ['pointermove', 'pointerleave', 'click'],
   setup(props, { emit, attrs }) {
-    const { gDropdown } = useDropdown()
-    const _instance = getCurrentInstance()
-    const itemRef = ref<HTMLElement | null>(null)
-    const textContent = computed(() => unref(itemRef)?.textContent ?? '')
-    const { onItemEnter, onItemLeave } = inject(DROPDOWN_INJECTION_KEY, undefined)!
+    const { gDropdown } = useDropdown();
+    const _instance = getCurrentInstance();
+    const itemRef = ref<HTMLElement | null>(null);
+    const textContent = computed(() => unref(itemRef)?.textContent ?? '');
+    const { onItemEnter, onItemLeave } = inject(
+      DROPDOWN_INJECTION_KEY,
+      undefined,
+    )!;
 
     const handlePointerMove = composeEventHandlers(
       (e: PointerEvent) => {
-        emit('pointermove', e)
-        return e.defaultPrevented
+        emit('pointermove', e);
+        return e.defaultPrevented;
       },
-      whenMouse((e) => {
+      whenMouse(e => {
         if (props.disabled) {
-          onItemLeave(e)
-          return
+          onItemLeave(e);
+          return;
         }
 
-        const target = e.currentTarget as HTMLElement
+        const target = e.currentTarget as HTMLElement;
         /**
          * This handles the following scenario:
          *   when the item contains a form element such as input element
@@ -58,52 +74,55 @@ export default defineComponent({
          *   the item, the default focusing logic should be prevented so that
          *   it won't cause weird action.
          */
-        if (target === document.activeElement || target.contains(document.activeElement)) {
-          return
+        if (
+          target === document.activeElement ||
+          target.contains(document.activeElement)
+        ) {
+          return;
         }
 
-        onItemEnter(e)
+        onItemEnter(e);
         if (!e.defaultPrevented) {
-          target?.focus()
+          target?.focus();
         }
-      })
-    )
+      }),
+    );
 
     const handlePointerLeave = composeEventHandlers((e: PointerEvent) => {
-      emit('pointerleave', e)
-      return e.defaultPrevented
-    }, whenMouse(onItemLeave))
+      emit('pointerleave', e);
+      return e.defaultPrevented;
+    }, whenMouse(onItemLeave));
 
     const handleClick = composeEventHandlers(
       (e: PointerEvent) => {
         if (props.disabled) {
-          return
+          return;
         }
-        emit('click', e)
-        return e.type !== 'keydown' && e.defaultPrevented
+        emit('click', e);
+        return e.type !== 'keydown' && e.defaultPrevented;
       },
-      (e) => {
+      e => {
         if (props.disabled) {
-          e.stopImmediatePropagation()
-          return
+          e.stopImmediatePropagation();
+          return;
         }
         if (gDropdown?.hideOnClick?.value) {
-          gDropdown.handleClick?.()
+          gDropdown.handleClick?.();
         }
-        gDropdown.commandHandler?.(props.command, _instance, e)
-      }
-    )
+        gDropdown.commandHandler?.(props.command, _instance, e);
+      },
+    );
 
     // direct usage of v-bind={ ...$props, ...$attrs } causes type errors
-    const propsAndAttrs = computed(() => ({ ...props, ...attrs }))
+    const propsAndAttrs = computed(() => ({ ...props, ...attrs }));
 
     return {
       handleClick,
       handlePointerMove,
       handlePointerLeave,
       textContent,
-      propsAndAttrs
-    }
-  }
-})
+      propsAndAttrs,
+    };
+  },
+});
 </script>

--- a/components/dropdown/src/dropdown-menu.vue
+++ b/components/dropdown/src/dropdown-menu.vue
@@ -16,37 +16,47 @@
 </template>
 
 <script lang="ts">
-import { computed, defineComponent, inject, unref } from 'vue'
-import { composeEventHandlers, composeRefs } from 'element-plus/es/utils/index'
-import { useNamespace, EVENT_CODE } from 'element-plus'
-import { FOCUS_TRAP_INJECTION_KEY } from '@flash-global66/g-focus-trap'
+import { computed, defineComponent, inject, unref } from 'vue';
+import {
+  composeEventHandlers,
+  composeRefs,
+  useNamespace,
+  EVENT_CODE,
+} from '@flash-global66/g-utils';
+import { FOCUS_TRAP_INJECTION_KEY } from '@flash-global66/g-focus-trap';
 import {
   ROVING_FOCUS_COLLECTION_INJECTION_KEY,
   ROVING_FOCUS_GROUP_INJECTION_KEY,
-  focusFirst
-} from '@flash-global66/g-roving-focus-group'
-import { DROPDOWN_INJECTION_KEY } from './tokens'
+  focusFirst,
+} from '@flash-global66/g-roving-focus-group';
+import { DROPDOWN_INJECTION_KEY } from './tokens';
 import {
   DROPDOWN_COLLECTION_INJECTION_KEY,
   FIRST_LAST_KEYS,
   LAST_KEYS,
-  dropdownMenuProps
-} from './dropdown'
+  dropdownMenuProps,
+} from './dropdown';
 
 export default defineComponent({
   name: 'GDropdownMenu',
   props: dropdownMenuProps,
   setup(props) {
-    const ns = useNamespace('dropdown')
+    const ns = useNamespace('dropdown');
 
-    const { focusTrapRef, onKeydown } = inject(FOCUS_TRAP_INJECTION_KEY, undefined)!
+    const { focusTrapRef, onKeydown } = inject(
+      FOCUS_TRAP_INJECTION_KEY,
+      undefined,
+    )!;
 
-    const { contentRef, role, triggerId } = inject(DROPDOWN_INJECTION_KEY, undefined)!
+    const { contentRef, role, triggerId } = inject(
+      DROPDOWN_INJECTION_KEY,
+      undefined,
+    )!;
 
     const { collectionRef: dropdownCollectionRef, getItems } = inject(
       DROPDOWN_COLLECTION_INJECTION_KEY,
-      undefined
-    )!
+      undefined,
+    )!;
 
     const {
       rovingFocusGroupRef,
@@ -54,58 +64,63 @@ export default defineComponent({
       tabIndex,
       onBlur,
       onFocus,
-      onMousedown
-    } = inject(ROVING_FOCUS_GROUP_INJECTION_KEY, undefined)!
+      onMousedown,
+    } = inject(ROVING_FOCUS_GROUP_INJECTION_KEY, undefined)!;
 
     const { collectionRef: rovingFocusGroupCollectionRef } = inject(
       ROVING_FOCUS_COLLECTION_INJECTION_KEY,
-      undefined
-    )!
+      undefined,
+    )!;
 
     const dropdownKls = computed(() => {
-      return [ns.b('menu')]
-    })
+      return [ns.b('menu')];
+    });
 
     const dropdownListWrapperRef = composeRefs(
       contentRef,
       dropdownCollectionRef,
       focusTrapRef,
       rovingFocusGroupRef,
-      rovingFocusGroupCollectionRef
-    )
+      rovingFocusGroupCollectionRef,
+    );
 
     const composedKeydown = composeEventHandlers(
       (e: KeyboardEvent) => {
-        props.onKeydown?.(e)
+        props.onKeydown?.(e);
       },
-      (e) => {
-        const { currentTarget, code, target } = e
-        const isKeydownContained = (currentTarget as Node).contains(target as Node)
+      e => {
+        const { currentTarget, code, target } = e;
+        const isKeydownContained = (currentTarget as Node).contains(
+          target as Node,
+        );
 
         if (isKeydownContained) {
           // TODO: implement typeahead search
         }
 
         if (EVENT_CODE.tab === code) {
-          e.stopImmediatePropagation()
+          e.stopImmediatePropagation();
         }
 
-        e.preventDefault()
+        e.preventDefault();
 
-        if (target !== unref(contentRef) || !FIRST_LAST_KEYS.includes(code)) return
-        const items = getItems<{ disabled: boolean }>().filter((item) => !item.disabled)
-        const targets = items.map((item) => item.ref!)
+        if (target !== unref(contentRef) || !FIRST_LAST_KEYS.includes(code))
+          return;
+        const items = getItems<{ disabled: boolean }>().filter(
+          item => !item.disabled,
+        );
+        const targets = items.map(item => item.ref!);
         if (LAST_KEYS.includes(code)) {
-          targets.reverse()
+          targets.reverse();
         }
-        focusFirst(targets)
-      }
-    )
+        focusFirst(targets);
+      },
+    );
 
     const handleKeydown = (e: KeyboardEvent) => {
-      composedKeydown(e)
-      onKeydown(e)
-    }
+      composedKeydown(e);
+      onKeydown(e);
+    };
 
     return {
       rovingFocusGroupRootStyle,
@@ -117,8 +132,8 @@ export default defineComponent({
       handleKeydown,
       onBlur,
       onFocus,
-      onMousedown
-    }
-  }
-})
+      onMousedown,
+    };
+  },
+});
 </script>

--- a/components/dropdown/src/dropdown.ts
+++ b/components/dropdown/src/dropdown.ts
@@ -1,25 +1,31 @@
-import { buildProps, definePropType } from 'element-plus/es/utils/index'
-import { EVENT_CODE } from 'element-plus'
-import { createCollectionWithScope } from '@flash-global66/g-collection'
-import { useTooltipContentProps, useTooltipTriggerProps } from '@flash-global66/g-tooltip'
+import {
+  buildProps,
+  definePropType,
+  EVENT_CODE,
+} from '@flash-global66/g-utils';
+import { createCollectionWithScope } from '@flash-global66/g-collection';
+import {
+  useTooltipContentProps,
+  useTooltipTriggerProps,
+} from '@flash-global66/g-tooltip';
 
-import { type Placement, roleTypes } from '@flash-global66/g-popper'
-import type { Options } from '@popperjs/core'
-import type { ComponentInternalInstance, ComputedRef, PropType } from 'vue'
-import type { IconString } from '@flash-global66/g-icon-font'
-import type { Nullable } from 'element-plus/es/utils/index'
-import type { actionType } from './dropdown.types'
+import { type Placement, roleTypes } from '@flash-global66/g-popper';
+import type { Options } from '@popperjs/core';
+import type { ComponentInternalInstance, ComputedRef, PropType } from 'vue';
+import type { IconString } from '@flash-global66/g-icon-font';
+import type { Nullable } from '@flash-global66/g-utils';
+import type { actionType } from './dropdown.types';
 
 export interface IGDropdownInstance {
-  instance?: ComponentInternalInstance
-  dropdownSize?: ComputedRef<string>
-  handleClick?: () => void
-  commandHandler?: (...arg: any[]) => void
-  show?: () => void
-  hide?: () => void
-  trigger?: ComputedRef<string>
-  hideOnClick?: ComputedRef<boolean>
-  triggerElm?: ComputedRef<Nullable<HTMLButtonElement>>
+  instance?: ComponentInternalInstance;
+  dropdownSize?: ComputedRef<string>;
+  handleClick?: () => void;
+  commandHandler?: (...arg: any[]) => void;
+  show?: () => void;
+  hide?: () => void;
+  trigger?: ComputedRef<string>;
+  hideOnClick?: ComputedRef<boolean>;
+  triggerElm?: ComputedRef<Nullable<HTMLButtonElement>>;
 }
 
 export const dropdownProps = buildProps({
@@ -29,21 +35,26 @@ export const dropdownProps = buildProps({
   trigger: useTooltipTriggerProps.trigger,
   triggerKeys: {
     type: definePropType<string[]>(Array),
-    default: () => [EVENT_CODE.enter, EVENT_CODE.numpadEnter, EVENT_CODE.space, EVENT_CODE.down]
+    default: () => [
+      EVENT_CODE.enter,
+      EVENT_CODE.numpadEnter,
+      EVENT_CODE.space,
+      EVENT_CODE.down,
+    ],
   },
   /**
    * @description placement of pop menu
    */
   placement: {
     type: definePropType<Placement>(String),
-    default: 'bottom'
+    default: 'bottom',
   },
   /**
    * @description [popper.js](https://popper.js.org/docs/v2/) parameters
    */
   popperOptions: {
     type: definePropType<Partial<Options>>(Object),
-    default: () => ({})
+    default: () => ({}),
   },
   id: String,
   /**
@@ -51,51 +62,51 @@ export const dropdownProps = buildProps({
    */
   hideOnClick: {
     type: Boolean,
-    default: true
+    default: true,
   },
   loop: {
     type: Boolean,
-    default: true
+    default: true,
   },
   /**
    * @description delay time before show a dropdown (only works when trigger is `hover`)
    */
   showTimeout: {
     type: Number,
-    default: 150
+    default: 150,
   },
   /**
    * @description delay time before hide a dropdown (only works when trigger is `hover`)
    */
   hideTimeout: {
     type: Number,
-    default: 150
+    default: 150,
   },
   /**
    * @description [tabindex](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/tabindex) of Dropdown
    */
   tabindex: {
     type: definePropType<number | string>([Number, String]),
-    default: 0
+    default: 0,
   },
   /**
    * @description the max height of menu
    */
   maxHeight: {
     type: definePropType<number | string>([Number, String]),
-    default: ''
+    default: '',
   },
   /**
    * @description custom class name for Dropdown's dropdown
    */
   popperClass: {
     type: String,
-    default: ''
+    default: '',
   },
   actions: {
     type: definePropType<actionType[]>(Array),
     required: true,
-    default: () => []
+    default: () => [],
   },
   /**
    * @description whether to disable
@@ -107,7 +118,7 @@ export const dropdownProps = buildProps({
   role: {
     type: String,
     values: roleTypes,
-    default: 'menu'
+    default: 'menu',
   },
   /**
    * @description whether the dropdown popup is teleported to the body
@@ -118,9 +129,9 @@ export const dropdownProps = buildProps({
    */
   persistent: {
     type: Boolean,
-    default: true
-  }
-} as const)
+    default: true,
+  },
+} as const);
 
 export const dropdownItemProps = buildProps({
   /**
@@ -128,7 +139,7 @@ export const dropdownItemProps = buildProps({
    */
   command: {
     type: [Object, String, Number],
-    default: () => ({})
+    default: () => ({}),
   },
   /**
    * @description whether the item is disabled
@@ -144,7 +155,7 @@ export const dropdownItemProps = buildProps({
   title: {
     type: String,
     default: '',
-    required: true
+    required: true,
   },
   /**
    * @description description of the item
@@ -158,26 +169,34 @@ export const dropdownItemProps = buildProps({
    * @description custom icon
    */
   icon: {
-    type: String as PropType<IconString>
-  }
-} as const)
+    type: String as PropType<IconString>,
+  },
+} as const);
 
 export const dropdownMenuProps = buildProps({
-  onKeydown: { type: definePropType<(e: KeyboardEvent) => void>(Function) }
-})
+  onKeydown: { type: definePropType<(e: KeyboardEvent) => void>(Function) },
+});
 
-export const FIRST_KEYS = [EVENT_CODE.down, EVENT_CODE.pageDown, EVENT_CODE.home]
+export const FIRST_KEYS = [
+  EVENT_CODE.down,
+  EVENT_CODE.pageDown,
+  EVENT_CODE.home,
+];
 
-export const LAST_KEYS = [EVENT_CODE.up, EVENT_CODE.pageUp, EVENT_CODE.end]
+export const LAST_KEYS = [EVENT_CODE.up, EVENT_CODE.pageUp, EVENT_CODE.end];
 
-export const FIRST_LAST_KEYS = [...FIRST_KEYS, ...LAST_KEYS]
+export const FIRST_LAST_KEYS = [...FIRST_KEYS, ...LAST_KEYS];
 
-const { GCollection, GCollectionItem, COLLECTION_INJECTION_KEY, COLLECTION_ITEM_INJECTION_KEY } =
-  createCollectionWithScope('Dropdown')
+const {
+  GCollection,
+  GCollectionItem,
+  COLLECTION_INJECTION_KEY,
+  COLLECTION_ITEM_INJECTION_KEY,
+} = createCollectionWithScope('Dropdown');
 
 export {
   GCollection,
   GCollectionItem,
   COLLECTION_INJECTION_KEY as DROPDOWN_COLLECTION_INJECTION_KEY,
-  COLLECTION_ITEM_INJECTION_KEY as DROPDOWN_COLLECTION_ITEM_INJECTION_KEY
-}
+  COLLECTION_ITEM_INJECTION_KEY as DROPDOWN_COLLECTION_ITEM_INJECTION_KEY,
+};

--- a/components/dropdown/src/dropdown.types.ts
+++ b/components/dropdown/src/dropdown.types.ts
@@ -1,10 +1,18 @@
+import type { IconString } from '@flash-global66/g-icon-font';
+
 export type actionType = {
-  title: string
-  icon?: string
-  description?: string
-  disabled?: boolean
-  action?: () => void
-  command?: string | number | Record<string, any>
-  divider?: boolean
-  [x: string]: string | number | Record<string, any> | undefined | boolean | Function
-}
+  title: string;
+  icon?: IconString;
+  description?: string;
+  disabled?: boolean;
+  action?: () => void;
+  command?: string | number | Record<string, any>;
+  divider?: boolean;
+  [x: string]:
+    | string
+    | number
+    | Record<string, any>
+    | undefined
+    | boolean
+    | ((...args: unknown[]) => unknown);
+};

--- a/components/dropdown/src/dropdown.vue
+++ b/components/dropdown/src/dropdown.vue
@@ -29,7 +29,12 @@
       @before-hide="handleBeforeHideTooltip"
     >
       <template #content>
-        <g-scrollbar ref="scrollbar" :wrap-style="wrapStyle" tag="div" :view-class="ns.e('list')">
+        <g-scrollbar
+          ref="scrollbar"
+          :wrap-style="wrapStyle"
+          tag="div"
+          :view-class="ns.e('list')"
+        >
           <slot name="dropdown-additional-top" />
           <g-roving-focus-group
             :loop="loop"
@@ -57,7 +62,12 @@
         </g-scrollbar>
       </template>
       <template #default>
-        <g-only-child :id="triggerId" ref="triggeringElementRef" role="button" :tabindex="tabindex">
+        <g-only-child
+          :id="triggerId"
+          ref="triggeringElementRef"
+          role="button"
+          :tabindex="tabindex"
+        >
           <slot name="default" />
         </g-only-child>
       </template>
@@ -76,22 +86,21 @@ import {
   ref,
   toRef,
   unref,
-  watch
-} from 'vue'
-import GTooltip from '@flash-global66/g-tooltip'
-import GScrollbar from '@flash-global66/g-scrollbar'
-import { GIconFont } from '@flash-global66/g-icon-font'
-import GRovingFocusGroup from '@flash-global66/g-roving-focus-group'
-import { GOnlyChild } from '@flash-global66/g-slot'
-import { addUnit, ensureArray } from 'element-plus/es/utils/index'
-import GDropdownMenu from './dropdown-menu.vue'
-import GDropdownItem from './dropdown-item.vue'
-import { useId, useLocale, useNamespace } from 'element-plus'
-import { GCollection as GDropdownCollection, dropdownProps } from './dropdown'
-import { DROPDOWN_INJECTION_KEY } from './tokens'
+  watch,
+} from 'vue';
+import GTooltip from '@flash-global66/g-tooltip';
+import GScrollbar from '@flash-global66/g-scrollbar';
+import GRovingFocusGroup from '@flash-global66/g-roving-focus-group';
+import { GOnlyChild } from '@flash-global66/g-slot';
+import { addUnit, ensureArray, useNamespace } from '@flash-global66/g-utils';
+import GDropdownMenu from './dropdown-menu.vue';
+import GDropdownItem from './dropdown-item.vue';
+import { useId, useLocale } from '@flash-global66/g-hooks';
+import { GCollection as GDropdownCollection, dropdownProps } from './dropdown';
+import { DROPDOWN_INJECTION_KEY } from './tokens';
 
-import type { TooltipInstance } from '@flash-global66/g-tooltip'
-import type { CSSProperties } from 'vue'
+import type { TooltipInstance } from '@flash-global66/g-tooltip';
+import type { CSSProperties } from 'vue';
 
 export default defineComponent({
   name: 'GDropdown',
@@ -103,30 +112,29 @@ export default defineComponent({
     GTooltip,
     GRovingFocusGroup,
     GOnlyChild,
-    GIconFont
   },
   props: dropdownProps,
   emits: ['visible-change', 'click', 'command'],
   setup(props, { emit }) {
-    const _instance = getCurrentInstance()
-    const ns = useNamespace('dropdown')
-    const { t } = useLocale()
+    const _instance = getCurrentInstance();
+    const ns = useNamespace('dropdown');
+    const { t } = useLocale();
 
-    const triggeringElementRef = ref()
-    const referenceElementRef = ref()
-    const popperRef = ref<TooltipInstance>()
-    const contentRef = ref<HTMLElement>()
-    const scrollbar = ref(null)
-    const currentTabId = ref<string | null>(null)
-    const isUsingKeyboard = ref(false)
+    const triggeringElementRef = ref();
+    const referenceElementRef = ref();
+    const popperRef = ref<TooltipInstance>();
+    const contentRef = ref<HTMLElement>();
+    const scrollbar = ref(null);
+    const currentTabId = ref<string | null>(null);
+    const isUsingKeyboard = ref(false);
 
     const wrapStyle = computed<CSSProperties>(() => ({
-      maxHeight: addUnit(props.maxHeight)
-    }))
-    const trigger = computed(() => ensureArray(props.trigger))
+      maxHeight: addUnit(props.maxHeight),
+    }));
+    const trigger = computed(() => ensureArray(props.trigger));
 
-    const defaultTriggerId = useId().value
-    const triggerId = computed<string>(() => props.id || defaultTriggerId)
+    const defaultTriggerId = useId().value;
+    const triggerId = computed<string>(() => props.id || defaultTriggerId);
 
     // The goal of this code is to focus on the tooltip triggering element when it is hovered.
     // This is a temporary fix for where closing the dropdown through pointerleave event focuses on a
@@ -136,42 +144,57 @@ export default defineComponent({
       [triggeringElementRef, trigger],
       ([triggeringElement, trigger], [prevTriggeringElement]) => {
         if (prevTriggeringElement?.$el?.removeEventListener) {
-          prevTriggeringElement.$el.removeEventListener('pointerenter', onAutofocusTriggerEnter)
+          prevTriggeringElement.$el.removeEventListener(
+            'pointerenter',
+            onAutofocusTriggerEnter,
+          );
         }
         if (triggeringElement?.$el?.removeEventListener) {
-          triggeringElement.$el.removeEventListener('pointerenter', onAutofocusTriggerEnter)
+          triggeringElement.$el.removeEventListener(
+            'pointerenter',
+            onAutofocusTriggerEnter,
+          );
         }
-        if (triggeringElement?.$el?.addEventListener && trigger.includes('hover')) {
-          triggeringElement.$el.addEventListener('pointerenter', onAutofocusTriggerEnter)
+        if (
+          triggeringElement?.$el?.addEventListener &&
+          trigger.includes('hover')
+        ) {
+          triggeringElement.$el.addEventListener(
+            'pointerenter',
+            onAutofocusTriggerEnter,
+          );
         }
       },
-      { immediate: true, flush: 'post' }
-    )
+      { immediate: true, flush: 'post' },
+    );
 
     onBeforeUnmount(() => {
       if (triggeringElementRef.value?.$el?.removeEventListener) {
-        triggeringElementRef.value.$el.removeEventListener('pointerenter', onAutofocusTriggerEnter)
+        triggeringElementRef.value.$el.removeEventListener(
+          'pointerenter',
+          onAutofocusTriggerEnter,
+        );
       }
-    })
+    });
 
     function handleClick() {
-      handleClose()
+      handleClose();
     }
 
     function handleClose() {
-      popperRef.value?.onClose()
+      popperRef.value?.onClose();
     }
 
     function handleOpen() {
-      popperRef.value?.onOpen()
+      popperRef.value?.onOpen();
     }
 
     function commandHandler(...args: any[]) {
-      emit('command', ...args)
+      emit('command', ...args);
     }
 
     function onAutofocusTriggerEnter() {
-      triggeringElementRef?.value?.$el?.focus()
+      triggeringElementRef?.value?.$el?.focus();
     }
 
     function onItemEnter() {
@@ -179,45 +202,45 @@ export default defineComponent({
     }
 
     function onItemLeave() {
-      const contentEl = unref(contentRef)
+      const contentEl = unref(contentRef);
 
       if (trigger.value.includes('hover') && contentEl) {
         // Use nextTick to avoid recursive updates
         nextTick(() => {
-          contentEl?.focus()
-        })
+          contentEl?.focus();
+        });
       }
-      currentTabId.value = null
+      currentTabId.value = null;
     }
 
     function handleCurrentTabIdChange(id: string) {
       // Use nextTick to avoid recursive updates
       nextTick(() => {
-        currentTabId.value = id
-      })
+        currentTabId.value = id;
+      });
     }
 
     function handleEntryFocus(e: Event) {
       if (!isUsingKeyboard.value) {
-        e.preventDefault()
-        e.stopImmediatePropagation()
+        e.preventDefault();
+        e.stopImmediatePropagation();
       }
     }
 
     function handleBeforeShowTooltip() {
-      emit('visible-change', true)
+      emit('visible-change', true);
     }
 
     function handleShowTooltip(event?: Event) {
       if (event?.type === 'keydown' && contentRef?.value) {
         nextTick(() => {
-          contentRef?.value?.focus()
-        })
+          contentRef?.value?.focus();
+        });
       }
     }
 
     function handleBeforeHideTooltip() {
-      emit('visible-change', false)
+      emit('visible-change', false);
     }
 
     provide(DROPDOWN_INJECTION_KEY, {
@@ -226,32 +249,32 @@ export default defineComponent({
       triggerId,
       isUsingKeyboard,
       onItemEnter,
-      onItemLeave
-    })
+      onItemLeave,
+    });
 
     provide('gDropdown', {
       instance: _instance,
       handleClick,
       commandHandler,
       trigger: toRef(props, 'trigger'),
-      hideOnClick: toRef(props, 'hideOnClick')
-    })
+      hideOnClick: toRef(props, 'hideOnClick'),
+    });
 
     const onFocusAfterTrapped = (e: Event) => {
-      e.preventDefault()
+      e.preventDefault();
       if (contentRef?.value?.focus) {
         // Use nextTick to avoid recursive updates
         nextTick(() => {
           contentRef.value?.focus({
-            preventScroll: true
-          })
-        })
+            preventScroll: true,
+          });
+        });
       }
-    }
+    };
 
     const handlerMainButtonClick = (event: MouseEvent) => {
-      emit('click', event)
-    }
+      emit('click', event);
+    };
 
     return {
       t,
@@ -273,8 +296,8 @@ export default defineComponent({
       contentRef,
       triggeringElementRef,
       referenceElementRef,
-      actions: computed(() => props.actions)
-    }
-  }
-})
+      actions: computed(() => props.actions),
+    };
+  },
+});
 </script>

--- a/openspec/changes/ep-extraction-v4/tasks.md
+++ b/openspec/changes/ep-extraction-v4/tasks.md
@@ -209,22 +209,19 @@ Publishes: `select`. Est. ~380 changed lines (watch budget). Requirements: `popp
 
 Publishes: `dropdown`. Est. ~400 changed lines (widest internal dependency surface in the slice per design §3/§6 — treat as the review-budget risk item). Requirements: `popper-overlay-migration` full set; `g-hooks-package` → `popper-overlay-composables-added`, `shared-hook-single-ownership` (owns `useLocale`, shared with WU-10 date-picker + WU-11 time-picker), `v4-hooks-unit-tested`.
 
-- [ ] T9.1 Confirm PR #6 (tooltip), PR #4 (scrollbar), and PR #7 (dialog) are merged before starting — `dropdown`'s fan-out touches focus-trap, roving-focus-group, collection, tooltip, scrollbar, icon-font, slot, popper (per design §3, most already clean or migrated by this point).
-- [ ] T9.2 Read EP's `whenMouse` from `node_modules/element-plus/es/components/dropdown/src/utils.mjs` (or wherever the 2.9.7 compiled path places it — confirm exact module). Cross-check sibling `../element-plus/packages/components/dropdown/src/utils.ts`.
-- [ ] T9.3 Write failing unit test for `whenMouse` (wraps a handler so it only fires for `PointerEvent`s where `pointerType === 'mouse'`; touch/pen pointer events are ignored) — new `common/g-hooks/tests/composables/whenMouse.spec.ts`.
-- [ ] T9.4 Implement `whenMouse` in `common/g-hooks/src/composables/whenMouse.ts` — byte-exact copy. Run `yarn test:run` → green.
-- [ ] T9.5 Read EP's `useLocale` from `node_modules/element-plus/es/hooks/use-locale/index.mjs` (2.9.7). Cross-check sibling.
-- [ ] T9.6 Write failing unit test for `useLocale` (returns `{ lang, locale, t }`; `locale` reflects an ancestor-provided override when present; falls back to a default locale/translation table when no override exists; `t()` resolves a translation key against the resolved locale) — new `common/g-hooks/tests/composables/useLocale.spec.ts`.
-- [ ] T9.7 Implement `useLocale` in `common/g-hooks/src/composables/useLocale.ts` — byte-exact copy. Run `yarn test:run` → green.
-- [ ] T9.8 Update `common/g-hooks/src/index.ts` barrel for `whenMouse`, `useLocale`.
-- [ ] T9.9 Migrate `components/dropdown/src/**`: re-point `composeRefs` from WU-7 (`@flash-global66/g-utils`); `composeEventHandlers`/`useId`/`addUnit`/`ensureArray`/`EVENT_CODE` → `@flash-global66/g-utils`/`g-hooks`; re-point remaining focus-trap/roving-focus-group/collection/tooltip/scrollbar/icon-font/slot/popper imports to their DS packages; wire `whenMouse`/`useLocale`. Zero public API change.
-- [ ] T9.10 Grep-verify zero `from ['"]element-plus` matches under `components/dropdown/src/**` and `index.ts`.
-- [ ] T9.11 Confirm `dropdown`'s `package.json` packaging convention across its wide dependency set.
-- [ ] T9.12 Remove `'components/dropdown/**'` from `excludedFiles` in `.eslintrc.cjs`. `yarn lint --max-warnings 0` passes.
-- [ ] T9.13 `yarn build` succeeds for `dropdown`. Full `yarn test:run` green.
-- [ ] T9.14 Validate in `front-b2b` (real copy).
-- [ ] T9.15 **Line-budget checkpoint (high-probability trigger)**: given the widest fan-out in the slice, this WU is the most likely to exceed 400 lines. If so, split into sequential commits by concern (hook additions first, then package re-point wiring) within the same PR — do NOT bundle any part of this WU with `select`'s PR (design/proposal explicit constraint).
-- [ ] T9.16 Commit as one work unit or the split from T9.15 (`feat(dropdown): migrate off element-plus internals, add whenMouse/useLocale`), open PR #9 (depends on PR #6 + PR #4 + PR #7 merged; its own dedicated PR), Lerna-publish on merge.
+- [x] T9.1 Confirmed WU-6/WU-4/WU-7 merged (and WU-5 popper, WU-8 select) before starting; branch rebased on current `main`.
+- [x] T9.2 Read EP's `whenMouse` — actual 2.9.7 path is `node_modules/element-plus/es/utils/dom/event.mjs` (co-located with `composeEventHandlers`, NOT `components/dropdown/src/utils`). Cross-checked sibling `../element-plus/packages/utils/dom/event.ts`.
+- [x] T9.3/T9.4 **Brief drift (placement)**: `whenMouse` is a pure function (no Vue reactivity), so ported into `common/g-utils/src/utils/function.util.ts` beside `composeEventHandlers` (mirrors EP's own `dom/event.ts` co-location), NOT `g-hooks/composables`. Failing test then green in `common/g-utils/tests/utils/function.util.spec.ts` (3 whenMouse cases; EP `any`→`unknown` per no-`any` mandate). Also ported `Nullable` type into `g-utils/types/utils.type.ts` (dropdown is first g-utils consumer).
+- [x] T9.5/T9.6/T9.7 **Superseded by WU-8**: `useLocale` (+ `en` lang pack, `gLocaleContextKey`) was already ported to `g-hooks` in WU-8 (select was the real first consumer). No re-port — dropdown just consumes it.
+- [x] T9.8 Barrel: `whenMouse`/`Nullable` auto-exported via `g-utils`'s `export *`; `useLocale` already in `g-hooks` barrel (WU-8).
+- [x] T9.9 Migrated 6 files (`dropdown.ts`, `dropdown.vue`, `dropdown-item.vue`, `dropdown-item-impl.vue`, `dropdown-menu.vue`, `index.ts`): `buildProps`/`definePropType`/`EVENT_CODE`/`composeEventHandlers`/`composeRefs`/`whenMouse`/`addUnit`/`ensureArray`/`useNamespace`/`withInstall`/`withNoopInstall`/`Nullable`/`SFCWithInstall` → g-utils; `useId`/`useLocale` → g-hooks. Zero public API change **except** the approved `actionType.icon: string → IconString` tightening (aligns the exported type with the already-existing `dropdown-item` `icon: PropType<IconString>` contract; cross-package to g-chip, verified no g-chip regression).
+- [x] T9.10 Grep-verified zero `from 'element-plus'` under `components/dropdown/src/**` + `index.ts` (scss `@use "element-plus/theme-chalk/..."` correctly retained).
+- [x] T9.11 Adopted the **tooltip packaging convention**: all 10 directly-imported `@flash-global66/*` in `dependencies` with ranges aligned to current workspace versions; only `@popperjs/core`/`element-plus`/`vue` as peers. Fixed the recurring bug (previously missing g-hooks/g-utils, stale peer ranges).
+- [x] T9.12 Removed `'components/dropdown/**'` from `.eslintrc.cjs`; fixed the 2 lint errors it surfaced (dead `GIconFont` registration in `dropdown.vue`; `Function` type → callable signature in `actionType` index signature). `eslint --max-warnings 0` clean.
+- [x] T9.13 `vue-tsc` on dropdown + g-chip: identical error profile to `origin/main` baseline (only environmental TS7016 from unbuilt local `dist/`, which CI resolves via build-before-typecheck). Full `test:run` → 324/324 green.
+- [ ] T9.14 **DEFERRED**: b2b real-copy validation batched with the popper family (tooltip+select+dropdown) after all three publish, per the agreed plan.
+- [x] T9.15 Line-budget: WU came in via re-points (no re-implementation, since useLocale pre-existed); split into a feature commit + a small stories-icon-fix commit. Not bundled with select's PR.
+- [x] T9.16 Committed (`feat(dropdown): migrate off element-plus internals, add whenMouse`); PR #264-follow (WU-9) opened as its own dedicated PR; Lerna-publish on merge. Dual blind review: both judges APPROVE-WITH-NITS.
 
 ## WU-10 — `date-picker` (deep migration + in-place lint-debt fix; depends on WU-9, WU-8)
 

--- a/stories/dropdown.stories.ts
+++ b/stories/dropdown.stories.ts
@@ -1,17 +1,27 @@
-import { StoryObj } from '@storybook/vue3'
-import { ref } from 'vue'
+import { StoryObj } from '@storybook/vue3';
+import { ref } from 'vue';
 
 // COMPONENTS
-import { GDropdown, GDropdownInstance, type actionType } from '@flash-global66/g-dropdown/index.ts'
-import { GButton } from '@flash-global66/g-button'
-import { GIconButton } from '@flash-global66/g-icon-button/index.ts'
-import { GRadioGroup } from '@flash-global66/g-radio/index.ts'
-import GTag from '@flash-global66/g-tag/index.ts'
+import {
+  GDropdown,
+  GDropdownInstance,
+  type actionType,
+} from '@flash-global66/g-dropdown/index.ts';
+import { GButton } from '@flash-global66/g-button';
+import { GIconButton } from '@flash-global66/g-icon-button/index.ts';
+import { GRadioGroup } from '@flash-global66/g-radio/index.ts';
+import GTag from '@flash-global66/g-tag/index.ts';
 
 // CONFIG
-import { GConfigProvider } from '../components/config-provider/index.ts'
-import { version, peerDependencies } from '@flash-global66/g-dropdown/package.json'
-import { generatePeerDepsInstalls, generatePeerDepsList } from '../helper/documentation-stories'
+import { GConfigProvider } from '../components/config-provider/index.ts';
+import {
+  version,
+  peerDependencies,
+} from '@flash-global66/g-dropdown/package.json';
+import {
+  generatePeerDepsInstalls,
+  generatePeerDepsList,
+} from '../helper/documentation-stories';
 
 const meta = {
   title: 'Data/Dropdown',
@@ -90,7 +100,7 @@ const actions: actionType[] = [
   },
   {
     title: 'Buscar',
-    icon: 'regular magnifying-glass',
+    icon: 'regular search',
     description: 'Esta acción te permite buscar un elemento',
     action: () => {
       console.log('Buscar')
@@ -109,9 +119,9 @@ const actions: actionType[] = [
 ]
 </script>
 \`\`\`
-`
-      }
-    }
+`,
+      },
+    },
   },
   argTypes: {
     // 1. Apariencia y Dimensiones
@@ -122,19 +132,26 @@ const actions: actionType[] = [
       table: {
         category: 'Apariencia y Dimensiones',
         type: { summary: 'string | number' },
-        defaultValue: { summary: '100%' }
-      }
+        defaultValue: { summary: '100%' },
+      },
     },
     placement: {
       name: 'placement',
       description: 'Ubicación del drawer',
       control: 'select',
-      options: ['top', 'bottom', 'top-start', 'top-end', 'bottom-start', 'bottom-end'],
+      options: [
+        'top',
+        'bottom',
+        'top-start',
+        'top-end',
+        'bottom-start',
+        'bottom-end',
+      ],
       table: {
         category: 'Apariencia y Dimensiones',
         type: { summary: 'string' },
-        defaultValue: { summary: 'top' }
-      }
+        defaultValue: { summary: 'top' },
+      },
     },
     role: {
       description: 'Rol del drawer',
@@ -142,8 +159,8 @@ const actions: actionType[] = [
       table: {
         category: 'Apariencia y Dimensiones',
         type: { summary: 'string' },
-        defaultValue: { summary: 'menu' }
-      }
+        defaultValue: { summary: 'menu' },
+      },
     },
     tabindex: {
       description: 'Tabindex del drawer',
@@ -151,8 +168,8 @@ const actions: actionType[] = [
       table: {
         category: 'Apariencia y Dimensiones',
         type: { summary: 'number' },
-        defaultValue: { summary: '0' }
-      }
+        defaultValue: { summary: '0' },
+      },
     },
 
     // 2. Comportamiento y Activación
@@ -162,8 +179,8 @@ const actions: actionType[] = [
       table: {
         category: 'Comportamiento y Activación',
         type: { summary: 'boolean' },
-        defaultValue: { summary: 'false' }
-      }
+        defaultValue: { summary: 'false' },
+      },
     },
     actions: {
       description: 'Array de acciones personalizadas para el drawer',
@@ -180,10 +197,10 @@ const actions: actionType[] = [
   disabled?: boolean
   action?: () => void
   divider?: boolean
-}`
+}`,
         },
-        defaultValue: { summary: '[]' }
-      }
+        defaultValue: { summary: '[]' },
+      },
     },
     trigger: {
       description: 'Tipo de disparador del drawer',
@@ -192,8 +209,8 @@ const actions: actionType[] = [
       table: {
         category: 'Comportamiento y Activación',
         type: { summary: 'string' },
-        defaultValue: { summary: 'hover' }
-      }
+        defaultValue: { summary: 'hover' },
+      },
     },
     triggerKeys: {
       name: 'trigger-keys',
@@ -202,8 +219,8 @@ const actions: actionType[] = [
       table: {
         category: 'Comportamiento y Activación',
         type: { summary: 'string[]' },
-        defaultValue: { summary: '[]' }
-      }
+        defaultValue: { summary: '[]' },
+      },
     },
     hideOnClick: {
       name: 'hide-on-click',
@@ -212,8 +229,8 @@ const actions: actionType[] = [
       table: {
         category: 'Comportamiento y Activación',
         type: { summary: 'boolean' },
-        defaultValue: { summary: 'true' }
-      }
+        defaultValue: { summary: 'true' },
+      },
     },
     showTimeout: {
       name: 'show-timeout',
@@ -222,8 +239,8 @@ const actions: actionType[] = [
       table: {
         category: 'Comportamiento y Activación',
         type: { summary: 'number' },
-        defaultValue: { summary: '150' }
-      }
+        defaultValue: { summary: '150' },
+      },
     },
     hideTimeout: {
       name: 'hide-timeout',
@@ -232,8 +249,8 @@ const actions: actionType[] = [
       table: {
         category: 'Comportamiento y Activación',
         type: { summary: 'number' },
-        defaultValue: { summary: '150' }
-      }
+        defaultValue: { summary: '150' },
+      },
     },
     teleported: {
       description: 'Teletransporta el dropdown al elemento append-to',
@@ -241,8 +258,8 @@ const actions: actionType[] = [
       table: {
         category: 'Comportamiento y Activación',
         type: { summary: 'boolean' },
-        defaultValue: { summary: 'true' }
-      }
+        defaultValue: { summary: 'true' },
+      },
     },
     persistent: {
       description: 'Tooltip persistente',
@@ -250,8 +267,8 @@ const actions: actionType[] = [
       table: {
         category: 'Comportamiento y Activación',
         type: { summary: 'boolean' },
-        defaultValue: { summary: 'false' }
-      }
+        defaultValue: { summary: 'false' },
+      },
     },
 
     // 3. Eventos y Métodos
@@ -260,32 +277,32 @@ const actions: actionType[] = [
       description: 'Se activa al ejecutar un comando en el drawer',
       table: {
         category: 'Eventos y Métodos',
-        type: { summary: '(...args: any[]) => void' }
-      }
+        type: { summary: '(...args: any[]) => void' },
+      },
     },
     visibleChange: {
       name: 'visible-change',
       description: 'Se activa al cambiar la visibilidad del drawer',
       table: {
         category: 'Eventos y Métodos',
-        type: { summary: '(visible: boolean) => void' }
-      }
+        type: { summary: '(visible: boolean) => void' },
+      },
     },
     handleClose: {
       name: 'handle-close',
       description: 'Método para cerrar el dropdown',
       table: {
         category: 'Eventos y Métodos',
-        type: { summary: '() => void' }
-      }
+        type: { summary: '() => void' },
+      },
     },
     handleOpen: {
       name: 'handle-open',
       description: 'Método para abrir el dropdown',
       table: {
         category: 'Eventos y Métodos',
-        type: { summary: '() => void' }
-      }
+        type: { summary: '() => void' },
+      },
     },
 
     // 4. Configuración Avanzada
@@ -296,8 +313,8 @@ const actions: actionType[] = [
       table: {
         category: 'Configuración Avanzada',
         type: { summary: 'object' },
-        defaultValue: { summary: '{}' }
-      }
+        defaultValue: { summary: '{}' },
+      },
     },
 
     // 5. Slots
@@ -305,10 +322,10 @@ const actions: actionType[] = [
       description: 'Disparador del dropdown',
       table: {
         category: 'Slot',
-        type: { summary: 'Slot' }
+        type: { summary: 'Slot' },
       },
-      control: false
-    }
+      control: false,
+    },
   },
   args: {
     maxHeight: '100%',
@@ -329,43 +346,43 @@ const actions: actionType[] = [
         title: 'Abrir',
         icon: 'regular arrow-up-right-from-square',
         action: () => {
-          console.log('Abrir')
-        }
+          console.log('Abrir');
+        },
       },
       {
         title: 'Editar',
         icon: 'regular pen',
         action: () => {
-          console.log('Editar')
-        }
+          console.log('Editar');
+        },
       },
       {
         title: 'Eliminar',
         icon: 'regular trash',
         action: () => {
-          console.log('Eliminar')
-        }
+          console.log('Eliminar');
+        },
       },
       {
         title: 'Actualizar',
         icon: 'regular arrows-rotate',
         disabled: true,
         action: () => {
-          console.log('Actualizar')
-        }
-      }
-    ]
-  }
-}
-export default meta
-type Story = StoryObj<GDropdownInstance>
+          console.log('Actualizar');
+        },
+      },
+    ],
+  },
+};
+export default meta;
+type Story = StoryObj<GDropdownInstance>;
 
 export const Basic: Story = {
   name: 'Básico',
-  render: (args) => ({
+  render: args => ({
     components: { GDropdown, GConfigProvider, GIconButton },
     setup() {
-      return { args }
+      return { args };
     },
     template: `
       <g-config-provider>
@@ -373,9 +390,9 @@ export const Basic: Story = {
           <g-icon-button icon="regular plus-circle" />
         </g-dropdown>
       </g-config-provider>
-    `
-  })
-}
+    `,
+  }),
+};
 
 export const allTypesOfTriggers: Story = {
   name: 'Todos los tipos de disparadores',
@@ -385,20 +402,20 @@ export const allTypesOfTriggers: Story = {
         story: `Este ejemplo muestra cómo se ven los diferentes tipos de disparadores.
 - Disparador de clic
 - Disparador de desplazamiento
-- Disparador de enfoque`
-      }
-    }
+- Disparador de enfoque`,
+      },
+    },
   },
   render: () => ({
     components: { GDropdown, GConfigProvider, GRadioGroup, GTag },
     setup() {
-      const trigger = ref<string>('click')
+      const trigger = ref<string>('click');
 
       const triggers = [
         { value: 'click', label: 'Click' },
         { value: 'hover', label: 'Hover' },
-        { value: 'contextmenu', label: 'Context Menu' }
-      ]
+        { value: 'contextmenu', label: 'Context Menu' },
+      ];
 
       const actions: actionType[] = [
         {
@@ -406,31 +423,31 @@ export const allTypesOfTriggers: Story = {
           icon: 'regular envelope',
           description: 'Esta acción te permite enviar un correo electrónico',
           action: () => {
-            console.log('Enviar correo')
+            console.log('Enviar correo');
           },
-          'data-test': 'send-email'
+          'data-test': 'send-email',
         },
         {
           title: 'Buscar',
-          icon: 'regular magnifying-glass',
+          icon: 'regular search',
           description: 'Esta acción te permite buscar un elemento',
           action: () => {
-            console.log('Buscar')
+            console.log('Buscar');
           },
-          'data-test': 'search'
+          'data-test': 'search',
         },
         {
           title: 'Exportar',
           icon: 'regular arrow-up-from-bracket',
           description: 'Esta acción te permite exportar un elemento',
           action: () => {
-            console.log('Exportar')
+            console.log('Exportar');
           },
-          'data-test': 'export'
-        }
-      ]
+          'data-test': 'export',
+        },
+      ];
 
-      return { actions, triggers, trigger }
+      return { actions, triggers, trigger };
     },
     template: `
       <g-config-provider>
@@ -445,9 +462,9 @@ export const allTypesOfTriggers: Story = {
           </div>
         </div>
       </g-config-provider>
-    `
-  })
-}
+    `,
+  }),
+};
 
 export const commandEvent: Story = {
   name: 'Manejo de la opción de comando',
@@ -456,14 +473,14 @@ export const commandEvent: Story = {
       description: {
         story: `Este ejemplo muestra cómo manejar el evento de comando.
 - Se utiliza un botón para abrir el menú desplegable.
-- Al hacer clic en una opción, se muestra un mensaje en la consola con el nombre de la opción seleccionada.`
-      }
-    }
+- Al hacer clic en una opción, se muestra un mensaje en la consola con el nombre de la opción seleccionada.`,
+      },
+    },
   },
   render: () => ({
     components: { GDropdown, GConfigProvider, GButton, GTag },
     setup() {
-      const commandClicked = ref<string>('')
+      const commandClicked = ref<string>('');
       const actions: actionType[] = [
         {
           title: 'Enviar correo',
@@ -471,19 +488,19 @@ export const commandEvent: Story = {
           command: 'send-email',
           description: 'Esta acción te permite enviar un correo electrónico',
           action: () => {
-            console.log('Enviar correo')
+            console.log('Enviar correo');
           },
-          'data-test': 'send-email'
+          'data-test': 'send-email',
         },
         {
           title: 'Buscar',
-          icon: 'regular magnifying-glass',
+          icon: 'regular search',
           command: 'search',
           description: 'Esta acción te permite buscar un elemento',
           action: () => {
-            console.log('Buscar')
+            console.log('Buscar');
           },
-          'data-test': 'search'
+          'data-test': 'search',
         },
         {
           title: 'Exportar',
@@ -491,17 +508,17 @@ export const commandEvent: Story = {
           command: 'export',
           description: 'Esta acción te permite exportar un elemento',
           action: () => {
-            console.log('Exportar')
+            console.log('Exportar');
           },
-          'data-test': 'export'
-        }
-      ]
+          'data-test': 'export',
+        },
+      ];
 
       const handleCommand = (command: string) => {
-        commandClicked.value = command
-      }
+        commandClicked.value = command;
+      };
 
-      return { actions, handleCommand, commandClicked }
+      return { actions, handleCommand, commandClicked };
     },
     template: `
       <g-config-provider>
@@ -532,9 +549,9 @@ export const commandEvent: Story = {
         </div>
 
       </g-config-provider>
-    `
-  })
-}
+    `,
+  }),
+};
 
 export const dropdownMethods: Story = {
   name: 'Métodos del dropdown',
@@ -544,50 +561,58 @@ export const dropdownMethods: Story = {
         story: `Este ejemplo muestra cómo usar los métodos del dropdown.
 
 - Se utiliza un botón para abrir el menú desplegable.
-- Se utiliza un botón para cerrar el menú desplegable.`
-      }
-    }
+- Se utiliza un botón para cerrar el menú desplegable.`,
+      },
+    },
   },
   render: () => ({
     components: { GDropdown, GConfigProvider, GButton, GIconButton },
     setup() {
-      const dropdownRef = ref<GDropdownInstance | null>(null)
-      const countries = ref<actionType[]>([])
-      const svgCurrentCountry = ref<string>('')
+      const dropdownRef = ref<GDropdownInstance | null>(null);
+      const countries = ref<actionType[]>([]);
+      const svgCurrentCountry = ref<string>('');
 
       const getCountries = async () => {
         try {
-          const response = await fetch('https://restcountries.com/v3.1/all?fields=name,flags')
-          const data = await response.json()
+          const response = await fetch(
+            'https://restcountries.com/v3.1/all?fields=name,flags',
+          );
+          const data = await response.json();
 
-          const limitedData = data.slice(0, 25)
+          const limitedData = data.slice(0, 25);
 
-          const countries = limitedData.map((country) => ({
+          const countries = limitedData.map(country => ({
             icon: country.flags.svg,
             title: country.name.common,
-            command: country.flags.svg
-          }))
+            command: country.flags.svg,
+          }));
 
-          return countries
+          return countries;
         } catch (error) {
-          console.error('Error fetching data:', error)
-          return []
+          console.error('Error fetching data:', error);
+          return [];
         }
-      }
+      };
 
       const handleVisibleChange = (visible: boolean) => {
         if (visible && countries.value.length === 0) {
-          getCountries().then((data) => {
-            countries.value = data
-          })
+          getCountries().then(data => {
+            countries.value = data;
+          });
         }
-      }
+      };
 
       const handleCommand = (command: string) => {
-        svgCurrentCountry.value = command
-      }
+        svgCurrentCountry.value = command;
+      };
 
-      return { dropdownRef, handleVisibleChange, countries, handleCommand, svgCurrentCountry }
+      return {
+        dropdownRef,
+        handleVisibleChange,
+        countries,
+        handleCommand,
+        svgCurrentCountry,
+      };
     },
     template: `
       <g-config-provider>
@@ -621,6 +646,6 @@ export const dropdownMethods: Story = {
           </div>
         </div>
       </g-config-provider>
-    `
-  })
-}
+    `,
+  }),
+};


### PR DESCRIPTION
## What

WU-9 of **ep-extraction-v4** — migrates `g-dropdown` (the widest fan-out in the slice) off element-plus internals. Its own dedicated PR (never bundled with select, per design §3/§6).

### Ported into `g-utils`
- **`whenMouse`** — byte-exact from EP 2.9.7 `es/utils/dom/event.mjs`, placed in `function.util.ts` beside `composeEventHandlers` (a pure function, not a Vue composable — matches EP's own `dom/event.ts` co-location; the task brief's `g-hooks/composables` guess was a miscategorization). EP's `any` tightened to `unknown` per the no-`any` mandate.
- **`Nullable<T> = T | null`** type (dropdown is the first g-utils consumer).

### Component migration
- Re-pointed all 6 dropdown files: `buildProps`/`definePropType`/`EVENT_CODE`/`composeEventHandlers`/`composeRefs`/`whenMouse`/`addUnit`/`ensureArray`/`useNamespace`/`withInstall`/`withNoopInstall`/`Nullable`/`SFCWithInstall` → `g-utils`; `useId`/`useLocale` → `g-hooks`. Zero `element-plus` runtime imports remain (scss `@use` of theme-chalk retained, as expected for a styled component).
- `useLocale` was already ported in WU-8 (select as first consumer) — dropdown just consumes it.

### Packaging
- Adopted the **tooltip convention**: all 10 directly-imported `@flash-global66/*` in `dependencies` with ranges aligned to current workspace versions; only `@popperjs/core`/`element-plus`/`vue` as peers. Fixes the recurring bug (previously missing g-hooks/g-utils, stale peer ranges that didn't satisfy the workspace).

### Lint
- Removed `components/dropdown/**` from the eslint exclusion; fixed the 2 surfaced errors: dead `GIconFont` registration removed from `dropdown.vue` (icons render in `dropdown-item-impl.vue`), and `Function` in `actionType`'s index signature replaced with a callable signature.

### Type tightening (approved)
- `actionType.icon`: `string` → `IconString`, aligning the exported type with the dropdown-item `icon: PropType<IconString>` contract that already existed. This is cross-package (`actionType` is also consumed by `g-chip`) — verified no g-chip regression. Also fixed 3 now-invalid `'regular magnifying-glass'` literals in the dropdown stories (`magnifying-glass` isn't in `ICON_SETS`) → `'regular search'`.

## Validation
- `vue-tsc` on dropdown + g-chip: **identical error profile to `origin/main` baseline** (only environmental TS7016 from unbuilt local `dist/`; CI resolves these via build-before-typecheck). Zero new type errors.
- `eslint --max-warnings 0`: clean.
- Full `test:run`: **324/324** green (incl. new `whenMouse` cases).
- Browser gate: deferred to the **batched popper-family validation** (tooltip + select + dropdown) now that all three are landing.

## Review
Dual blind review — both judges **APPROVE-WITH-NITS**. NITs are pre-existing debt outside scope (raw-string same-package `provide('gDropdown')`, pre-existing `any` in `IGDropdownInstance`); the actionable MINOR (invalid story icon literals) is fixed here.

Comments/JSDoc in Spanish per project convention.