### PR TITLE
feat(input-tag): migrate off element-plus internals, add INPUT_EVENT constant (ep-extraction-v4 WU-12)

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -45,7 +45,6 @@ module.exports = {
         // element-plus component. (useLocale ported in WU-8/select —
         // dropdown/date-picker/time-picker/table should re-point to
         // @flash-global66/g-hooks instead of re-implementing.)
-        'components/input-tag/**',
         'components/toast/**',
         'components/table/**',
         'components/pagination/**',

--- a/common/g-utils/src/constants/event.constant.ts
+++ b/common/g-utils/src/constants/event.constant.ts
@@ -10,6 +10,9 @@ export const UPDATE_MODEL_EVENT = 'update:modelValue';
 /** Nombre del evento estándar para cambios confirmados de valor. */
 export const CHANGE_EVENT = 'change';
 
+/** Nombre del evento estándar de entrada (mientras el usuario escribe). */
+export const INPUT_EVENT = 'input';
+
 /**
  * Mapa de códigos de tecla (`KeyboardEvent.code`) usados en interacciones de teclado.
  *

--- a/components/input-tag/index.ts
+++ b/components/input-tag/index.ts
@@ -1,8 +1,9 @@
-import { withInstall, SFCWithInstall } from 'element-plus/es/utils/index.mjs'
-import InputTag from './src/input-tag.vue'
+import { withInstall } from '@flash-global66/g-utils';
+import type { SFCWithInstall } from '@flash-global66/g-utils';
+import InputTag from './src/input-tag.vue';
 
-export const GInputTag: SFCWithInstall<typeof InputTag> = withInstall(InputTag)
-export type { InputTagInstance } from './src/instance'
-export * from './src/input-tag'
+export const GInputTag: SFCWithInstall<typeof InputTag> = withInstall(InputTag);
+export type { InputTagInstance } from './src/instance';
+export * from './src/input-tag';
 
-export default GInputTag
+export default GInputTag;

--- a/components/input-tag/package.json
+++ b/components/input-tag/package.json
@@ -28,11 +28,16 @@
   "repository": {
     "url": "https://github.com/Flash-Global66/global-design-system.git"
   },
+  "dependencies": {
+    "@flash-global66/g-form": "^0.2.15",
+    "@flash-global66/g-hooks": "^0.11.3",
+    "@flash-global66/g-icon-font": "^0.25.14",
+    "@flash-global66/g-popper": "^0.0.20",
+    "@flash-global66/g-tag": "^0.2.14",
+    "@flash-global66/g-tooltip": "^0.1.8",
+    "@flash-global66/g-utils": "^0.11.0"
+  },
   "peerDependencies": {
-    "@flash-global66/g-form": "^0.1.0",
-    "@flash-global66/g-icon-font": "^0.0.8",
-    "@flash-global66/g-tag": "^0.2.2",
-    "@flash-global66/g-tooltip": "^0.1.1",
     "@vueuse/core": "^13.0.0",
     "element-plus": "^2.9.0",
     "lodash-unified": "^1.0.3",

--- a/components/input-tag/src/composables/use-drag-tag.ts
+++ b/components/input-tag/src/composables/use-drag-tag.ts
@@ -1,19 +1,18 @@
-import { ref, shallowRef } from 'vue'
-import { useNamespace } from 'element-plus'
-import { isUndefined } from 'element-plus/es/utils/index.mjs'
+import { ref, shallowRef } from 'vue';
+import { isUndefined, useNamespace } from '@flash-global66/g-utils';
 
-import type { ShallowRef } from 'vue'
+import type { ShallowRef } from 'vue';
 
-type DropType = 'before' | 'after'
+type DropType = 'before' | 'after';
 
 interface UseDragTagOptions {
-  wrapperRef: ShallowRef<HTMLElement | undefined>
+  wrapperRef: ShallowRef<HTMLElement | undefined>;
   handleDragged: (
     draggingIndex: number,
     dropIndex: number,
-    type: DropType
-  ) => void
-  afterDragged?: () => void
+    type: DropType,
+  ) => void;
+  afterDragged?: () => void;
 }
 
 export function useDragTag({
@@ -21,94 +20,95 @@ export function useDragTag({
   handleDragged,
   afterDragged,
 }: UseDragTagOptions) {
-  const ns = useNamespace('input-tag')
-  const dropIndicatorRef: ShallowRef<HTMLElement | undefined> = shallowRef()
-  const showDropIndicator = ref(false)
+  const ns = useNamespace('input-tag');
+  const dropIndicatorRef: ShallowRef<HTMLElement | undefined> = shallowRef();
+  const showDropIndicator = ref(false);
 
-  let draggingIndex: number | undefined
-  let draggingTag: HTMLElement | null
-  let dropIndex: number | undefined
-  let dropType: DropType | undefined
+  let draggingIndex: number | undefined;
+  let draggingTag: HTMLElement | null;
+  let dropIndex: number | undefined;
+  let dropType: DropType | undefined;
 
   function getTagClassName(index: number) {
-    return `.${ns.e('inner')} > .${ns.e('tag-wrapper')}:nth-child(${index + 1})`
+    return `.${ns.e('inner')} > .${ns.e('tag-wrapper')}:nth-child(${index + 1})`;
   }
 
   function handleDragStart(event: DragEvent, index: number) {
-    draggingIndex = index
+    draggingIndex = index;
     draggingTag = wrapperRef.value!.querySelector<HTMLElement>(
-      getTagClassName(index)
-    )
+      getTagClassName(index),
+    );
 
     if (draggingTag) {
-      draggingTag.style.opacity = '0.5'
+      draggingTag.style.opacity = '0.5';
     }
     if (event.dataTransfer) {
-      event.dataTransfer.effectAllowed = 'move'
+      event.dataTransfer.effectAllowed = 'move';
     }
   }
 
   function handleDragOver(event: DragEvent, index: number) {
-    dropIndex = index
-    event.preventDefault()
+    dropIndex = index;
+    event.preventDefault();
     if (event.dataTransfer) {
-      event.dataTransfer.dropEffect = 'move'
+      event.dataTransfer.dropEffect = 'move';
     }
 
     if (isUndefined(draggingIndex) || draggingIndex === index) {
-      showDropIndicator.value = false
-      return
+      showDropIndicator.value = false;
+      return;
     }
 
     const dropPosition = wrapperRef
       .value!.querySelector<HTMLElement>(getTagClassName(index))!
-      .getBoundingClientRect()
-    const dropPrev = !(draggingIndex! + 1 === index)
-    const dropNext = !(draggingIndex! - 1 === index)
-    const distance = event.clientX - dropPosition.left
-    const prevPercent = dropPrev ? (dropNext ? 0.5 : 1) : -1
-    const nextPercent = dropNext ? (dropPrev ? 0.5 : 0) : 1
+      .getBoundingClientRect();
+    const dropPrev = !(draggingIndex! + 1 === index);
+    const dropNext = !(draggingIndex! - 1 === index);
+    const distance = event.clientX - dropPosition.left;
+    const prevPercent = dropPrev ? (dropNext ? 0.5 : 1) : -1;
+    const nextPercent = dropNext ? (dropPrev ? 0.5 : 0) : 1;
 
     if (distance <= dropPosition.width * prevPercent) {
-      dropType = 'before'
+      dropType = 'before';
     } else if (distance > dropPosition.width * nextPercent) {
-      dropType = 'after'
+      dropType = 'after';
     } else {
-      dropType = undefined
+      dropType = undefined;
     }
 
     const innerEl = wrapperRef.value!.querySelector<HTMLElement>(
-      `.${ns.e('inner')}`
-    )!
-    const innerPosition = innerEl.getBoundingClientRect()
-    const gap = Number.parseFloat(window.getComputedStyle(innerEl).gap || '6') / 2
+      `.${ns.e('inner')}`,
+    )!;
+    const innerPosition = innerEl.getBoundingClientRect();
+    const gap =
+      Number.parseFloat(window.getComputedStyle(innerEl).gap || '6') / 2;
 
-    const indicatorTop = dropPosition.top - innerPosition.top
-    let indicatorLeft = -9999
+    const indicatorTop = dropPosition.top - innerPosition.top;
+    let indicatorLeft = -9999;
 
     if (dropType === 'before') {
       indicatorLeft = Math.max(
         dropPosition.left - innerPosition.left - gap,
-        Math.floor(-gap / 2)
-      )
+        Math.floor(-gap / 2),
+      );
     } else if (dropType === 'after') {
-      const left = dropPosition.right - innerPosition.left
+      const left = dropPosition.right - innerPosition.left;
       indicatorLeft =
-        left + (innerPosition.width === left ? Math.floor(gap / 2) : gap)
+        left + (innerPosition.width === left ? Math.floor(gap / 2) : gap);
     }
 
     if (dropIndicatorRef.value) {
-      dropIndicatorRef.value.style.top = `${indicatorTop}px`
-      dropIndicatorRef.value.style.left = `${indicatorLeft}px`
+      dropIndicatorRef.value.style.top = `${indicatorTop}px`;
+      dropIndicatorRef.value.style.left = `${indicatorLeft}px`;
     }
-    showDropIndicator.value = Boolean(dropType)
+    showDropIndicator.value = Boolean(dropType);
   }
 
   function handleDragEnd(event: DragEvent) {
-    event.preventDefault()
+    event.preventDefault();
 
     if (draggingTag) {
-      draggingTag.style.opacity = ''
+      draggingTag.style.opacity = '';
     }
 
     if (
@@ -117,15 +117,15 @@ export function useDragTag({
       !isUndefined(dropIndex) &&
       draggingIndex !== dropIndex
     ) {
-      handleDragged(draggingIndex, dropIndex, dropType)
+      handleDragged(draggingIndex, dropIndex, dropType);
     }
 
-    showDropIndicator.value = false
-    draggingIndex = undefined
-    draggingTag = null
-    dropIndex = undefined
-    dropType = undefined
-    afterDragged?.()
+    showDropIndicator.value = false;
+    draggingIndex = undefined;
+    draggingTag = null;
+    dropIndex = undefined;
+    dropType = undefined;
+    afterDragged?.();
   }
 
   return {
@@ -134,5 +134,5 @@ export function useDragTag({
     handleDragStart,
     handleDragOver,
     handleDragEnd,
-  }
+  };
 }

--- a/components/input-tag/src/composables/use-input-tag-dom.ts
+++ b/components/input-tag/src/composables/use-input-tag-dom.ts
@@ -1,17 +1,17 @@
-import { computed, reactive, ref, useAttrs, useSlots } from 'vue'
-import { useNamespace } from 'element-plus'
-import { useResizeObserver } from '@vueuse/core'
+import { computed, reactive, ref, useAttrs, useSlots } from 'vue';
+import { useNamespace } from '@flash-global66/g-utils';
+import { useResizeObserver } from '@vueuse/core';
 
-import type { ComputedRef, Ref, StyleValue } from 'vue'
-import type { InputTagProps } from '../input-tag'
+import type { ComputedRef, Ref, StyleValue } from 'vue';
+import type { InputTagProps } from '../input-tag';
 
 interface UseInputTagDomOptions {
-  props: InputTagProps
-  isFocused: Ref<boolean>
-  hovering: Ref<boolean>
-  disabled: ComputedRef<boolean>
-  inputValue: Ref<string>
-  size: ComputedRef<string>
+  props: InputTagProps;
+  isFocused: Ref<boolean>;
+  hovering: Ref<boolean>;
+  disabled: ComputedRef<boolean>;
+  inputValue: Ref<string>;
+  size: ComputedRef<string>;
 }
 
 export function useInputTagDom({
@@ -22,12 +22,12 @@ export function useInputTagDom({
   inputValue,
   size,
 }: UseInputTagDomOptions) {
-  const attrs = useAttrs()
-  const slots = useSlots()
-  const ns = useNamespace('input-tag')
+  const attrs = useAttrs();
+  const slots = useSlots();
+  const ns = useNamespace('input-tag');
 
-  const collapseItemRef = ref<HTMLElement>()
-  const innerRef = ref<HTMLElement>()
+  const collapseItemRef = ref<HTMLElement>();
+  const innerRef = ref<HTMLElement>();
 
   const containerKls = computed(() => [
     ns.b(),
@@ -37,66 +37,66 @@ export function useInputTagDom({
     ns.is('disabled', disabled.value),
     ns.m(size.value),
     attrs.class,
-  ])
+  ]);
   const containerStyle = computed<StyleValue>(() => [
     attrs.style as StyleValue,
-  ])
+  ]);
   const inputAttrs = computed(() => {
-    const result: Record<string, unknown> = {}
+    const result: Record<string, unknown> = {};
     for (const key in attrs) {
-      if (key === 'class' || key === 'style') continue
-      result[key] = attrs[key]
+      if (key === 'class' || key === 'style') continue;
+      result[key] = attrs[key];
     }
-    return result
-  })
+    return result;
+  });
   const innerKls = computed(() => [
     ns.e('inner'),
     ns.is('draggable', Boolean(props.draggable)),
     ns.is('left-space', !props.modelValue?.length && !slots.prefix),
     ns.is('right-space', !props.modelValue?.length && !slots.suffix),
-  ])
+  ]);
   const showClear = computed(() => {
     return Boolean(
       props.clearable &&
         !disabled.value &&
         !props.readonly &&
         (props.modelValue?.length || inputValue.value) &&
-        (isFocused.value || hovering.value)
-    )
-  })
+        (isFocused.value || hovering.value),
+    );
+  });
   const showSuffix = computed(() => {
-    return Boolean(slots.suffix || showClear.value)
-  })
+    return Boolean(slots.suffix || showClear.value);
+  });
 
   const states = reactive({
     innerWidth: 0,
     collapseItemWidth: 0,
-  })
+  });
 
   const getGapWidth = () => {
-    if (!innerRef.value) return 0
-    const style = window.getComputedStyle(innerRef.value)
-    return Number.parseFloat(style.gap || '6px')
-  }
+    if (!innerRef.value) return 0;
+    const style = window.getComputedStyle(innerRef.value);
+    return Number.parseFloat(style.gap || '6px');
+  };
 
   const resetInnerWidth = () => {
-    if (!innerRef.value) return
+    if (!innerRef.value) return;
     states.innerWidth = Number.parseFloat(
-      window.getComputedStyle(innerRef.value).width
-    )
-  }
+      window.getComputedStyle(innerRef.value).width,
+    );
+  };
 
   const resetCollapseItemWidth = () => {
-    if (!collapseItemRef.value) return
+    if (!collapseItemRef.value) return;
     states.collapseItemWidth =
-      collapseItemRef.value.getBoundingClientRect().width
-  }
+      collapseItemRef.value.getBoundingClientRect().width;
+  };
 
   const tagStyle = computed(() => {
-    if (!props.collapseTags) return {}
-    const gapWidth = getGapWidth()
-    const MINIMUM_INPUT_WIDTH = 11
-    const inputSlotWidth = gapWidth + MINIMUM_INPUT_WIDTH
+    if (!props.collapseTags) return {};
+    const gapWidth = getGapWidth();
+    const MINIMUM_INPUT_WIDTH = 11;
+    const inputSlotWidth = gapWidth + MINIMUM_INPUT_WIDTH;
 
     const maxWidth =
       collapseItemRef.value && props.maxCollapseTags === 1
@@ -104,13 +104,13 @@ export function useInputTagDom({
           states.collapseItemWidth -
           gapWidth -
           inputSlotWidth
-        : states.innerWidth - inputSlotWidth
+        : states.innerWidth - inputSlotWidth;
 
-    return { maxWidth: `${Math.max(maxWidth, 0)}px` }
-  })
+    return { maxWidth: `${Math.max(maxWidth, 0)}px` };
+  });
 
-  useResizeObserver(innerRef, resetInnerWidth)
-  useResizeObserver(collapseItemRef, resetCollapseItemWidth)
+  useResizeObserver(innerRef, resetInnerWidth);
+  useResizeObserver(collapseItemRef, resetCollapseItemWidth);
 
   return {
     ns,
@@ -123,5 +123,5 @@ export function useInputTagDom({
     tagStyle,
     collapseItemRef,
     innerRef,
-  }
+  };
 }

--- a/components/input-tag/src/composables/use-input-tag.ts
+++ b/components/input-tag/src/composables/use-input-tag.ts
@@ -1,116 +1,110 @@
-import { computed, ref, shallowRef, watch } from 'vue'
+import { computed, ref, shallowRef, watch } from 'vue';
 import {
   CHANGE_EVENT,
   EVENT_CODE,
   INPUT_EVENT,
   UPDATE_MODEL_EVENT,
-} from 'element-plus/es/constants/index.mjs'
-import { NOOP } from 'element-plus/es/utils/index.mjs'
-import { useComposition, useFocusController } from 'element-plus'
-import { useFormDisabled } from '@flash-global66/g-form'
+  NOOP,
+} from '@flash-global66/g-utils';
+import { useComposition, useFocusController } from '@flash-global66/g-hooks';
+import { useFormDisabled } from '@flash-global66/g-form';
 
-import type { ShallowRef } from 'vue'
-import type { TooltipInstance } from '@flash-global66/g-tooltip'
-import type { FormItemContext } from '@flash-global66/g-form'
-import type { InputTagEmits, InputTagProps } from '../input-tag'
+import type { ShallowRef } from 'vue';
+import type { TooltipInstance } from '@flash-global66/g-tooltip';
+import type { FormItemContext } from '@flash-global66/g-form';
+import type { InputTagProps } from '../input-tag';
 
 const ensureArray = (value: string | string[]): string[] =>
-  Array.isArray(value) ? value : [value]
+  Array.isArray(value) ? value : [value];
 
 const getEventCode = (event: KeyboardEvent): string => {
-  const code = event.code || event.key
-  return code
-}
+  const code = event.code || event.key;
+  return code;
+};
 
 const isAndroid = (): boolean => {
-  if (typeof navigator === 'undefined') return false
-  return /android/i.test(navigator.userAgent)
-}
+  if (typeof navigator === 'undefined') return false;
+  return /android/i.test(navigator.userAgent);
+};
 
 interface UseInputTagOptions {
-  props: InputTagProps
-  emit: (event: string, ...args: unknown[]) => void
-  formItem?: FormItemContext
+  props: InputTagProps;
+  emit: (event: string, ...args: unknown[]) => void;
+  formItem?: FormItemContext;
 }
 
-export function useInputTag({
-  props,
-  emit,
-  formItem,
-}: UseInputTagOptions) {
-  const disabled = useFormDisabled()
+export function useInputTag({ props, emit, formItem }: UseInputTagOptions) {
+  const disabled = useFormDisabled();
   // GForm does not export `useFormSize`; fall back to local prop with a safe default.
-  const size = computed(() => props.size ?? 'default')
+  const size = computed(() => props.size ?? 'default');
 
-  const inputRef: ShallowRef<HTMLInputElement | undefined> = shallowRef()
-  const inputValue = ref<string>('')
-  const tagTooltipRef = ref<TooltipInstance>()
+  const inputRef: ShallowRef<HTMLInputElement | undefined> = shallowRef();
+  const inputValue = ref<string>('');
+  const tagTooltipRef = ref<TooltipInstance>();
 
   const tagSize = computed<'xs' | 'sm' | 'md'>(() => {
-    if (size.value === 'small') return 'xs'
-    if (size.value === 'large') return 'md'
-    return 'sm'
-  })
+    if (size.value === 'small') return 'xs';
+    if (size.value === 'large') return 'md';
+    return 'sm';
+  });
   const placeholder = computed(() => {
-    return props.modelValue?.length ? undefined : props.placeholder
-  })
-  const closable = computed(() => !(props.readonly || disabled.value))
+    return props.modelValue?.length ? undefined : props.placeholder;
+  });
+  const closable = computed(() => !(props.readonly || disabled.value));
   const inputLimit = computed(() => {
-    if (props.max === undefined || props.max === null) return false
-    const maxValue = props.max as number
-    return (props.modelValue?.length ?? 0) >= maxValue
-  })
+    if (props.max === undefined || props.max === null) return false;
+    const maxValue = props.max as number;
+    return (props.modelValue?.length ?? 0) >= maxValue;
+  });
   const showTagList = computed(() => {
     if (props.collapseTags) {
-      return props.modelValue?.slice(0, props.maxCollapseTags)
+      return props.modelValue?.slice(0, props.maxCollapseTags);
     }
-    return props.modelValue
-  })
+    return props.modelValue;
+  });
   const collapseTagList = computed(() => {
     if (props.collapseTags) {
-      return props.modelValue?.slice(props.maxCollapseTags)
+      return props.modelValue?.slice(props.maxCollapseTags);
     }
-    return []
-  })
+    return [];
+  });
 
   const addTagsEmit = (value: string | string[]) => {
-    if (props.readonly || disabled.value) return
-    const current = props.modelValue ?? []
-    const incoming = ensureArray(value)
-    const filtered: string[] = []
+    if (props.readonly || disabled.value) return;
+    const current = props.modelValue ?? [];
+    const incoming = ensureArray(value);
+    const filtered: string[] = [];
     for (const item of incoming) {
       if (!current.includes(item) && !filtered.includes(item)) {
-        filtered.push(item)
+        filtered.push(item);
       }
     }
     if (props.max !== undefined && props.max !== null) {
-      const maxInsert = Math.max((props.max as number) - current.length, 0)
-      filtered.splice(maxInsert)
+      const maxInsert = Math.max((props.max as number) - current.length, 0);
+      filtered.splice(maxInsert);
     }
     if (!filtered.length) {
-      inputValue.value = ''
-      return
+      inputValue.value = '';
+      return;
     }
-    const list = [...current, ...filtered]
-    const emitted = filtered.length === 1 ? filtered[0] : filtered
+    const list = [...current, ...filtered];
+    const emitted = filtered.length === 1 ? filtered[0] : filtered;
 
-    emit(UPDATE_MODEL_EVENT, list)
-    emit(CHANGE_EVENT, list)
-    emit('add-tag', emitted)
-    inputValue.value = ''
-  }
+    emit(UPDATE_MODEL_EVENT, list);
+    emit(CHANGE_EVENT, list);
+    emit('add-tag', emitted);
+    inputValue.value = '';
+  };
 
   const getDelimitedTags = (input: string) => {
-    const parts = input.split(props.delimiter as string)
+    const parts = input.split(props.delimiter as string);
     const tags =
-      parts.length > 1
-        ? parts.map((val) => val.trim()).filter(Boolean)
-        : []
-    return tags.length === 1 ? tags[0] : (tags as string | string[])
-  }
+      parts.length > 1 ? parts.map(val => val.trim()).filter(Boolean) : [];
+    return tags.length === 1 ? tags[0] : (tags as string | string[]);
+  };
 
   const handlePaste = (event: ClipboardEvent) => {
-    const pasted = event.clipboardData?.getData('text')
+    const pasted = event.clipboardData?.getData('text');
     if (
       props.readonly ||
       disabled.value ||
@@ -118,183 +112,185 @@ export function useInputTag({
       !props.delimiter ||
       !pasted
     ) {
-      return
+      return;
     }
-    const target = event.target as HTMLInputElement
-    const { selectionStart, selectionEnd, value } = target
-    const start = selectionStart ?? 0
-    const end = selectionEnd ?? 0
-    const nextValue = value.slice(0, start) + pasted + value.slice(end)
-    const tags = getDelimitedTags(nextValue) as string | string[]
+    const target = event.target as HTMLInputElement;
+    const { selectionStart, selectionEnd, value } = target;
+    const start = selectionStart ?? 0;
+    const end = selectionEnd ?? 0;
+    const nextValue = value.slice(0, start) + pasted + value.slice(end);
+    const tags = getDelimitedTags(nextValue) as string | string[];
     if (Array.isArray(tags) ? tags.length : Boolean(tags)) {
-      addTagsEmit(tags)
-      emit(INPUT_EVENT, inputValue.value)
-      event.preventDefault()
+      addTagsEmit(tags);
+      emit(INPUT_EVENT, inputValue.value);
+      event.preventDefault();
     }
-  }
+  };
 
-  const handleInput = (event: Event) => {
+  const handleInput = () => {
     if (inputLimit.value) {
-      inputValue.value = ''
-      emit(INPUT_EVENT, '')
-      return
+      inputValue.value = '';
+      emit(INPUT_EVENT, '');
+      return;
     }
 
-    if (isComposing.value) return
+    if (isComposing.value) return;
     if (props.delimiter && inputValue.value) {
-      const tags = getDelimitedTags(inputValue.value)
-      const list = Array.isArray(tags) ? tags : tags ? [tags] : []
+      const tags = getDelimitedTags(inputValue.value);
+      const list = Array.isArray(tags) ? tags : tags ? [tags] : [];
       if (list.length) {
-        addTagsEmit(list)
+        addTagsEmit(list);
       }
     }
-    emit(INPUT_EVENT, inputValue.value)
-  }
+    emit(INPUT_EVENT, inputValue.value);
+  };
 
   const handleKeydown = (event: KeyboardEvent) => {
-    if (isComposing.value) return
-    const code = getEventCode(event)
+    if (isComposing.value) return;
+    const code = getEventCode(event);
 
     switch (code) {
       case props.trigger:
-        event.preventDefault()
-        event.stopPropagation()
-        handleAddTag()
-        break
+        event.preventDefault();
+        event.stopPropagation();
+        handleAddTag();
+        break;
       case EVENT_CODE.numpadEnter:
         if (props.trigger === EVENT_CODE.enter) {
-          event.preventDefault()
-          event.stopPropagation()
-          handleAddTag()
+          event.preventDefault();
+          event.stopPropagation();
+          handleAddTag();
         }
-        break
+        break;
       case EVENT_CODE.backspace:
-        if (props.readonly || disabled.value) return
+        if (props.readonly || disabled.value) return;
         if (!inputValue.value && props.modelValue?.length) {
-          event.preventDefault()
-          event.stopPropagation()
-          handleRemoveTag(props.modelValue.length - 1)
+          event.preventDefault();
+          event.stopPropagation();
+          handleRemoveTag(props.modelValue.length - 1);
         }
-        break
+        break;
     }
-  }
+  };
 
   const handleKeyup = (event: KeyboardEvent) => {
-    if (isComposing.value || !isAndroid()) return
-    const code = getEventCode(event)
+    if (isComposing.value || !isAndroid()) return;
+    const code = getEventCode(event);
 
     switch (code) {
       case EVENT_CODE.space:
         if (props.trigger === EVENT_CODE.space) {
-          event.preventDefault()
-          event.stopPropagation()
-          handleAddTag()
+          event.preventDefault();
+          event.stopPropagation();
+          handleAddTag();
         }
-        break
+        break;
     }
-  }
+  };
 
   const handleAddTag = () => {
-    if (props.readonly || disabled.value) return
-    const value = inputValue.value?.trim()
-    if (!value || inputLimit.value) return
-    addTagsEmit(value)
-  }
+    if (props.readonly || disabled.value) return;
+    const value = inputValue.value?.trim();
+    if (!value || inputLimit.value) return;
+    addTagsEmit(value);
+  };
 
   const handleRemoveTag = (index: number) => {
-    if (props.readonly || disabled.value) return
-    const value = (props.modelValue ?? []).slice()
-    const [item] = value.splice(index, 1)
+    if (props.readonly || disabled.value) return;
+    const value = (props.modelValue ?? []).slice();
+    const [item] = value.splice(index, 1);
 
-    emit(UPDATE_MODEL_EVENT, value)
-    emit(CHANGE_EVENT, value)
-    emit('remove-tag', item, index)
-  }
+    emit(UPDATE_MODEL_EVENT, value);
+    emit(CHANGE_EVENT, value);
+    emit('remove-tag', item, index);
+  };
 
   const handleClear = () => {
-    if (props.readonly || disabled.value) return
-    const value: string[] = []
-    inputValue.value = ''
-    emit(UPDATE_MODEL_EVENT, value)
-    emit(CHANGE_EVENT, value)
-    emit(INPUT_EVENT, '')
-    emit('clear')
-  }
+    if (props.readonly || disabled.value) return;
+    const value: string[] = [];
+    inputValue.value = '';
+    emit(UPDATE_MODEL_EVENT, value);
+    emit(CHANGE_EVENT, value);
+    emit(INPUT_EVENT, '');
+    emit('clear');
+  };
 
   const handleDragged = (
     draggingIndex: number,
     dropIndex: number,
-    type: 'before' | 'after'
+    type: 'before' | 'after',
   ) => {
-    if (props.readonly || disabled.value) return
-    const value = (props.modelValue ?? []).slice()
-    const [draggedItem] = value.splice(draggingIndex, 1)
+    if (props.readonly || disabled.value) return;
+    const value = (props.modelValue ?? []).slice();
+    const [draggedItem] = value.splice(draggingIndex, 1);
     const step =
       dropIndex > draggingIndex && type === 'before'
         ? -1
         : dropIndex < draggingIndex && type === 'after'
           ? 1
-          : 0
+          : 0;
 
-    value.splice(dropIndex + step, 0, draggedItem)
-    emit(UPDATE_MODEL_EVENT, value)
-    emit(CHANGE_EVENT, value)
-    emit('drag-tag', draggingIndex, dropIndex + step, draggedItem)
-  }
+    value.splice(dropIndex + step, 0, draggedItem);
+    emit(UPDATE_MODEL_EVENT, value);
+    emit(CHANGE_EVENT, value);
+    emit('drag-tag', draggingIndex, dropIndex + step, draggedItem);
+  };
 
   const focus = () => {
-    inputRef.value?.focus()
-  }
+    inputRef.value?.focus();
+  };
 
   const blur = () => {
-    inputRef.value?.blur()
-  }
+    inputRef.value?.blur();
+  };
 
   const handleFocus = (event: FocusEvent) => {
-    emit('focus', event)
-  }
+    emit('focus', event);
+  };
 
   const handleBlur = (event: FocusEvent) => {
-    emit('blur', event)
-  }
+    emit('blur', event);
+  };
 
   const { wrapperRef, isFocused } = useFocusController(inputRef, {
     beforeBlur(event) {
       // Tooltip may capture focus when expanded; preserve focus inside it.
-      const tooltip = tagTooltipRef.value as unknown as {
-        isFocusInsideContent?: (e: FocusEvent) => boolean
-      } | undefined
-      const guard = tooltip?.isFocusInsideContent
-      return typeof guard === 'function' ? Boolean(guard(event)) : false
+      const tooltip = tagTooltipRef.value as unknown as
+        | {
+            isFocusInsideContent?: (e: FocusEvent) => boolean;
+          }
+        | undefined;
+      const guard = tooltip?.isFocusInsideContent;
+      return typeof guard === 'function' ? Boolean(guard(event)) : false;
     },
     afterBlur() {
       if (props.saveOnBlur) {
-        handleAddTag()
+        handleAddTag();
       } else {
-        inputValue.value = ''
+        inputValue.value = '';
       }
 
       if (props.validateEvent) {
-        formItem?.validate?.('blur').catch(NOOP)
+        formItem?.validate?.('blur').catch(NOOP);
       }
     },
-  })
+  });
 
   const {
     isComposing,
     handleCompositionStart,
     handleCompositionUpdate,
     handleCompositionEnd,
-  } = useComposition({ afterComposition: handleInput })
+  } = useComposition({ afterComposition: handleInput });
 
   watch(
     () => props.modelValue,
     () => {
       if (props.validateEvent) {
-        formItem?.validate?.(CHANGE_EVENT).catch(NOOP)
+        formItem?.validate?.(CHANGE_EVENT).catch(NOOP);
       }
-    }
-  )
+    },
+  );
 
   return {
     inputRef,
@@ -326,5 +322,5 @@ export function useInputTag({
     handleBlur,
     focus,
     blur,
-  }
+  };
 }

--- a/components/input-tag/src/input-tag.ts
+++ b/components/input-tag/src/input-tag.ts
@@ -5,18 +5,16 @@ import {
   isNumber,
   isString,
   isUndefined,
-} from 'element-plus/es/utils/index.mjs'
-import { tagProps } from '@flash-global66/g-tag'
-import {
   CHANGE_EVENT,
   EVENT_CODE,
   INPUT_EVENT,
   UPDATE_MODEL_EVENT,
-} from 'element-plus/es/constants/index.mjs'
-import { IconString } from '@flash-global66/g-icon-font'
+} from '@flash-global66/g-utils';
+import { tagProps } from '@flash-global66/g-tag';
+import { IconString } from '@flash-global66/g-icon-font';
 
-import type { ExtractPropTypes } from 'vue'
-import type { PopperEffect } from 'element-plus/es/components/popper'
+import type { ExtractPropTypes } from 'vue';
+import type { PopperEffect } from '@flash-global66/g-popper';
 
 export const inputTagProps = buildProps({
   /**
@@ -174,7 +172,7 @@ export const inputTagProps = buildProps({
    * @description native `aria-label` attribute
    */
   ariaLabel: String,
-} as const)
+} as const);
 
 export const inputTagEmits = {
   [UPDATE_MODEL_EVENT]: (value?: string[] | string) =>
@@ -190,7 +188,7 @@ export const inputTagEmits = {
   focus: (evt: FocusEvent) => evt instanceof FocusEvent,
   blur: (evt: FocusEvent) => evt instanceof FocusEvent,
   clear: () => true,
-}
+};
 
