### PR TITLE
feat(time-picker): migrate off element-plus internals, add vRepeatClick/isDate/isEmpty (ep-extraction-v4 WU-11)

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -48,7 +48,6 @@ module.exports = {
         'components/inline/**',
         'components/input-tag/**',
         'components/toast/**',
-        'components/time-picker/**',
         'components/table/**',
         'components/pagination/**',
         'components/input-number/**',

--- a/common/g-utils/src/directives/repeatClick.directive.ts
+++ b/common/g-utils/src/directives/repeatClick.directive.ts
@@ -1,0 +1,64 @@
+import { isFunction } from '../utils/function.util';
+
+import type { ObjectDirective } from 'vue';
+
+/** Intervalo (ms) entre repeticiones mientras el botón sigue presionado. */
+export const REPEAT_INTERVAL = 100;
+/** Retraso (ms) antes de que comience la repetición automática. */
+export const REPEAT_DELAY = 600;
+
+/** Opciones de la directiva `vRepeatClick`. */
+interface RepeatClickOptions {
+  interval?: number;
+  delay?: number;
+  handler: (...args: unknown[]) => unknown;
+}
+
+/** Valor aceptado por `vRepeatClick`: un handler directo o un objeto de opciones. */
+type RepeatClickValue = RepeatClickOptions | RepeatClickOptions['handler'];
+
+/**
+ * Directiva que repite la ejecución de un handler mientras se mantiene
+ * presionado el botón izquierdo del mouse: se dispara una vez de inmediato,
+ * espera `delay` ms y luego repite cada `interval` ms hasta `mouseup`.
+ *
+ * Copiada del algoritmo exacto de element-plus (`es/directives/repeat-click`)
+ * para mantener paridad con los consumidores migrados (ej: `time-picker`).
+ */
+export const vRepeatClick: ObjectDirective<HTMLElement, RepeatClickValue> = {
+  beforeMount(el, binding) {
+    const value = binding.value;
+    const options: Partial<RepeatClickOptions> = isFunction(value) ? {} : value;
+    const { interval = REPEAT_INTERVAL, delay = REPEAT_DELAY } = options;
+
+    let intervalId: ReturnType<typeof setInterval> | undefined;
+    let delayId: ReturnType<typeof setTimeout> | undefined;
+
+    const handler = () => (isFunction(value) ? value() : value.handler());
+
+    const clear = () => {
+      if (delayId) {
+        clearTimeout(delayId);
+        delayId = undefined;
+      }
+      if (intervalId) {
+        clearInterval(intervalId);
+        intervalId = undefined;
+      }
+    };
+
+    el.addEventListener('mousedown', (evt: MouseEvent) => {
+      if (evt.button !== 0) return;
+      clear();
+      handler();
+      document.addEventListener('mouseup', () => clear(), { once: true });
+      delayId = setTimeout(() => {
+        intervalId = setInterval(() => {
+          handler();
+        }, interval);
+      }, delay);
+    });
+  },
+};
+
+export default vRepeatClick;

--- a/common/g-utils/src/index.ts
+++ b/common/g-utils/src/index.ts
@@ -18,6 +18,7 @@ export * from './utils/dom.util';
 export * from './utils/refs.util';
 export * from './utils/string.util';
 export { default as ClickOutside } from './directives/clickOutside.directive';
+export * from './directives/repeatClick.directive';
 export * from './composables/useNamespace';
 export * from './constants/event.constant';
 export * from './types/utils.type';

--- a/common/g-utils/src/utils/validators.util.ts
+++ b/common/g-utils/src/utils/validators.util.ts
@@ -1,5 +1,6 @@
 import { componentSizes, ComponentSize } from '../types/component.type';
 import { isFunction } from './function.util';
+import { isArray } from './array.util';
 
 /**
  * Comprueba si un valor es de tipo `boolean`.
@@ -50,6 +51,33 @@ export const isString = (val: unknown): val is string =>
  */
 export const isObject = (val: unknown): val is Record<string, unknown> =>
   val !== null && typeof val === 'object';
+
+/**
+ * Comprueba si un valor es una instancia de `Date`.
+ *
+ * Actúa como type guard de TypeScript. Replica el algoritmo de `@vue/shared`
+ * (reexportado por element-plus) basado en `Object.prototype.toString`.
+ *
+ * @param val - El valor a verificar.
+ * @returns `true` si `val` es un `Date`.
+ */
+export const isDate = (val: unknown): val is Date =>
+  Object.prototype.toString.call(val) === '[object Date]';
+
+/**
+ * Comprueba si un valor está "vacío".
+ *
+ * Copiado byte a byte del `isEmpty` interno de element-plus: son vacíos los
+ * valores "falsy" (excepto `0`), los arrays sin elementos y los objetos sin
+ * claves propias.
+ *
+ * @param val - El valor a verificar.
+ * @returns `true` si `val` se considera vacío.
+ */
+export const isEmpty = (val: unknown): boolean =>
+  (!val && val !== 0) ||
+  (isArray(val) && val.length === 0) ||
+  (isObject(val) && !Object.keys(val).length);
 
 /**
  * Comprueba si un valor es un tamaño de componente válido.

--- a/common/g-utils/tests/directives/repeatClick.directive.spec.ts
+++ b/common/g-utils/tests/directives/repeatClick.directive.spec.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  vRepeatClick,
+  REPEAT_DELAY,
+  REPEAT_INTERVAL,
+} from '../../src/directives/repeatClick.directive';
+import type { DirectiveBinding } from 'vue';
+
+const mount = (value: DirectiveBinding['value']) => {
+  const el = document.createElement('button');
+  document.body.appendChild(el);
+  vRepeatClick.beforeMount(el, { value } as DirectiveBinding);
+  return el;
+};
+
+const mousedown = (el: HTMLElement) =>
+  el.dispatchEvent(new MouseEvent('mousedown', { button: 0 }));
+
+describe('vRepeatClick', () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => {
+    vi.useRealTimers();
+    document.body.innerHTML = '';
+  });
+
+  it('invokes the handler once immediately on left mousedown', () => {
+    const handler = vi.fn();
+    const el = mount(handler);
+    mousedown(el);
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  it('ignores non-left mouse buttons', () => {
+    const handler = vi.fn();
+    const el = mount(handler);
+    el.dispatchEvent(new MouseEvent('mousedown', { button: 2 }));
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it('repeats the handler after the delay, then on each interval', () => {
+    const handler = vi.fn();
+    const el = mount(handler);
+    mousedown(el);
+    expect(handler).toHaveBeenCalledTimes(1);
+    vi.advanceTimersByTime(REPEAT_DELAY);
+    vi.advanceTimersByTime(REPEAT_INTERVAL * 3);
+    expect(handler.mock.calls.length).toBeGreaterThanOrEqual(4);
+  });
+
+  it('stops repeating after mouseup', () => {
+    const handler = vi.fn();
+    const el = mount(handler);
+    mousedown(el);
+    vi.advanceTimersByTime(REPEAT_DELAY);
+    document.dispatchEvent(new MouseEvent('mouseup'));
+    const callsAfterStop = handler.mock.calls.length;
+    vi.advanceTimersByTime(REPEAT_INTERVAL * 5);
+    expect(handler.mock.calls.length).toBe(callsAfterStop);
+  });
+
+  it('accepts an options object with a handler and custom timings', () => {
+    const handler = vi.fn();
+    const el = mount({ handler, interval: 50, delay: 200 });
+    mousedown(el);
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+});

--- a/common/g-utils/tests/utils/validators.util.spec.ts
+++ b/common/g-utils/tests/utils/validators.util.spec.ts
@@ -4,6 +4,8 @@ import {
   isString,
   isValidComponentSize,
   isPromise,
+  isDate,
+  isEmpty,
 } from '../../src/utils/validators.util';
 import type { ComponentSize } from '../../src/types/component.type';
 
@@ -124,5 +126,48 @@ describe('isPromise', () => {
 
   it('returns false for an object missing catch', () => {
     expect(isPromise({ then: () => {} })).toBe(false);
+  });
+});
+
+describe('isDate', () => {
+  it('returns true for a Date instance', () => {
+    expect(isDate(new Date())).toBe(true);
+  });
+
+  it('returns false for a date-like string', () => {
+    expect(isDate('2020-01-01')).toBe(false);
+  });
+
+  it('returns false for a timestamp number', () => {
+    expect(isDate(1577836800000)).toBe(false);
+  });
+
+  it('returns false for null and plain objects', () => {
+    expect(isDate(null)).toBe(false);
+    expect(isDate({})).toBe(false);
+  });
+});
+
+describe('isEmpty', () => {
+  it('treats falsy values other than 0 as empty', () => {
+    expect(isEmpty('')).toBe(true);
+    expect(isEmpty(null)).toBe(true);
+    expect(isEmpty(undefined)).toBe(true);
+    expect(isEmpty(false)).toBe(true);
+  });
+
+  it('treats 0 as NOT empty', () => {
+    expect(isEmpty(0)).toBe(false);
+  });
+
+  it('treats an empty array/object as empty and a populated one as not', () => {
+    expect(isEmpty([])).toBe(true);
+    expect(isEmpty({})).toBe(true);
+    expect(isEmpty([1])).toBe(false);
+    expect(isEmpty({ a: 1 })).toBe(false);
+  });
+
+  it('treats a non-empty string as not empty', () => {
+    expect(isEmpty('x')).toBe(false);
   });
 });

--- a/components/time-picker/index.ts
+++ b/components/time-picker/index.ts
@@ -1,11 +1,11 @@
-import { withInstall, SFCWithInstall } from "element-plus/es/utils/index.mjs";
-import TimePicker from "./src/time-picker";
-import CommonPicker from "./src/common/picker.vue";
-import TimePickPanel from "./src/time-picker-com/panel-time-pick.vue";
+import { withInstall, SFCWithInstall } from '@flash-global66/g-utils';
+import TimePicker from './src/time-picker';
+import CommonPicker from './src/common/picker.vue';
+import TimePickPanel from './src/time-picker-com/panel-time-pick.vue';
 
-export * from "./src/utils";
-export * from "./src/constants";
-export * from "./src/common/props";
+export * from './src/utils';
+export * from './src/constants';
+export * from './src/common/props';
 
 export const GTimePicker: SFCWithInstall<typeof TimePicker> =
   withInstall(TimePicker);

--- a/components/time-picker/package.json
+++ b/components/time-picker/package.json
@@ -28,12 +28,17 @@
   "repository": {
     "url": "https://github.com/Flash-Global66/global-design-system.git"
   },
+  "dependencies": {
+    "@flash-global66/g-form": "^0.2.14",
+    "@flash-global66/g-hooks": "^0.11.2",
+    "@flash-global66/g-icon-font": "^0.25.13",
+    "@flash-global66/g-input": "^0.3.18",
+    "@flash-global66/g-popper": "^0.0.19",
+    "@flash-global66/g-scrollbar": "^0.1.8",
+    "@flash-global66/g-tooltip": "^0.1.7",
+    "@flash-global66/g-utils": "^0.10.0"
+  },
   "peerDependencies": {
-    "@flash-global66/g-icon-font": "^0.0.8",
-    "@flash-global66/g-input": "^0.3.1",
-    "@flash-global66/g-popper": "^0.0.10",
-    "@flash-global66/g-scrollbar": "^0.1.0",
-    "@flash-global66/g-tooltip": "^0.0.5",
     "dayjs": "^1.11.13",
     "element-plus": "^2.9.0",
     "vue": "^3.2.0"

--- a/components/time-picker/src/common/picker-range-trigger.vue
+++ b/components/time-picker/src/common/picker-range-trigger.vue
@@ -2,7 +2,7 @@
   <div
     ref="wrapperRef"
     :class="[nsDate.is('active', isFocused), $attrs.class]"
-    :style="($attrs.style as CSSProperties)"
+    :style="$attrs.style as CSSProperties"
     @click="handleClick"
     @mouseenter="handleMouseEnter"
     @mouseleave="handleMouseLeave"
@@ -40,36 +40,37 @@
 </template>
 
 <script lang="ts" setup>
-import { ref, computed } from "vue";
-import { useAttrs, useFocusController, useNamespace } from "element-plus";
-import { timePickerRangeTriggerProps } from "./props";
-import type { CSSProperties } from "vue";
-import { useResizeObserver } from "@vueuse/core";
-import { isNil } from "lodash-unified";
+import { ref, computed } from 'vue';
+import { useNamespace } from '@flash-global66/g-utils';
+import { useAttrs, useFocusController } from '@flash-global66/g-hooks';
+import { timePickerRangeTriggerProps } from './props';
+import type { CSSProperties } from 'vue';
+import { useResizeObserver } from '@vueuse/core';
+import { isNil } from 'lodash-unified';
 
 defineOptions({
-  name: "PickerRangeTrigger",
+  name: 'PickerRangeTrigger',
   inheritAttrs: false,
 });
 
 const props = defineProps(timePickerRangeTriggerProps);
 const emit = defineEmits([
-  "mouseenter",
-  "mouseleave",
-  "click",
-  "touchstart",
-  "focus",
-  "blur",
-  "startInput",
-  "endInput",
-  "startChange",
-  "endChange",
+  'mouseenter',
+  'mouseleave',
+  'click',
+  'touchstart',
+  'focus',
+  'blur',
+  'startInput',
+  'endInput',
+  'startChange',
+  'endChange',
 ]);
 
 const attrs = useAttrs();
-const nsInput = useNamespace("input");
-const nsDate = useNamespace("date");
-const nsRange = useNamespace("range");
+const nsInput = useNamespace('input');
+const nsDate = useNamespace('date');
+const nsRange = useNamespace('range');
 const leftPrefix = ref<string | undefined>(undefined);
 const prefixRef = ref<HTMLElement | null>(null);
 
@@ -79,35 +80,35 @@ const endInputRef = ref<HTMLInputElement>();
 const { wrapperRef, isFocused } = useFocusController(inputRef);
 
 const handleClick = (evt: MouseEvent) => {
-  emit("click", evt);
+  emit('click', evt);
 };
 
 const handleMouseEnter = (evt: MouseEvent) => {
-  emit("mouseenter", evt);
+  emit('mouseenter', evt);
 };
 
 const handleMouseLeave = (evt: MouseEvent) => {
-  emit("mouseleave", evt);
+  emit('mouseleave', evt);
 };
 
 const handleTouchStart = (evt: TouchEvent) => {
-  emit("mouseenter", evt);
+  emit('mouseenter', evt);
 };
 
 const handleStartInput = (evt: Event) => {
-  emit("startInput", evt);
+  emit('startInput', evt);
 };
 
 const handleEndInput = (evt: Event) => {
-  emit("endInput", evt);
+  emit('endInput', evt);
 };
 
 const handleStartChange = (evt: Event) => {
-  emit("startChange", evt);
+  emit('startChange', evt);
 };
 
 const handleEndChange = (evt: Event) => {
-  emit("endChange", evt);
+  emit('endChange', evt);
 };
 
 const focus = () => {
@@ -128,7 +129,7 @@ const labelStyle = computed(() => {
 });
 
 const nativeInputValue = computed(() =>
-  isNil(props.modelValue) ? "" : String(props.modelValue)
+  isNil(props.modelValue) ? '' : String(props.modelValue),
 );
 
 const updatePrefixPosition = () => {

--- a/components/time-picker/src/common/picker.vue
+++ b/components/time-picker/src/common/picker.vue
@@ -23,10 +23,10 @@
     <template #default>
       <g-input
         v-if="!isRangeInput"
-        :id="(id as string | undefined)"
+        :id="id as MaybeString"
         ref="inputRef"
         container-role="combobox"
-        :model-value="(displayValue as string)"
+        :model-value="displayValue as string"
         :name="name"
         :disabled="pickerDisabled"
         :label="label"
@@ -84,10 +84,10 @@
       </g-input>
       <picker-range-trigger
         v-else
-        :id="(id as string[] | undefined)"
+        :id="id as MaybeStringArray"
         ref="inputRef"
         :model-value="displayValue"
-        :name="(name as string[] | undefined)"
+        :name="name as MaybeStringArray"
         :disabled="pickerDisabled"
         :readonly="!editable || readonly"
         :label="label"
@@ -169,31 +169,35 @@ import {
   unref,
   useAttrs,
   watch,
-} from "vue";
-import { isEqual } from "lodash-unified";
-import { onClickOutside, unrefElement } from "@vueuse/core";
+} from 'vue';
+import { isEqual } from 'lodash-unified';
+import { onClickOutside, unrefElement } from '@vueuse/core';
+import {
+  NOOP,
+  debugWarn,
+  isArray,
+  EVENT_CODE,
+  useNamespace,
+} from '@flash-global66/g-utils';
 import {
   useEmptyValues,
   useFocusController,
   useLocale,
-  useNamespace,
-} from "element-plus";
-import { useFormItem } from "@flash-global66/g-form";
-import GInput from "@flash-global66/g-input";
-import { GIconFont } from "@flash-global66/g-icon-font";
-import GTooltip from "@flash-global66/g-tooltip";
-import { NOOP, debugWarn, isArray } from "element-plus/es/utils/index";
-import { EVENT_CODE } from "element-plus/es/constants/index.mjs";
-import { isNil } from "lodash-unified";
-import { dayOrDaysToDate, formatter, parseDate, valueEquals } from "../utils";
-import { timePickerDefaultProps } from "./props";
-import PickerRangeTrigger from "./picker-range-trigger.vue";
-import type { InputInstance } from "@flash-global66/g-input";
+} from '@flash-global66/g-hooks';
+import { useFormItem } from '@flash-global66/g-form';
+import GInput from '@flash-global66/g-input';
+import { GIconFont } from '@flash-global66/g-icon-font';
+import GTooltip from '@flash-global66/g-tooltip';
+import { isNil } from 'lodash-unified';
+import { dayOrDaysToDate, formatter, parseDate, valueEquals } from '../utils';
+import { timePickerDefaultProps } from './props';
+import PickerRangeTrigger from './picker-range-trigger.vue';
+import type { InputInstance } from '@flash-global66/g-input';
 
-import type { Dayjs } from "dayjs";
-import type { ComponentPublicInstance, Ref } from "vue";
-import { useResizeObserver } from "@vueuse/core";
-import type { Options } from "@popperjs/core";
+import type { Dayjs } from 'dayjs';
+import type { ComponentPublicInstance, Ref } from 'vue';
+import { useResizeObserver } from '@vueuse/core';
+import type { Options } from '@popperjs/core';
 import type {
   DateModelType,
   DayOrDays,
@@ -201,44 +205,53 @@ import type {
   SingleOrRange,
   TimePickerDefaultProps,
   UserInput,
-} from "./props";
-import type { TooltipInstance } from "@flash-global66/g-tooltip";
+} from './props';
+import type { TooltipInstance } from '@flash-global66/g-tooltip';
+
+/**
+ * Alias para castear `id`/`name` en las bindings del template sin exponer una
+ * unión con `|` a nivel superior: `vue-eslint-parser` la interpretaría como el
+ * operador de filtros (Vue 2) y `prettier` elimina los paréntesis que la
+ * desambiguarían. El alias evita ambos problemas sin cambiar el tipo.
+ */
+type MaybeString = string | undefined;
+type MaybeStringArray = string[] | undefined;
 
 defineOptions({
-  name: "Picker",
+  name: 'Picker',
 });
 
 const props = defineProps(timePickerDefaultProps);
 const emit = defineEmits([
-  "update:modelValue",
-  "change",
-  "focus",
-  "blur",
-  "clear",
-  "calendar-change",
-  "panel-change",
-  "visible-change",
-  "keydown",
+  'update:modelValue',
+  'change',
+  'focus',
+  'blur',
+  'clear',
+  'calendar-change',
+  'panel-change',
+  'visible-change',
+  'keydown',
 ]);
 const attrs = useAttrs();
 
 const { lang } = useLocale();
 
-const nsDate = useNamespace("date");
-const nsInput = useNamespace("input");
-const nsRange = useNamespace("range");
+const nsDate = useNamespace('date');
+const nsInput = useNamespace('input');
+const nsRange = useNamespace('range');
 const leftPrefix = ref<string | undefined>(undefined);
 const prefixRef = ref<HTMLElement | null>(null);
 
 const { form, formItem } = useFormItem();
-const elPopperOptions = inject("ElPopperOptions", {} as Options);
+const elPopperOptions = inject('ElPopperOptions', {} as Options);
 const { valueOnClear } = useEmptyValues(props, null);
 
 const refPopper = ref<TooltipInstance>();
 const inputRef = ref<InputInstance>();
 const pickerVisible = ref(false);
 const pickerActualVisible = ref(false);
-const valueOnOpen = ref<TimePickerDefaultProps["modelValue"] | null>(null);
+const valueOnOpen = ref<TimePickerDefaultProps['modelValue'] | null>(null);
 let hasJustTabExitedInput = false;
 
 const { isFocused, handleFocus, handleBlur } = useFocusController(inputRef, {
@@ -258,7 +271,7 @@ const { isFocused, handleFocus, handleBlur } = useFocusController(inputRef, {
     pickerVisible.value = false;
     hasJustTabExitedInput = false;
     props.validateEvent &&
-      formItem?.validate("blur").catch((err) => debugWarn(err));
+      formItem?.validate('blur').catch(err => debugWarn(err));
   },
 });
 
@@ -271,12 +284,12 @@ const labelStyle = computed(() => {
 });
 
 const nativeInputValue = computed(() =>
-  isNil(props.modelValue) ? "" : String(props.modelValue)
+  isNil(props.modelValue) ? '' : String(props.modelValue),
 );
 
 const updatePrefixPosition = () => {
   if (!props.prefixIcon) {
-    leftPrefix.value = "0";
+    leftPrefix.value = '0';
     return;
   }
 
@@ -287,22 +300,22 @@ const updatePrefixPosition = () => {
 };
 
 const rangeInputKls = computed(() => [
-  nsDate.b("editor"),
-  nsDate.bm("editor", props.type),
-  nsInput.e("wrapper"),
-  nsDate.is("disabled", pickerDisabled.value),
-  nsDate.is("active", pickerVisible.value),
-  nsRange.b("editor"),
+  nsDate.b('editor'),
+  nsDate.bm('editor', props.type),
+  nsInput.e('wrapper'),
+  nsDate.is('disabled', pickerDisabled.value),
+  nsDate.is('active', pickerVisible.value),
+  nsRange.b('editor'),
   attrs.class,
 ]);
 
 const clearIconKls = computed(() => [
-  nsInput.e("icon"),
-  nsRange.e("close-icon"),
-  !showClose.value ? nsRange.e("close-icon--hidden") : "",
+  nsInput.e('icon'),
+  nsRange.e('close-icon'),
+  !showClose.value ? nsRange.e('close-icon--hidden') : '',
 ]);
 
-watch(pickerVisible, (val) => {
+watch(pickerVisible, val => {
   if (!val) {
     userInput.value = null;
     pickerOptions.value.intermediateValue = null;
@@ -318,60 +331,59 @@ watch(pickerVisible, (val) => {
   }
 });
 const emitChange = (
-  val: TimePickerDefaultProps["modelValue"] | null,
-  isClear?: boolean
+  val: TimePickerDefaultProps['modelValue'] | null,
+  isClear?: boolean,
 ) => {
   // determine user real change only
   if (isClear || !valueEquals(val, valueOnOpen.value)) {
-    emit("change", val);
+    emit('change', val);
     props.validateEvent &&
-      formItem?.validate("change").catch((err) => debugWarn(err));
+      formItem?.validate('change').catch(err => debugWarn(err));
   }
 };
 const emitInput = (input: SingleOrRange<DateModelType> | null) => {
   if (!valueEquals(props.modelValue, input)) {
     let formatted;
     if (isArray(input)) {
-      formatted = input.map((item) =>
-        formatter(item, props.valueFormat, lang.value)
+      formatted = input.map(item =>
+        formatter(item, props.valueFormat, lang.value),
       );
     } else if (input) {
       formatted = formatter(input, props.valueFormat, lang.value);
     }
-    emit("update:modelValue", input ? formatted : input, lang.value);
+    emit('update:modelValue', input ? formatted : input, lang.value);
   }
 };
 const emitKeydown = (e: KeyboardEvent) => {
-  emit("keydown", e);
+  emit('keydown', e);
 };
 
 const refInput = computed<HTMLInputElement[]>(() => {
   if (inputRef.value) {
     return Array.from<HTMLInputElement>(
-      inputRef.value.$el.querySelectorAll("input")
+      inputRef.value.$el.querySelectorAll('input'),
     );
   }
   return [];
 });
 
-// @ts-ignore
-const setSelectionRange = (start: number, end: number, pos?: "min" | "max") => {
+const setSelectionRange = (start: number, end: number, pos?: 'min' | 'max') => {
   const _inputs = refInput.value;
   if (!_inputs.length) return;
-  if (!pos || pos === "min") {
+  if (!pos || pos === 'min') {
     _inputs[0].setSelectionRange(start, end);
     _inputs[0].focus();
-  } else if (pos === "max") {
+  } else if (pos === 'max') {
     _inputs[1].setSelectionRange(start, end);
     _inputs[1].focus();
   }
 };
 
-const onPick = (date: any = "", visible = false) => {
+const onPick = (date: any = '', visible = false) => {
   pickerVisible.value = visible;
   let result;
   if (isArray(date)) {
-    result = date.map((_) => _.toDate());
+    result = date.map(_ => (_ as Dayjs).toDate());
   } else {
     // clear btn emit null
     result = date ? date.toDate() : date;
@@ -386,13 +398,13 @@ const onBeforeShow = () => {
 };
 
 const onShow = () => {
-  emit("visible-change", true);
+  emit('visible-change', true);
 };
 
 const onHide = () => {
   pickerActualVisible.value = false;
   pickerVisible.value = false;
-  emit("visible-change", false);
+  emit('visible-change', false);
 };
 
 const handleOpen = () => {
@@ -415,8 +427,8 @@ const parsedValue = computed(() => {
     }
   } else {
     if (isArray(props.modelValue)) {
-      dayOrDays = props.modelValue.map((d) =>
-        parseDate(d, props.valueFormat, lang.value)
+      dayOrDays = props.modelValue.map(d =>
+        parseDate(d, props.valueFormat, lang.value),
       ) as [Dayjs, Dayjs];
     } else {
       dayOrDays = parseDate(props.modelValue, props.valueFormat, lang.value)!;
@@ -425,7 +437,7 @@ const parsedValue = computed(() => {
 
   if (pickerOptions.value.getRangeAvailableTime) {
     const availableResult = pickerOptions.value.getRangeAvailableTime(
-      dayOrDays!
+      dayOrDays!,
     );
     if (!isEqual(availableResult, dayOrDays!)) {
       dayOrDays = availableResult;
@@ -436,19 +448,19 @@ const parsedValue = computed(() => {
       }
     }
   }
-  if (isArray(dayOrDays!) && dayOrDays.some((day) => !day)) {
+  if (isArray(dayOrDays!) && dayOrDays.some(day => !day)) {
     dayOrDays = [] as unknown as DayOrDays;
   }
   return dayOrDays!;
 });
 
 const displayValue = computed<UserInput>(() => {
-  if (!pickerOptions.value.panelReady) return "";
+  if (!pickerOptions.value.panelReady) return '';
   const formattedValue = formatDayjsToString(parsedValue.value);
   if (isArray(userInput.value)) {
     return [
-      userInput.value[0] || (formattedValue && formattedValue[0]) || "",
-      userInput.value[1] || (formattedValue && formattedValue[1]) || "",
+      userInput.value[0] || (formattedValue && formattedValue[0]) || '',
+      userInput.value[1] || (formattedValue && formattedValue[1]) || '',
     ];
   } else if (userInput.value !== null) {
     return userInput.value;
@@ -459,30 +471,30 @@ const displayValue = computed<UserInput>(() => {
     return intermediateValue;
   }
 
-  if (!isTimePicker.value && valueIsEmpty.value) return "";
-  if (!pickerVisible.value && valueIsEmpty.value) return "";
+  if (!isTimePicker.value && valueIsEmpty.value) return '';
+  if (!pickerVisible.value && valueIsEmpty.value) return '';
   if (formattedValue) {
     return isDatesPicker.value || isMonthsPicker.value || isYearsPicker.value
-      ? (formattedValue as Array<string>).join(", ")
+      ? (formattedValue as Array<string>).join(', ')
       : formattedValue;
   }
-  return "";
+  return '';
 });
 
-const isTimeLikePicker = computed(() => props.type.includes("time"));
+const isTimeLikePicker = computed(() => props.type.includes('time'));
 
-const isTimePicker = computed(() => props.type.startsWith("time"));
+const isTimePicker = computed(() => props.type.startsWith('time'));
 
-const isDatesPicker = computed(() => props.type === "dates");
+const isDatesPicker = computed(() => props.type === 'dates');
 
-const isMonthsPicker = computed(() => props.type === "months");
+const isMonthsPicker = computed(() => props.type === 'months');
 
-const isYearsPicker = computed(() => props.type === "years");
+const isYearsPicker = computed(() => props.type === 'years');
 
 const triggerIcon = computed(
   () =>
     props.prefixIcon ||
-    (isTimeLikePicker.value ? "regular clock" : "regular calendar")
+    (isTimeLikePicker.value ? 'regular clock' : 'regular calendar'),
 );
 
 const showClose = ref(false);
@@ -502,7 +514,7 @@ const onClearIconClick = (event: MouseEvent) => {
     showClose.value = false;
     onHide();
   }
-  emit("clear");
+  emit('clear');
 };
 
 const valueIsEmpty = computed(() => {
@@ -514,7 +526,7 @@ const valueIsEmpty = computed(() => {
 
 const onMouseDownInput = async (event: MouseEvent) => {
   if (props.readonly || pickerDisabled.value) return;
-  if ((event.target as HTMLElement)?.tagName !== "INPUT" || isFocused.value) {
+  if ((event.target as HTMLElement)?.tagName !== 'INPUT' || isFocused.value) {
     pickerVisible.value = true;
   }
 };
@@ -531,7 +543,7 @@ const onMouseLeave = () => {
 const onTouchStartInput = (event: TouchEvent) => {
   if (props.readonly || pickerDisabled.value) return;
   if (
-    (event.touches[0].target as HTMLElement)?.tagName !== "INPUT" ||
+    (event.touches[0].target as HTMLElement)?.tagName !== 'INPUT' ||
     isFocused.value
   ) {
     pickerVisible.value = true;
@@ -539,7 +551,7 @@ const onTouchStartInput = (event: TouchEvent) => {
 };
 
 const isRangeInput = computed(() => {
-  return props.type.includes("range");
+  return props.type.includes('range');
 });
 
 const popperEl = computed(() => unref(refPopper)?.popperRef?.contentRef);
@@ -558,7 +570,7 @@ const stophandle = onClickOutside(
     )
       return;
     pickerVisible.value = false;
-  }
+  },
 );
 
 onBeforeUnmount(() => {
@@ -579,7 +591,7 @@ const handleChange = () => {
       }
     }
   }
-  if (userInput.value === "") {
+  if (userInput.value === '') {
     emitInput(valueOnClear.value);
     emitChange(valueOnClear.value);
     userInput.value = null;
@@ -637,7 +649,7 @@ const handleKeydownInput = async (event: Event | KeyboardEvent) => {
   if (code === EVENT_CODE.enter || code === EVENT_CODE.numpadEnter) {
     if (
       userInput.value === null ||
-      userInput.value === "" ||
+      userInput.value === '' ||
       isValidValue(parseUserInputToDayjs(displayValue.value) as DayOrDays)
     ) {
       handleChange();
@@ -718,26 +730,23 @@ const handleEndChange = () => {
 };
 
 const pickerOptions = ref<Partial<PickerOptions>>({});
-// @ts-ignore
 const onSetPickerOption = <T extends keyof PickerOptions>(
-  e: [T, PickerOptions[T]]
+  e: [T, PickerOptions[T]],
 ) => {
   pickerOptions.value[e[0]] = e[1];
   pickerOptions.value.panelReady = true;
 };
 
-// @ts-ignore
 const onCalendarChange = (e: [Date, null | Date]) => {
-  emit("calendar-change", e);
+  emit('calendar-change', e);
 };
 
-// @ts-ignore
 const onPanelChange = (
   value: [Dayjs, Dayjs],
-  mode: "month" | "year",
-  view: unknown
+  mode: 'month' | 'year',
+  view: unknown,
 ) => {
-  emit("panel-change", value, mode, view);
+  emit('panel-change', value, mode, view);
 };
 
 const focus = () => {
@@ -748,7 +757,7 @@ const blur = () => {
   inputRef.value?.blur();
 };
 
-provide("EP_PICKER_BASE", {
+provide('EP_PICKER_BASE', {
   props,
 });
 

--- a/components/time-picker/src/common/props.ts
+++ b/components/time-picker/src/common/props.ts
@@ -1,14 +1,14 @@
-import { placements } from "@popperjs/core";
-import { buildProps, definePropType } from "element-plus/es/utils/index";
-import { useAriaProps, useEmptyValuesProps } from "element-plus";
-import { CircleClose } from "@element-plus/icons-vue";
-import { disabledTimeListsProps } from "../props/shared";
-import { IconString } from "@flash-global66/g-icon-font";
+import { placements } from '@popperjs/core';
+import { buildProps, definePropType } from '@flash-global66/g-utils';
+import { useAriaProps, useEmptyValuesProps } from '@flash-global66/g-hooks';
+import { CircleClose } from '@element-plus/icons-vue';
+import { disabledTimeListsProps } from '../props/shared';
+import { IconString } from '@flash-global66/g-icon-font';
 
-import type { Component, ExtractPropTypes } from "vue";
-import type { Options } from "@popperjs/core";
-import type { Dayjs } from "dayjs";
-import type { Placement } from "@flash-global66/g-popper";
+import type { Component, ExtractPropTypes } from 'vue';
+import type { Options } from '@popperjs/core';
+import type { Dayjs } from 'dayjs';
+import type { Placement } from '@flash-global66/g-popper';
 
 export type SingleOrRange<T> = T | [T, T];
 export type DateModelType = number | string | Date;
@@ -18,18 +18,18 @@ export type DateOrDates = SingleOrRange<Date>;
 export type UserInput = SingleOrRange<string | null>;
 export type GetDisabledHours = (
   role: string,
-  comparingDate?: Dayjs
+  comparingDate?: Dayjs,
 ) => number[];
 export type GetDisabledMinutes = (
   hour: number,
   role: string,
-  comparingDate?: Dayjs
+  comparingDate?: Dayjs,
 ) => number[];
 export type GetDisabledSeconds = (
   hour: number,
   minute: number,
   role: string,
-  comparingDate?: Dayjs
+  comparingDate?: Dayjs,
 ) => number[];
 
 export const timePickerDefaultProps = buildProps({
@@ -50,7 +50,7 @@ export const timePickerDefaultProps = buildProps({
    */
   popperClass: {
     type: String,
-    default: "",
+    default: '',
   },
   /**
    * @description format of the displayed value in the input box
@@ -73,7 +73,7 @@ export const timePickerDefaultProps = buildProps({
    */
   type: {
     type: String,
-    default: "",
+    default: '',
   },
   /**
    * @description whether to show clear button
@@ -101,7 +101,7 @@ export const timePickerDefaultProps = buildProps({
    */
   prefixIcon: {
     type: definePropType<IconString>(String),
-    default: "",
+    default: '',
   },
   /**
    * @description whether TimePicker is read only
@@ -116,21 +116,21 @@ export const timePickerDefaultProps = buildProps({
    */
   label: {
     type: String,
-    default: "",
+    default: '',
   },
   /**
    * @description label in non-range mode
    */
   helpText: {
     type: String,
-    default: "",
+    default: '',
   },
   /**
    * @description label in non-range mode
    */
   messageError: {
     type: String,
-    default: "",
+    default: '',
   },
   /**
    * @description [popper.js](https://popper.js.org/docs/v2/) parameters
@@ -144,14 +144,14 @@ export const timePickerDefaultProps = buildProps({
    */
   modelValue: {
     type: definePropType<ModelValueType>([Date, Array, String, Number]),
-    default: "",
+    default: '',
   },
   /**
    * @description range separator
    */
   rangeSeparator: {
     type: String,
-    default: "-",
+    default: '-',
   },
   /**
    * @description placeholder for the start date in range mode
@@ -225,17 +225,17 @@ export const timePickerDefaultProps = buildProps({
   placement: {
     type: definePropType<Placement>(String),
     values: placements,
-    default: "bottom",
+    default: 'bottom',
   },
   /**
    * @description list of possible positions for dropdown
    */
   fallbackPlacements: {
     type: definePropType<Placement[]>(Array),
-    default: ["bottom", "top", "right", "left"],
+    default: ['bottom', 'top', 'right', 'left'],
   },
   ...useEmptyValuesProps,
-  ...useAriaProps(["ariaLabel"]),
+  ...useAriaProps(['ariaLabel']),
   /**
    * @description whether to show the now button
    */

--- a/components/time-picker/src/props/basic-time-spinner.ts
+++ b/components/time-picker/src/props/basic-time-spinner.ts
@@ -1,8 +1,8 @@
-import { buildProps, definePropType } from "element-plus/es/utils/index";
-import { disabledTimeListsProps } from "../props/shared";
+import { buildProps, definePropType } from '@flash-global66/g-utils';
+import { disabledTimeListsProps } from '../props/shared';
 
-import type { ExtractPropTypes } from "vue";
-import type { Dayjs } from "dayjs";
+import type { ExtractPropTypes } from 'vue';
+import type { Dayjs } from 'dayjs';
 
 export const basicTimeSpinnerProps = buildProps({
   role: {
@@ -20,8 +20,8 @@ export const basicTimeSpinnerProps = buildProps({
   arrowControl: Boolean,
   amPmMode: {
     // 'a': am/pm; 'A': AM/PM
-    type: definePropType<"a" | "A" | "">(String),
-    default: "",
+    type: definePropType<'a' | 'A' | ''>(String),
+    default: '',
   },
   ...disabledTimeListsProps,
 } as const);

--- a/components/time-picker/src/props/panel-time-picker.ts
+++ b/components/time-picker/src/props/panel-time-picker.ts
@@ -1,8 +1,8 @@
-import { buildProps, definePropType } from "element-plus/es/utils/index";
-import { timePanelSharedProps } from "./shared";
+import { buildProps, definePropType } from '@flash-global66/g-utils';
+import { timePanelSharedProps } from './shared';
 
-import type { ExtractPropTypes } from "vue";
-import type { Dayjs } from "dayjs";
+import type { ExtractPropTypes } from 'vue';
+import type { Dayjs } from 'dayjs';
 
 export const panelTimePickerProps = buildProps({
   ...timePanelSharedProps,

--- a/components/time-picker/src/props/panel-time-range.ts
+++ b/components/time-picker/src/props/panel-time-range.ts
@@ -1,8 +1,8 @@
-import { buildProps, definePropType } from "element-plus/es/utils/index";
-import { timePanelSharedProps } from "./shared";
+import { buildProps, definePropType } from '@flash-global66/g-utils';
+import { timePanelSharedProps } from './shared';
 
-import type { ExtractPropTypes } from "vue";
-import type { Dayjs } from "dayjs";
+import type { ExtractPropTypes } from 'vue';
+import type { Dayjs } from 'dayjs';
 
 export const panelTimeRangeProps = buildProps({
   ...timePanelSharedProps,

--- a/components/time-picker/src/props/shared.ts
+++ b/components/time-picker/src/props/shared.ts
@@ -1,12 +1,12 @@
-import { buildProps, definePropType } from "element-plus/es/utils/index";
+import { buildProps, definePropType } from '@flash-global66/g-utils';
 
-import type { ExtractPropTypes } from "vue";
+import type { ExtractPropTypes } from 'vue';
 
 import type {
   GetDisabledHours,
   GetDisabledMinutes,
   GetDisabledSeconds,
-} from "../common/props";
+} from '../common/props';
 
 export const disabledTimeListsProps = buildProps({
   /**
@@ -41,7 +41,7 @@ export const timePanelSharedProps = buildProps({
   },
   format: {
     type: String,
-    default: "",
+    default: '',
   },
 } as const);
 

--- a/components/time-picker/src/time-picker-com/basic-time-spinner.vue
+++ b/components/time-picker/src/time-picker-com/basic-time-spinner.vue
@@ -24,11 +24,11 @@
           @click="handleClick(item, { value: key, disabled })"
         >
           <template v-if="item === 'hours'">
-            {{ ("0" + (amPmMode ? key % 12 || 12 : key)).slice(-2)
+            {{ ('0' + (amPmMode ? key % 12 || 12 : key)).slice(-2)
             }}{{ getAmPmFlag(key) }}
           </template>
           <template v-else>
-            {{ ("0" + key).slice(-2) }}
+            {{ ('0' + key).slice(-2) }}
           </template>
         </li>
       </g-scrollbar>
@@ -54,11 +54,11 @@
           >
             <template v-if="isNumber(time)">
               <template v-if="item === 'hours'">
-                {{ ("0" + (amPmMode ? time % 12 || 12 : time)).slice(-2)
+                {{ ('0' + (amPmMode ? time % 12 || 12 : time)).slice(-2)
                 }}{{ getAmPmFlag(time) }}
               </template>
               <template v-else>
-                {{ ("0" + time).slice(-2) }}
+                {{ ('0' + time).slice(-2) }}
               </template>
             </template>
           </li>
@@ -68,34 +68,37 @@
   </div>
 </template>
 <script lang="ts" setup>
-import { computed, inject, nextTick, onMounted, ref, unref, watch } from "vue";
-import { debounce } from "lodash-unified";
-import { vRepeatClick } from "element-plus";
-import GScrollbar from "@flash-global66/g-scrollbar";
-import { GIconFont } from "@flash-global66/g-icon-font";
-import { useNamespace } from "element-plus";
-import { getStyle, isNumber } from "element-plus/es/utils/index.mjs";
-import { timeUnits } from "../constants";
-import { buildTimeList } from "../utils";
-import { basicTimeSpinnerProps } from "../props/basic-time-spinner";
-import { getTimeLists } from "../composables/use-time-picker";
+import { computed, inject, nextTick, onMounted, ref, unref, watch } from 'vue';
+import { debounce } from 'lodash-unified';
+import GScrollbar from '@flash-global66/g-scrollbar';
+import { GIconFont } from '@flash-global66/g-icon-font';
+import {
+  vRepeatClick,
+  useNamespace,
+  getStyle,
+  isNumber,
+} from '@flash-global66/g-utils';
+import { timeUnits } from '../constants';
+import { buildTimeList } from '../utils';
+import { basicTimeSpinnerProps } from '../props/basic-time-spinner';
+import { getTimeLists } from '../composables/use-time-picker';
 
-import type { Ref } from "vue";
-import type { ScrollbarInstance } from "@flash-global66/g-scrollbar";
-import type { TimeUnit } from "../constants";
-import type { TimeList } from "../utils";
+import type { Ref } from 'vue';
+import type { ScrollbarInstance } from '@flash-global66/g-scrollbar';
+import type { TimeUnit } from '../constants';
+import type { TimeList } from '../utils';
 
 const props = defineProps(basicTimeSpinnerProps);
-const pickerBase = inject("EP_PICKER_BASE") as any;
+const pickerBase = inject('EP_PICKER_BASE') as any;
 const { isRange } = pickerBase.props;
-const emit = defineEmits(["change", "select-range", "set-option"]);
+const emit = defineEmits(['change', 'select-range', 'set-option']);
 
-const ns = useNamespace("time");
+const ns = useNamespace('time');
 
 const { getHoursList, getMinutesList, getSecondsList } = getTimeLists(
   props.disabledHours,
   props.disabledMinutes,
-  props.disabledSeconds
+  props.disabledSeconds,
 );
 
 // data
@@ -145,17 +148,17 @@ const arrowControlTimeList = computed<Record<TimeUnit, TimeList>>(() => {
   };
 });
 
-const debouncedResetScroll = debounce((type) => {
+const debouncedResetScroll = debounce(type => {
   isScrolling = false;
   adjustCurrentSpinner(type);
 }, 200);
 
 const getAmPmFlag = (hour: number) => {
   const shouldShowAmPm = !!props.amPmMode;
-  if (!shouldShowAmPm) return "";
-  const isCapital = props.amPmMode === "A";
+  if (!shouldShowAmPm) return '';
+  const isCapital = props.amPmMode === 'A';
   // todo locale
-  let content = hour < 12 ? " am" : " pm";
+  let content = hour < 12 ? ' am' : ' pm';
   if (isCapital) content = content.toUpperCase();
   return content;
 };
@@ -164,19 +167,19 @@ const emitSelectRange = (type: TimeUnit) => {
   let range;
 
   switch (type) {
-    case "hours":
+    case 'hours':
       range = [0, 2];
       break;
-    case "minutes":
+    case 'minutes':
       range = [3, 5];
       break;
-    case "seconds":
+    case 'seconds':
       range = [6, 8];
       break;
   }
   const [left, right] = range;
 
-  emit("select-range", left, right);
+  emit('select-range', left, right);
   currentScrollbar.value = type;
 };
 
@@ -185,9 +188,9 @@ const adjustCurrentSpinner = (type: TimeUnit) => {
 };
 
 const adjustSpinners = () => {
-  adjustCurrentSpinner("hours");
-  adjustCurrentSpinner("minutes");
-  adjustCurrentSpinner("seconds");
+  adjustCurrentSpinner('hours');
+  adjustCurrentSpinner('minutes');
+  adjustCurrentSpinner('seconds');
 };
 
 const getScrollbarElement = (el: HTMLElement) =>
@@ -199,16 +202,16 @@ const adjustSpinner = (type: TimeUnit, value: number) => {
   if (scrollbar && scrollbar.$el) {
     getScrollbarElement(scrollbar.$el).scrollTop = Math.max(
       0,
-      value * typeItemHeight(type)
+      value * typeItemHeight(type),
     );
   }
 };
 
 const typeItemHeight = (type: TimeUnit): number => {
   const scrollbar = unref(listRefsMap[type]);
-  const listItem = scrollbar?.$el.querySelector("li");
+  const listItem = scrollbar?.$el.querySelector('li');
   if (listItem) {
-    return Number.parseFloat(getStyle(listItem, "height")) || 0;
+    return Number.parseFloat(getStyle(listItem, 'height')) || 0;
   }
   return 0;
 };
@@ -223,12 +226,12 @@ const onDecrement = () => {
 
 const scrollDown = (step: number) => {
   if (!currentScrollbar.value) {
-    emitSelectRange("hours");
+    emitSelectRange('hours');
   }
 
   const label = currentScrollbar.value!;
   const now = unref(timePartials)[label];
-  const total = currentScrollbar.value === "hours" ? 24 : 60;
+  const total = currentScrollbar.value === 'hours' ? 24 : 60;
   const next = findNextUnDisabled(label, now, step, total);
 
   modifyDateField(label, next);
@@ -240,7 +243,7 @@ const findNextUnDisabled = (
   type: TimeUnit,
   now: number,
   step: number,
-  total: number
+  total: number,
 ) => {
   let next = (now + step + total) % total;
   const list = unref(timeList)[type];
@@ -259,22 +262,22 @@ const modifyDateField = (type: TimeUnit, value: number) => {
 
   let changeTo;
   switch (type) {
-    case "hours":
+    case 'hours':
       changeTo = props.spinnerDate.hour(value).minute(minutes).second(seconds);
       break;
-    case "minutes":
+    case 'minutes':
       changeTo = props.spinnerDate.hour(hours).minute(value).second(seconds);
       break;
-    case "seconds":
+    case 'seconds':
       changeTo = props.spinnerDate.hour(hours).minute(minutes).second(value);
       break;
   }
-  emit("change", changeTo);
+  emit('change', changeTo);
 };
 
 const handleClick = (
   type: TimeUnit,
-  { value, disabled }: { value: number; disabled: boolean }
+  { value, disabled }: { value: number; disabled: boolean },
 ) => {
   if (!disabled) {
     modifyDateField(type, value);
@@ -294,9 +297,9 @@ const handleScroll = (type: TimeUnit) => {
       (getScrollbarElement(scrollbar.$el).scrollTop -
         (scrollBarHeight(type) * 0.5 - 10) / typeItemHeight(type) +
         3) /
-        typeItemHeight(type)
+        typeItemHeight(type),
     ),
-    type === "hours" ? 23 : 59
+    type === 'hours' ? 23 : 59,
   );
   modifyDateField(type, value);
 };
@@ -316,9 +319,9 @@ const bindScrollEvent = () => {
       };
     }
   };
-  bindFunction("hours");
-  bindFunction("minutes");
-  bindFunction("seconds");
+  bindFunction('hours');
+  bindFunction('minutes');
+  bindFunction('seconds');
 };
 
 onMounted(() => {
@@ -326,7 +329,7 @@ onMounted(() => {
     !props.arrowControl && bindScrollEvent();
     adjustSpinners();
     // set selection on the first hour part
-    if (props.role === "start") emitSelectRange("hours");
+    if (props.role === 'start') emitSelectRange('hours');
   });
 });
 
@@ -334,14 +337,14 @@ const setRef = (scrollbar: ScrollbarInstance | null, type: TimeUnit) => {
   listRefsMap[type].value = scrollbar ?? undefined;
 };
 
-emit("set-option", [`${props.role}_scrollDown`, scrollDown]);
-emit("set-option", [`${props.role}_emitSelectRange`, emitSelectRange]);
+emit('set-option', [`${props.role}_scrollDown`, scrollDown]);
+emit('set-option', [`${props.role}_emitSelectRange`, emitSelectRange]);
 
 watch(
   () => props.spinnerDate,
   () => {
     if (isScrolling) return;
     adjustSpinners();
-  }
+  },
 );
 </script>

--- a/components/time-picker/src/time-picker-com/panel-time-pick.vue
+++ b/components/time-picker/src/time-picker-com/panel-time-pick.vue
@@ -8,7 +8,7 @@
           :arrow-control="arrowControl"
           :show-seconds="showSeconds"
           :am-pm-mode="amPmMode"
-          :spinner-date="(parsedValue as any)"
+          :spinner-date="parsedValue as any"
           :disabled-hours="disabledHours"
           :disabled-minutes="disabledMinutes"
           :disabled-seconds="disabledSeconds"
@@ -38,26 +38,25 @@
 </template>
 
 <script lang="ts" setup>
-import { computed, inject, ref } from "vue";
-import dayjs from "dayjs";
-import { EVENT_CODE } from "element-plus/es/constants/index.mjs";
-import { useLocale, useNamespace } from "element-plus";
-import { isUndefined } from "element-plus/es/utils/index.mjs";
-import { panelTimePickerProps } from "../props/panel-time-picker";
-import { useTimePanel } from "../composables/use-time-panel";
+import { computed, inject, ref } from 'vue';
+import dayjs from 'dayjs';
+import { EVENT_CODE, useNamespace, isUndefined } from '@flash-global66/g-utils';
+import { useLocale } from '@flash-global66/g-hooks';
+import { panelTimePickerProps } from '../props/panel-time-picker';
+import { useTimePanel } from '../composables/use-time-panel';
 import {
   buildAvailableTimeSlotGetter,
   useOldValue,
-} from "../composables/use-time-picker";
-import TimeSpinner from "./basic-time-spinner.vue";
+} from '../composables/use-time-picker';
+import TimeSpinner from './basic-time-spinner.vue';
 
-import type { Dayjs } from "dayjs";
+import type { Dayjs } from 'dayjs';
 
 const props = defineProps(panelTimePickerProps);
-const emit = defineEmits(["pick", "select-range", "set-picker-option"]);
+const emit = defineEmits(['pick', 'select-range', 'set-picker-option']);
 
 // Injections
-const pickerBase = inject("EP_PICKER_BASE") as any;
+const pickerBase = inject('EP_PICKER_BASE') as any;
 const {
   arrowControl,
   disabledHours,
@@ -68,8 +67,8 @@ const {
 const { getAvailableHours, getAvailableMinutes, getAvailableSeconds } =
   buildAvailableTimeSlotGetter(disabledHours, disabledMinutes, disabledSeconds);
 
-const ns = useNamespace("time");
-const { t, lang } = useLocale();
+const ns = useNamespace('time');
+const { lang } = useLocale();
 // data
 const selectionRange = ref([0, 2]);
 const oldValue = useOldValue(props);
@@ -77,15 +76,15 @@ const oldValue = useOldValue(props);
 const transitionName = computed(() => {
   return isUndefined(props.actualVisible)
     ? `${ns.namespace.value}-zoom-in-top`
-    : "";
+    : '';
 });
 const showSeconds = computed(() => {
-  return props.format.includes("ss");
+  return props.format.includes('ss');
 });
 const amPmMode = computed(() => {
-  if (props.format.includes("A")) return "A";
-  if (props.format.includes("a")) return "a";
-  return "";
+  if (props.format.includes('A')) return 'A';
+  if (props.format.includes('a')) return 'a';
+  return '';
 });
 // method
 const isValidValue = (_date: Dayjs) => {
@@ -94,11 +93,11 @@ const isValidValue = (_date: Dayjs) => {
   return parsedDate.isSame(result);
 };
 const handleCancel = () => {
-  emit("pick", oldValue.value, false);
+  emit('pick', oldValue.value, false);
 };
 const handleConfirm = (visible = false, first = false) => {
   if (first) return;
-  emit("pick", props.parsedValue, visible);
+  emit('pick', props.parsedValue, visible);
 };
 const handleChange = (_date: Dayjs) => {
   // visible avoids edge cases, when use scrolls during panel closing animation
@@ -106,22 +105,22 @@ const handleChange = (_date: Dayjs) => {
     return;
   }
   const result = getRangeAvailableTime(_date).millisecond(0);
-  emit("pick", result, true);
+  emit('pick', result, true);
 };
 
 const setSelectionRange = (start: number, end: number) => {
-  emit("select-range", start, end);
+  emit('select-range', start, end);
   selectionRange.value = [start, end];
 };
 
 const changeSelectionRange = (step: number) => {
   const list = [0, 3].concat(showSeconds.value ? [6] : []);
-  const mapping = ["hours", "minutes"].concat(
-    showSeconds.value ? ["seconds"] : []
+  const mapping = ['hours', 'minutes'].concat(
+    showSeconds.value ? ['seconds'] : [],
   );
   const index = list.indexOf(selectionRange.value[0]);
   const next = (index + step + list.length) % list.length;
-  timePickerOptions["start_emitSelectRange"](mapping[next]);
+  timePickerOptions['start_emitSelectRange'](mapping[next]);
 };
 
 const handleKeydown = (event: KeyboardEvent) => {
@@ -138,7 +137,7 @@ const handleKeydown = (event: KeyboardEvent) => {
 
   if ([up, down].includes(code)) {
     const step = code === up ? -1 : 1;
-    timePickerOptions["start_scrollDown"](step);
+    timePickerOptions['start_scrollDown'](step);
     event.preventDefault();
     return;
   }
@@ -151,7 +150,7 @@ const { timePickerOptions, onSetOption, getAvailableTime } = useTimePanel({
 });
 
 const getRangeAvailableTime = (date: Dayjs) => {
-  return getAvailableTime(date, props.datetimeRole || "", true);
+  return getAvailableTime(date, props.datetimeRole || '', true);
 };
 
 const parseUserInput = (value: Dayjs) => {
@@ -168,10 +167,10 @@ const getDefaultValue = () => {
   return dayjs(defaultValue).locale(lang.value);
 };
 
-emit("set-picker-option", ["isValidValue", isValidValue]);
-emit("set-picker-option", ["formatToString", formatToString]);
-emit("set-picker-option", ["parseUserInput", parseUserInput]);
-emit("set-picker-option", ["handleKeydownInput", handleKeydown]);
-emit("set-picker-option", ["getRangeAvailableTime", getRangeAvailableTime]);
-emit("set-picker-option", ["getDefaultValue", getDefaultValue]);
+emit('set-picker-option', ['isValidValue', isValidValue]);
+emit('set-picker-option', ['formatToString', formatToString]);
+emit('set-picker-option', ['parseUserInput', parseUserInput]);
+emit('set-picker-option', ['handleKeydownInput', handleKeydown]);
+emit('set-picker-option', ['getRangeAvailableTime', getRangeAvailableTime]);
+emit('set-picker-option', ['getDefaultValue', getDefaultValue]);
 </script>

--- a/components/time-picker/src/time-picker-com/panel-time-range.vue
+++ b/components/time-picker/src/time-picker-com/panel-time-range.vue
@@ -64,24 +64,23 @@
 </template>
 
 <script lang="ts" setup>
-import { computed, inject, ref, unref } from "vue";
-import dayjs from "dayjs";
-import { union } from "lodash-unified";
-import { useLocale, useNamespace } from "element-plus";
-import { isArray } from "element-plus/es/utils/index.mjs";
-import { EVENT_CODE } from "element-plus/es/constants/index.mjs";
-import { panelTimeRangeProps } from "../props/panel-time-range";
-import { useTimePanel } from "../composables/use-time-panel";
+import { computed, inject, ref, unref } from 'vue';
+import dayjs from 'dayjs';
+import { union } from 'lodash-unified';
+import { useNamespace, isArray, EVENT_CODE } from '@flash-global66/g-utils';
+import { useLocale } from '@flash-global66/g-hooks';
+import { panelTimeRangeProps } from '../props/panel-time-range';
+import { useTimePanel } from '../composables/use-time-panel';
 import {
   buildAvailableTimeSlotGetter,
   useOldValue,
-} from "../composables/use-time-picker";
-import TimeSpinner from "./basic-time-spinner.vue";
+} from '../composables/use-time-picker';
+import TimeSpinner from './basic-time-spinner.vue';
 
-import type { Dayjs } from "dayjs";
+import type { Dayjs } from 'dayjs';
 
 const props = defineProps(panelTimeRangeProps);
-const emit = defineEmits(["pick", "select-range", "set-picker-option"]);
+const emit = defineEmits(['pick', 'select-range', 'set-picker-option']);
 
 const makeSelectRange = (start: number, end: number) => {
   const result: number[] = [];
@@ -91,10 +90,10 @@ const makeSelectRange = (start: number, end: number) => {
   return result;
 };
 
-const { t, lang } = useLocale();
-const nsTime = useNamespace("time");
-const nsPicker = useNamespace("picker");
-const pickerBase = inject("EP_PICKER_BASE") as any;
+const { lang } = useLocale();
+const nsTime = useNamespace('time');
+const nsPicker = useNamespace('picker');
+const pickerBase = inject('EP_PICKER_BASE') as any;
 const {
   arrowControl,
   disabledHours,
@@ -104,35 +103,35 @@ const {
 } = pickerBase.props;
 
 const startContainerKls = computed(() => [
-  nsTime.be("range-picker", "body"),
-  nsTime.be("panel", "content"),
-  nsTime.is("arrow", arrowControl),
-  showSeconds.value ? "has-seconds" : "",
+  nsTime.be('range-picker', 'body'),
+  nsTime.be('panel', 'content'),
+  nsTime.is('arrow', arrowControl),
+  showSeconds.value ? 'has-seconds' : '',
 ]);
 const endContainerKls = computed(() => [
-  nsTime.be("range-picker", "body"),
-  nsTime.be("panel", "content"),
-  nsTime.is("arrow", arrowControl),
-  showSeconds.value ? "has-seconds" : "",
+  nsTime.be('range-picker', 'body'),
+  nsTime.be('panel', 'content'),
+  nsTime.is('arrow', arrowControl),
+  showSeconds.value ? 'has-seconds' : '',
 ]);
 
 const startTime = computed(() => props.parsedValue![0]);
 const endTime = computed(() => props.parsedValue![1]);
 const oldValue = useOldValue(props);
 const handleCancel = () => {
-  emit("pick", oldValue.value, false);
+  emit('pick', oldValue.value, false);
 };
 const showSeconds = computed(() => {
-  return props.format.includes("ss");
+  return props.format.includes('ss');
 });
 const amPmMode = computed(() => {
-  if (props.format.includes("A")) return "A";
-  if (props.format.includes("a")) return "a";
-  return "";
+  if (props.format.includes('A')) return 'A';
+  if (props.format.includes('a')) return 'a';
+  return '';
 });
 
 const handleConfirm = (visible = false) => {
-  emit("pick", [startTime.value, endTime.value], visible);
+  emit('pick', [startTime.value, endTime.value], visible);
 };
 
 const handleMinChange = (date: Dayjs) => {
@@ -143,7 +142,7 @@ const handleMaxChange = (date: Dayjs) => {
 };
 
 const isValidValue = (_date: Dayjs[]) => {
-  const parsedDate = _date.map((_) => dayjs(_).locale(lang.value));
+  const parsedDate = _date.map(_ => dayjs(_).locale(lang.value));
   const result = getRangeAvailableTime(parsedDate);
   return parsedDate[0].isSame(result[0]) && parsedDate[1].isSame(result[1]);
 };
@@ -153,7 +152,7 @@ const handleChange = (start: Dayjs, end: Dayjs) => {
     return;
   }
   // todo getRangeAvailableTime(_date).millisecond(0)
-  emit("pick", [start, end], true);
+  emit('pick', [start, end], true);
 };
 const btnConfirmDisabled = computed(() => {
   return startTime.value > endTime.value;
@@ -161,29 +160,29 @@ const btnConfirmDisabled = computed(() => {
 
 const selectionRange = ref([0, 2]);
 const setMinSelectionRange = (start: number, end: number) => {
-  emit("select-range", start, end, "min");
+  emit('select-range', start, end, 'min');
   selectionRange.value = [start, end];
 };
 
 const offset = computed(() => (showSeconds.value ? 11 : 8));
 const setMaxSelectionRange = (start: number, end: number) => {
-  emit("select-range", start, end, "max");
+  emit('select-range', start, end, 'max');
   const _offset = unref(offset);
   selectionRange.value = [start + _offset, end + _offset];
 };
 
 const changeSelectionRange = (step: number) => {
   const list = showSeconds.value ? [0, 3, 6, 11, 14, 17] : [0, 3, 8, 11];
-  const mapping = ["hours", "minutes"].concat(
-    showSeconds.value ? ["seconds"] : []
+  const mapping = ['hours', 'minutes'].concat(
+    showSeconds.value ? ['seconds'] : [],
   );
   const index = list.indexOf(selectionRange.value[0]);
   const next = (index + step + list.length) % list.length;
   const half = list.length / 2;
   if (next < half) {
-    timePickerOptions["start_emitSelectRange"](mapping[next]);
+    timePickerOptions['start_emitSelectRange'](mapping[next]);
   } else {
-    timePickerOptions["end_emitSelectRange"](mapping[next - half]);
+    timePickerOptions['end_emitSelectRange'](mapping[next - half]);
   }
 };
 
@@ -201,7 +200,7 @@ const handleKeydown = (event: KeyboardEvent) => {
 
   if ([up, down].includes(code)) {
     const step = code === up ? -1 : 1;
-    const role = selectionRange.value[0] < offset.value ? "start" : "end";
+    const role = selectionRange.value[0] < offset.value ? 'start' : 'end';
     timePickerOptions[`${role}_scrollDown`](step);
     event.preventDefault();
     return;
@@ -210,7 +209,7 @@ const handleKeydown = (event: KeyboardEvent) => {
 
 const disabledHours_ = (role: string, compare?: Dayjs) => {
   const defaultDisable = disabledHours ? disabledHours(role) : [];
-  const isStart = role === "start";
+  const isStart = role === 'start';
   const compareDate = compare || (isStart ? endTime.value : startTime.value);
   const compareHour = compareDate.hour();
   const nextDisable = isStart
@@ -220,7 +219,7 @@ const disabledHours_ = (role: string, compare?: Dayjs) => {
 };
 const disabledMinutes_ = (hour: number, role: string, compare?: Dayjs) => {
   const defaultDisable = disabledMinutes ? disabledMinutes(hour, role) : [];
-  const isStart = role === "start";
+  const isStart = role === 'start';
   const compareDate = compare || (isStart ? endTime.value : startTime.value);
   const compareHour = compareDate.hour();
   if (hour !== compareHour) {
@@ -236,12 +235,12 @@ const disabledSeconds_ = (
   hour: number,
   minute: number,
   role: string,
-  compare?: Dayjs
+  compare?: Dayjs,
 ) => {
   const defaultDisable = disabledSeconds
     ? disabledSeconds(hour, minute, role)
     : [];
-  const isStart = role === "start";
+  const isStart = role === 'start';
   const compareDate = compare || (isStart ? endTime.value : startTime.value);
   const compareHour = compareDate.hour();
   const compareMinute = compareDate.minute();
@@ -257,8 +256,8 @@ const disabledSeconds_ = (
 
 const getRangeAvailableTime = ([start, end]: Array<Dayjs>) => {
   return [
-    getAvailableTime(start, "start", true, end),
-    getAvailableTime(end, "end", false, start),
+    getAvailableTime(start, 'start', true, end),
+    getAvailableTime(end, 'end', false, start),
   ] as const;
 };
 
@@ -266,7 +265,7 @@ const { getAvailableHours, getAvailableMinutes, getAvailableSeconds } =
   buildAvailableTimeSlotGetter(
     disabledHours_,
     disabledMinutes_,
-    disabledSeconds_
+    disabledSeconds_,
   );
 
 const {
@@ -283,7 +282,7 @@ const {
 const parseUserInput = (days: Dayjs[] | Dayjs) => {
   if (!days) return null;
   if (isArray(days)) {
-    return days.map((d) => dayjs(d, props.format).locale(lang.value));
+    return days.map(d => dayjs(d, props.format).locale(lang.value));
   }
   return dayjs(days, props.format).locale(lang.value);
 };
@@ -291,23 +290,23 @@ const parseUserInput = (days: Dayjs[] | Dayjs) => {
 const formatToString = (days: Dayjs[] | Dayjs) => {
   if (!days) return null;
   if (isArray(days)) {
-    return days.map((d) => d.format(props.format));
+    return days.map(d => d.format(props.format));
   }
   return days.format(props.format);
 };
 
 const getDefaultValue = () => {
   if (isArray(defaultValue)) {
-    return defaultValue.map((d: Date) => dayjs(d).locale(lang.value));
+    return defaultValue.map(d => dayjs(d as Date).locale(lang.value));
   }
   const defaultDay = dayjs(defaultValue).locale(lang.value);
-  return [defaultDay, defaultDay.add(60, "m")];
+  return [defaultDay, defaultDay.add(60, 'm')];
 };
 
-emit("set-picker-option", ["formatToString", formatToString]);
-emit("set-picker-option", ["parseUserInput", parseUserInput]);
-emit("set-picker-option", ["isValidValue", isValidValue]);
-emit("set-picker-option", ["handleKeydownInput", handleKeydown]);
-emit("set-picker-option", ["getDefaultValue", getDefaultValue]);
-emit("set-picker-option", ["getRangeAvailableTime", getRangeAvailableTime]);
+emit('set-picker-option', ['formatToString', formatToString]);
+emit('set-picker-option', ['parseUserInput', parseUserInput]);
+emit('set-picker-option', ['isValidValue', isValidValue]);
+emit('set-picker-option', ['handleKeydownInput', handleKeydown]);
+emit('set-picker-option', ['getDefaultValue', getDefaultValue]);
+emit('set-picker-option', ['getRangeAvailableTime', getRangeAvailableTime]);
 </script>

--- a/components/time-picker/src/utils.ts
+++ b/components/time-picker/src/utils.ts
@@ -1,8 +1,8 @@
-import dayjs from "dayjs";
-import { isArray, isDate, isEmpty } from "element-plus/es/utils/index.mjs";
+import dayjs from 'dayjs';
+import { isArray, isDate, isEmpty } from '@flash-global66/g-utils';
 
-import type { Dayjs } from "dayjs";
-import type { DateOrDates, DayOrDays } from "./common/props";
+import type { Dayjs } from 'dayjs';
+import type { DateOrDates, DayOrDays } from './common/props';
 export type TimeList = [number | undefined, number, undefined | number];
 
 export const buildTimeList = (value: number, bound: number): TimeList => {
@@ -18,14 +18,14 @@ export const rangeArr = (n: number) =>
 
 export const extractDateFormat = (format: string) => {
   return format
-    .replace(/\W?m{1,2}|\W?ZZ/g, "")
-    .replace(/\W?h{1,2}|\W?s{1,3}|\W?a/gi, "")
+    .replace(/\W?m{1,2}|\W?ZZ/g, '')
+    .replace(/\W?h{1,2}|\W?s{1,3}|\W?a/gi, '')
     .trim();
 };
 
 export const extractTimeFormat = (format: string) => {
   return format
-    .replace(/\W?D{1,2}|\W?Do|\W?d{1,4}|\W?M{1,4}|\W?Y{2,4}/g, "")
+    .replace(/\W?D{1,2}|\W?Do|\W?d{1,4}|\W?M{1,4}|\W?Y{2,4}/g, '')
     .trim();
 };
 
@@ -43,7 +43,7 @@ export const dateEquals = function (a: Date | unknown, b: Date | unknown) {
 
 export const valueEquals = function (
   a: Array<Date> | unknown,
-  b: Array<Date> | unknown
+  b: Array<Date> | unknown,
 ) {
   const aIsArray = isArray(a);
   const bIsArray = isArray(b);
@@ -62,10 +62,10 @@ export const valueEquals = function (
 export const parseDate = function (
   date: string | number | Date,
   format: string | undefined,
-  lang: string
+  lang: string,
 ) {
   const day =
-    isEmpty(format) || format === "x"
+    isEmpty(format) || format === 'x'
       ? dayjs(date).locale(lang)
       : dayjs(date, format).locale(lang);
   return day.isValid() ? day : undefined;
@@ -74,10 +74,10 @@ export const parseDate = function (
 export const formatter = function (
   date: string | number | Date | Dayjs,
   format: string | undefined,
-  lang: string
+  lang: string,
 ) {
   if (isEmpty(format)) return date;
-  if (format === "x") return +date;
+  if (format === 'x') return +date;
   return dayjs(date).locale(lang).format(format);
 };
 
@@ -92,6 +92,6 @@ export const makeList = (total: number, method?: () => number[]) => {
 
 export const dayOrDaysToDate = (dayOrDays: DayOrDays): DateOrDates => {
   return isArray(dayOrDays)
-    ? (dayOrDays.map((d) => d.toDate()) as [Date, Date])
+    ? (dayOrDays.map(d => d.toDate()) as [Date, Date])
     : dayOrDays.toDate();
 };

--- a/openspec/changes/ep-extraction-v4/tasks.md
+++ b/openspec/changes/ep-extraction-v4/tasks.md
@@ -245,21 +245,20 @@ Publishes: `date-picker`. Est. ~250 changed lines (includes the lint-debt cleanu
 
 Publishes: `time-picker`. Est. ~220 changed lines. Requirements: `popper-overlay-migration` full set; `g-utils-extended` → `popper-overlay-utils-added`, `v4-utils-unit-tested`.
 
-- [ ] T11.1 Confirm PR #6 (tooltip), PR #9 (dropdown), and PR #8 (select) are merged before starting.
-- [ ] T11.2 Read EP's `getStyle` from `node_modules/element-plus/es/utils/dom/style.mjs` (2.9.7). Cross-check sibling.
-- [ ] T11.3 Write failing unit test for `getStyle` (reads a computed style property from an element via `getComputedStyle`, with the same fallback/normalization EP applies for cross-browser `float`/vendor-prefixed properties) — new `common/g-utils/tests/utils/dom.util.spec.ts` (extend WU-1's file if already created).
-- [ ] T11.4 Implement `getStyle` in `common/g-utils/src/utils/dom.util.ts` — byte-exact copy. Run `yarn test:run` → green.
-- [ ] T11.5 Read EP's `vRepeatClick` directive from `node_modules/element-plus/es/directives/repeat-click/index.mjs` (2.9.7). Cross-check sibling. Note per design §4 this directive is also needed by `input-number` in the deferred v5 slice — build it EP-faithful so v5 can re-point cleanly.
-- [ ] T11.6 Write failing unit test for `vRepeatClick` (mousedown starts a repeating interval invoking the bound handler after an initial delay; mouseup/mouseleave clears the interval; single click without hold still fires once) — new `common/g-utils/tests/directives/repeatClick.directive.spec.ts`.
-- [ ] T11.7 Implement `vRepeatClick` in `common/g-utils/src/directives/repeatClick.directive.ts` — byte-exact copy. Run `yarn test:run` → green.
-- [ ] T11.8 Update `common/g-utils/src/index.ts` barrel for `getStyle`, `vRepeatClick`.
-- [ ] T11.9 Migrate `components/time-picker/src/**`: re-point `useEmptyValues` from WU-8, `useLocale` from WU-9, `useFocusController` (already exists in g-hooks per v3 — currently `time-picker` still imports it straight from EP per obs #269, per the proposal's "already-extracted hooks not auto-consumed" risk); wire `getStyle`/`vRepeatClick`. Zero public API change.
-- [ ] T11.10 Grep-verify zero `from ['"]element-plus` matches under `components/time-picker/src/**` and `index.ts`, including confirming `useFocusController` now resolves from `@flash-global66/g-hooks`, not EP.
-- [ ] T11.11 Confirm `time-picker`'s `package.json` packaging convention, including `g-form`/`g-input`/`g-icon-font`/`g-tooltip` as real dependencies where used per design §3.
-- [ ] T11.12 Remove `'components/time-picker/**'` from `excludedFiles` in `.eslintrc.cjs`. `yarn lint --max-warnings 0` passes.
-- [ ] T11.13 `yarn build` succeeds for `time-picker`. Full `yarn test:run` green.
-- [ ] T11.14 Validate in `front-b2b` (real copy).
-- [ ] T11.15 Commit as one work unit (`feat(time-picker): migrate off element-plus internals, add getStyle/vRepeatClick, re-point useFocusController`), open PR #11 (depends on PR #6 + PR #9 + PR #8 merged), Lerna-publish on merge.
+- [x] T11.1 Confirmed WU-6/WU-9/WU-8 (+ all prior) merged + published before starting; branch off current `main`.
+- [x] T11.2/T11.3/T11.4 **Superseded**: `getStyle` was already ported to `common/g-utils/src/utils/dom.util.ts` in WU-7 (dialog). No re-port — time-picker re-points to it.
+- [x] T11.5 Read EP's `vRepeatClick` from `node_modules/element-plus/es/directives/repeat-click/index.mjs`. Cross-checked sibling.
+- [x] T11.6 Failing unit test in `common/g-utils/tests/directives/repeatClick.directive.spec.ts` (immediate fire on left mousedown; ignores non-left; delay→interval repeat; mouseup clears; function-or-options value).
+- [x] T11.7 Implemented `vRepeatClick` in `common/g-utils/src/directives/repeatClick.directive.ts` byte-exact (typed as `ObjectDirective`, EP `any`→typed, no `any`). Green (5/5).
+- [x] T11.8 Barrel: `vRepeatClick`/`REPEAT_INTERVAL`/`REPEAT_DELAY` via `export * from './directives/repeatClick.directive'`; `getStyle` already exported.
+- [x] **Brief gap (like WU-10)**: `isDate` + `isEmpty` were also imported from EP by `time-picker/src/utils.ts` — not in the brief. Ported byte-exact into `common/g-utils/src/utils/validators.util.ts` (TDD, +8 tests).
+- [x] T11.9 Migrated 12 files: `useLocale`/`useFocusController`/`useAttrs`/`useEmptyValues(Props)`/`useAriaProps` → g-hooks; `isArray`/`isNumber`/`isUndefined`/`isDate`/`isEmpty`/`buildProps`/`definePropType`/`NOOP`/`debugWarn`/`EVENT_CODE`/`useNamespace`/`withInstall`/`getStyle`/`vRepeatClick`/`SFCWithInstall` → g-utils. Zero public API change. Two type-only casts for g-utils' stricter `isArray` (`_ as Dayjs`, `d as Date`).
+- [x] T11.10 Grep-verified zero `from 'element-plus'` under `src/**` + `index.ts`; `useFocusController` resolves from g-hooks.
+- [x] T11.11 Adopted the tooltip packaging convention: all 8 directly-imported `@flash-global66/*` (incl. `g-form` via `useFormItem`) in `dependencies` with aligned ranges; only `dayjs`/`element-plus`/`vue` peer (previously NO `dependencies` block, stale peer ranges).
+- [x] T11.12 Removed `'components/time-picker/**'` from `.eslintrc.cjs`; fixed lint debt (4 dead `@ts-ignore` removed; 2 unused `t` removed). **Post-review fix**: dual blind review caught 3 CI-blocking `vue/no-deprecated-filter` errors — prettier stripped the parens around union-typed template casts (`id as string | undefined`), making `vue-eslint-parser` read the `|` as a Vue-2 filter. Fixed by hoisting the unions into `MaybeString`/`MaybeStringArray` type aliases (no bare `|` in template → prettier-safe). `eslint --max-warnings 0` clean.
+- [x] T11.13 `vue-tsc` on time-picker: identical error profile to baseline (2 TS7016 environmental). Full `test:run` → 341/341 green.
+- [ ] T11.14 **DEFERRED**: b2b real-copy validation batched with the popper/picker family after publish.
+- [x] T11.15 Committed as the WU; PR opened as its own dedicated PR; Lerna-publish on merge. Dual blind review: both judges REQUEST-CHANGES on the paren regression → fixed → clean.
 
 ## WU-12 — `input-tag` (pure re-point; depends on WU-8)
 


### PR DESCRIPTION
## What

WU-11 of **ep-extraction-v4** — migrates `g-time-picker` off element-plus internals (12 files) + in-place lint-debt fix.

### Ported into `g-utils`
- **`vRepeatClick`** directive — byte-exact from EP 2.9.7 (`es/directives/repeat-click`), typed as `ObjectDirective` without `any`. Unit-tested.
- **`isDate`** / **`isEmpty`** — byte-exact from EP `es/utils/types.mjs` (added to `validators.util.ts`). These were EP imports in `time-picker/src/utils.ts` not named in the task brief (same gap pattern as WU-10). Unit-tested.
- `getStyle` was already ported in WU-7 → re-point only.

### Component migration
- Re-pointed 12 files: `useLocale`/`useFocusController`/`useAttrs`/`useEmptyValues(Props)`/`useAriaProps` → `g-hooks`; `isArray`/`isNumber`/`isUndefined`/`isDate`/`isEmpty`/`buildProps`/`definePropType`/`NOOP`/`debugWarn`/`EVENT_CODE`/`useNamespace`/`withInstall`/`getStyle`/`vRepeatClick`/`SFCWithInstall` → `g-utils`. Zero `element-plus` runtime imports remain (scss `@use theme-chalk` retained). `useFocusController` now correctly resolves from `g-hooks` (was still importing from EP — obs #269).
- Plain string injection keys (`'ElPopperOptions'`/`'EP_PICKER_BASE'`) are internal same-package — left as-is.

### Packaging
- Adopted the **tooltip convention**: all 8 directly-imported `@flash-global66/*` (incl. `g-form` via `useFormItem`) in `dependencies` with ranges aligned to current workspace versions; only `dayjs`/`element-plus`/`vue` peer. The package previously had **no** `dependencies` block and badly stale peer ranges.

### Lint (in-place debt fix)
- Removed `components/time-picker/**` from the eslint exclusion; removed 4 dead `@ts-ignore` (verified they suppressed no real error) and 2 unused `t` destructures.

## Type accommodations (pure type-level, zero runtime change)
- Two casts for g-utils' stricter `isArray` (`val is unknown[]` vs EP's `any[]`): `picker.vue` `(_ as Dayjs).toDate()`, `panel-time-range.vue` `dayjs(d as Date)`.
- `picker.vue` template: hoisted union-typed casts into `MaybeString`/`MaybeStringArray` aliases so no bare `|` appears in a template expression (avoids a `vue/no-deprecated-filter` false-positive; prettier-safe).

## Validation
- `vue-tsc` on time-picker: **identical error profile to `origin/main` baseline** (2 TS7016 environmental). No new errors.
- `eslint --max-warnings 0`: clean.
- Full `test:run`: **341/341** green (incl. new `vRepeatClick`/`isDate`/`isEmpty` cases).
- Browser gate: deferred to the batched popper/picker-family validation post-publish.

## Review
Dual blind review — both judges initially **REQUEST-CHANGES** on one CI-blocking regression: prettier had stripped the parens around 3 union-typed template casts in `picker.vue`, tripping `vue/no-deprecated-filter`. Fixed via the type-alias hoist above; re-verified clean (eslint + prettier-safe + vue-tsc baseline). Everything else in both reviews checked out (byte-exact ports, dependency hygiene, no new `any`, Spanish comments).

Comments/JSDoc in Spanish per project convention.