-export type InputTagProps = ExtractPropTypes<typeof inputTagProps>
-export type InputTagEmits = typeof inputTagEmits
+export type InputTagProps = ExtractPropTypes<typeof inputTagProps>;
+export type InputTagEmits = typeof inputTagEmits;

--- a/components/input-tag/src/input-tag.vue
+++ b/components/input-tag/src/input-tag.vue
@@ -2,7 +2,10 @@
   <div :class="ns.e('container')">
     <div
       ref="wrapperRef"
-      :class="[containerKls, ns.is('error', isError || formItem?.shouldShowError)]"
+      :class="[
+        containerKls,
+        ns.is('error', isError || formItem?.shouldShowError),
+      ]"
       :style="containerStyle"
       @mouseenter="handleMouseEnter"
       @mouseleave="handleMouseLeave"
@@ -14,7 +17,10 @@
         <div
           v-for="(item, index) in showTagList"
           :key="`${index}-${item}`"
-          :class="[ns.e('tag-wrapper'), closable && draggable ? ns.is('draggable', true) : '']"
+          :class="[
+            ns.e('tag-wrapper'),
+            closable && draggable ? ns.is('draggable', true) : '',
+          ]"
           :draggable="closable && draggable ? true : undefined"
           @dragstart="(event: DragEvent) => handleDragStart(event, index)"
           @dragover="(event: DragEvent) => handleDragOver(event, index)"
@@ -36,7 +42,9 @@
           </g-tag>
         </div>
         <g-tooltip
-          v-if="collapseTags && modelValue && modelValue.length > maxCollapseTags"
+          v-if="
+            collapseTags && modelValue && modelValue.length > maxCollapseTags
+          "
           ref="tagTooltipRef"
           :disabled="!collapseTagsTooltip"
           :fallback-placements="['bottom', 'top', 'right', 'left']"
@@ -138,36 +146,36 @@
 </template>
 
 <script lang="ts" setup>
-import { computed } from 'vue'
-import { useCalcInputWidth } from 'element-plus'
-import { GTag } from '@flash-global66/g-tag'
-import { GTooltip } from '@flash-global66/g-tooltip'
-import { GIconFont } from '@flash-global66/g-icon-font'
-import { useFormItem, useFormItemInputId } from '@flash-global66/g-form'
+import { computed } from 'vue';
+import { useCalcInputWidth } from '@flash-global66/g-hooks';
+import { GTag } from '@flash-global66/g-tag';
+import { GTooltip } from '@flash-global66/g-tooltip';
+import { GIconFont } from '@flash-global66/g-icon-font';
+import { useFormItem, useFormItemInputId } from '@flash-global66/g-form';
 
-import { inputTagEmits, inputTagProps } from './input-tag'
+import { inputTagEmits, inputTagProps } from './input-tag';
 import {
   useDragTag,
   useHovering,
   useInputTag,
   useInputTagDom,
-} from './composables'
+} from './composables';
 
 defineOptions({
   name: 'GInputTag',
   inheritAttrs: false,
-})
+});
 
-const props = defineProps(inputTagProps)
-const emit = defineEmits(inputTagEmits)
+const props = defineProps(inputTagProps);
+const emit = defineEmits(inputTagEmits);
 
 // `useInputTag` expects a generic emit signature; widen the typed defineEmits fn.
-const emitFn = emit as unknown as (event: string, ...args: unknown[]) => void
+const emitFn = emit as unknown as (event: string, ...args: unknown[]) => void;
 
-const { formItem } = useFormItem()
+const { formItem } = useFormItem();
 const { inputId } = useFormItemInputId(props, {
   formItemContext: formItem,
-})
+});
 
 const {
   inputRef,
@@ -196,10 +204,10 @@ const {
   handleBlur,
   focus,
   blur,
-} = useInputTag({ props, emit: emitFn, formItem })
+} = useInputTag({ props, emit: emitFn, formItem });
 
-const { hovering, handleMouseEnter, handleMouseLeave } = useHovering()
-const { calculatorRef, inputStyle } = useCalcInputWidth()
+const { hovering, handleMouseEnter, handleMouseLeave } = useHovering();
+const { calculatorRef, inputStyle } = useCalcInputWidth();
 
 const {
   dropIndicatorRef,
@@ -207,7 +215,7 @@ const {
   handleDragStart,
   handleDragOver,
   handleDragEnd,
-} = useDragTag({ wrapperRef, handleDragged, afterDragged: focus })
+} = useDragTag({ wrapperRef, handleDragged, afterDragged: focus });
 
 const {
   ns,
@@ -227,30 +235,31 @@ const {
   disabled,
   inputValue,
   size,
-})
+});
 
 const isError = computed(() => {
   return Boolean(
     formItem?.shouldShowErrorChild ||
-      (formItem?.showMessage === 'child' && formItem?.validateState === 'error')
-  )
-})
+      (formItem?.showMessage === 'child' &&
+        formItem?.validateState === 'error'),
+  );
+});
 
-const error = computed(() => formItem?.validateMessage)
+const error = computed(() => formItem?.validateMessage);
 
 const helpTextKls = computed(() => [
   ns.e('help-text'),
   {
     [ns.e('help-error')]: isError.value,
   },
-])
+]);
 
 const hasHelpInfo = computed(() => {
-  return error.value || props.helpText || formItem?.$el
-})
+  return error.value || props.helpText || formItem?.$el;
+});
 
 defineExpose({
   focus,
   blur,
-})
+});
 </script>

--- a/openspec/changes/ep-extraction-v4/tasks.md
+++ b/openspec/changes/ep-extraction-v4/tasks.md
@@ -264,14 +264,14 @@ Publishes: `time-picker`. Est. ~220 changed lines. Requirements: `popper-overlay
 
 Publishes: `input-tag`. Est. ~100 changed lines. Requirements: `popper-overlay-migration` → `zero-ep-imports-per-migrated-package`, `public-api-and-styles-preserved`, `reused-composables-repointed`, `packaging-convention-followed`, `migration-gated-by-green-tests`.
 
-- [ ] T12.1 Confirm PR #8 (select) is merged before starting — this WU re-points `useCalcInputWidth` from `select`'s new export.
-- [ ] T12.2 Re-point `components/input-tag/src/**` imports: `useCalcInputWidth` → `@flash-global66/g-hooks` (built in WU-8); `useComposition`/`useFocusController` → `@flash-global66/g-hooks` (already exist per v3); `useNamespace`/`NOOP`/`isUndefined` → `@flash-global66/g-utils`. No new hooks built. Zero public API change.
-- [ ] T12.3 Grep-verify zero `from ['"]element-plus` matches under `components/input-tag/src/**` and `index.ts`.
-- [ ] T12.4 Confirm `input-tag`'s `package.json` packaging convention.
-- [ ] T12.5 Remove `'components/input-tag/**'` from `excludedFiles` in `.eslintrc.cjs`. `yarn lint --max-warnings 0` passes.
-- [ ] T12.6 `yarn build` succeeds for `input-tag`. Full `yarn test:run` green.
-- [ ] T12.7 Validate in `front-b2b` (real copy).
-- [ ] T12.8 Commit as one work unit (`refactor(input-tag): re-point imports off element-plus internals`), open PR #12 (depends on PR #8 merged), Lerna-publish on merge.
+- [x] T12.1 Confirmed WU-8 (select) merged + published before starting; branch off current `main`.
+- [x] T12.2 Re-pointed `components/input-tag/src/**` + index.ts (6 files): `useComposition`/`useFocusController`/`useCalcInputWidth` → g-hooks; `buildProps`/`definePropType`/`isArray`/`isNumber`/`isString`/`isUndefined`/`NOOP`/`withInstall`/`SFCWithInstall`/`useNamespace`/`CHANGE_EVENT`/`EVENT_CODE`/`INPUT_EVENT`/`UPDATE_MODEL_EVENT` → g-utils; `PopperEffect` (type) → `@flash-global66/g-popper`. No new hooks. Zero public API change. **Brief gap**: `INPUT_EVENT` was missing from g-utils → ported byte-exact into `event.constant.ts` (beside UPDATE_MODEL_EVENT/CHANGE_EVENT). `PopperEffect`/g-popper dep also not in the brief.
+- [x] T12.3 Grep-verified zero `from 'element-plus'` under `components/input-tag/src/**` + `index.ts` (scss `@use theme-chalk` retained).
+- [x] T12.4 Adopted the tooltip packaging convention: all 7 imported `@flash-global66/*` (g-form/g-hooks/g-icon-font/g-popper/g-tag/g-tooltip/g-utils) in `dependencies` with aligned ranges; only `@vueuse/core`/`element-plus`/`lodash-unified`/`vue` peer (previously NO `dependencies` block, stale peer ranges).
+- [x] T12.5 Removed `'components/input-tag/**'` from `.eslintrc.cjs`; fixed 2 lint errors (unused `InputTagEmits` type import; unused `event` param in `handleInput` — verified callback-only, safe). `eslint --max-warnings 0` clean.
+- [x] T12.6 `vue-tsc` on input-tag: 0 errors (clean, no regression). Full `test:run` → 341/341 green.
+- [ ] T12.7 **DEFERRED**: b2b real-copy validation batched with the family after publish.
+- [x] T12.8 Committed as the WU; PR opened; Lerna-publish on merge. Dual blind review: **both judges APPROVE** (zero CRITICAL/MAJOR/MINOR).
 
 ## WU-13 — `inline` (pure re-point, smallest; no dependencies, fully independent of the popper chain)
 


### PR DESCRIPTION
## What

WU-12 of **ep-extraction-v4** — migrates `g-input-tag` off element-plus internals (6 files) + ports one missing constant.

### Ported into `g-utils`
- **`INPUT_EVENT`** (`'input'`) — byte-exact from EP `es/constants/event.mjs`, placed beside `UPDATE_MODEL_EVENT`/`CHANGE_EVENT`. It was missing from g-utils (brief gap); without it the EP constants import couldn't be fully dropped.

### Component migration
- Re-pointed 6 files: `useComposition`/`useFocusController`/`useCalcInputWidth` → `g-hooks`; `buildProps`/`definePropType`/`isArray`/`isNumber`/`isString`/`isUndefined`/`NOOP`/`withInstall`/`SFCWithInstall`/`useNamespace`/`CHANGE_EVENT`/`EVENT_CODE`/`INPUT_EVENT`/`UPDATE_MODEL_EVENT` → `g-utils`; **`PopperEffect` (type) → `@flash-global66/g-popper`**. Zero `element-plus` runtime imports remain (scss `@use theme-chalk` retained).

### Packaging
- Adopted the **tooltip convention**: all 7 imported `@flash-global66/*` (g-form/g-hooks/g-icon-font/**g-popper**/g-tag/g-tooltip/g-utils) in `dependencies` with ranges aligned to current workspace versions; only `@vueuse/core`/`element-plus`/`lodash-unified`/`vue` peer. The package previously had **no** `dependencies` block and stale peer ranges. `g-popper` is a new fan-out edge (for `PopperEffect`), not in the original estimate.

### Lint (in-place debt fix)
- Removed `components/input-tag/**` from the eslint exclusion; fixed 2 errors — unused `InputTagEmits` type import, and the unused `event` param in `handleInput` (verified callback-only: `@input` / `afterComposition`, never called directly with an arg).

## Validation
- `vue-tsc` on input-tag: **0 errors** (PopperEffect + INPUT_EVENT resolve; no regression).
- `eslint --max-warnings 0`: clean.
- Full `test:run`: **341/341** green.
- Browser gate: deferred to the batched family validation post-publish.

## Review
Dual blind review — **both judges APPROVE**, zero CRITICAL/MAJOR/MINOR. Confirmed: `INPUT_EVENT` byte-exact, all symbols resolve from the correct DS packages, `PopperEffect` correctly from g-popper, dependency versions pinned to workspace, the 2 lint fixes behavior-safe, zero API/behavior change.

Comments/JSDoc in Spanish per project convention.