### PR TITLE
feat(pagination): migrate off element-plus internals to g-utils

### DIFF
--- a/components/pagination/index.ts
+++ b/components/pagination/index.ts
@@ -1,11 +1,11 @@
-import { withInstall, SFCWithInstall } from 'element-plus/es/utils/index.mjs'
+import { withInstall, SFCWithInstall } from '@flash-global66/g-utils';
 
-import Pagination from './src/pagination'
+import Pagination from './src/pagination';
 
 export const GPagination: SFCWithInstall<typeof Pagination> =
-  withInstall(Pagination)
-export default GPagination
+  withInstall(Pagination);
+export default GPagination;
 
-export * from './src/pagination'
-export * from './src/constants'
-export * from './src/composable/usePagination'
+export * from './src/pagination';
+export * from './src/constants';
+export * from './src/composable/usePagination';

--- a/components/pagination/package.json
+++ b/components/pagination/package.json
@@ -28,8 +28,11 @@
   "repository": {
     "url": "https://github.com/Flash-Global66/global-design-system.git"
   },
+  "dependencies": {
+    "@flash-global66/g-icon-font": "^0.25.15",
+    "@flash-global66/g-utils": "^0.12.0"
+  },
   "peerDependencies": {
-    "@flash-global66/g-icon-button": "^0.1.1",
     "element-plus": "^2.9.0",
     "vue": "^3.2.0"
   },

--- a/components/pagination/src/components/next.ts
+++ b/components/pagination/src/components/next.ts
@@ -1,7 +1,6 @@
-import { buildProps, iconPropType } from 'element-plus/es/utils/index.mjs'
-import type { ExtractPropTypes, PropType } from 'vue'
-import type Next from './next.vue'
-import { IconString } from '@flash-global66/g-icon-font';
+import { buildProps } from '@flash-global66/g-utils';
+import type { ExtractPropTypes } from 'vue';
+import type Next from './next.vue';
 
 export const paginationNextProps = buildProps({
   disabled: Boolean,
@@ -12,9 +11,9 @@ export const paginationNextProps = buildProps({
   pageCount: {
     type: Number,
     default: 50,
-  }
-} as const)
+  },
+} as const);
 
-export type PaginationNextProps = ExtractPropTypes<typeof paginationNextProps>
+export type PaginationNextProps = ExtractPropTypes<typeof paginationNextProps>;
 
-export type NextInstance = InstanceType<typeof Next> & unknown
+export type NextInstance = InstanceType<typeof Next> & unknown;

--- a/components/pagination/src/components/next.vue
+++ b/components/pagination/src/components/next.vue
@@ -12,25 +12,25 @@
 </template>
 
 <script lang="ts" setup>
-import { computed } from 'vue'
-import { GIconFont } from '@flash-global66/g-icon-font'
-import { paginationNextProps } from './next'
-import { useNamespace } from 'element-plus'
+import { computed } from 'vue';
+import { GIconFont } from '@flash-global66/g-icon-font';
+import { paginationNextProps } from './next';
+import { useNamespace } from '@flash-global66/g-utils';
 
 defineOptions({
   name: 'GPaginationNext',
-})
+});
 
-const props = defineProps(paginationNextProps)
+const props = defineProps(paginationNextProps);
 
-const ns = useNamespace('pagination')
+const ns = useNamespace('pagination');
 
-defineEmits(['click'])
+defineEmits(['click']);
 
 const internalDisabled = computed(
   () =>
     props.disabled ||
     props.currentPage === props.pageCount ||
-    props.pageCount === 0
-)
+    props.pageCount === 0,
+);
 </script>

--- a/components/pagination/src/components/pager.ts
+++ b/components/pagination/src/components/pager.ts
@@ -1,6 +1,6 @@
-import { buildProps } from 'element-plus/es/utils/index.mjs'
-import type { ExtractPropTypes } from 'vue'
-import type Pager from './pager.vue'
+import { buildProps } from '@flash-global66/g-utils';
+import type { ExtractPropTypes } from 'vue';
+import type Pager from './pager.vue';
 
 export const paginationPagerProps = buildProps({
   currentPage: {
@@ -16,8 +16,10 @@ export const paginationPagerProps = buildProps({
     default: 7,
   },
   disabled: Boolean,
-} as const)
+} as const);
 
-export type PaginationPagerProps = ExtractPropTypes<typeof paginationPagerProps>
+export type PaginationPagerProps = ExtractPropTypes<
+  typeof paginationPagerProps
+>;
 
-export type PagerInstance = InstanceType<typeof Pager> & unknown
+export type PagerInstance = InstanceType<typeof Pager> & unknown;

--- a/components/pagination/src/components/pager.vue
+++ b/components/pagination/src/components/pager.vue
@@ -23,7 +23,10 @@
       @focus="onFocus(true)"
       @blur="quickPrevFocus = false"
     >
-      <g-icon-font name="regular angles-left" v-if="(quickPrevHover || quickPrevFocus) && !disabled" />
+      <g-icon-font
+        name="regular angles-left"
+        v-if="(quickPrevHover || quickPrevFocus) && !disabled"
+      />
       <g-icon-font name="regular ellipsis" v-else />
     </li>
     <li
@@ -50,7 +53,10 @@
       @focus="onFocus()"
       @blur="quickNextFocus = false"
     >
-      <g-icon-font v-if="(quickNextHover || quickNextFocus) && !disabled" name="regular angles-right" />
+      <g-icon-font
+        v-if="(quickNextHover || quickNextFocus) && !disabled"
+        name="regular angles-right"
+      />
       <g-icon-font v-else name="regular ellipsis" />
     </li>
     <li
@@ -70,148 +76,148 @@
 </template>
 
 <script lang="ts" setup>
-import { computed, ref, watchEffect } from 'vue'
-import { GIconFont } from '@flash-global66/g-icon-font'
-import { useNamespace, CHANGE_EVENT } from 'element-plus'
-import { paginationPagerProps } from './pager'
+import { computed, ref, watchEffect } from 'vue';
+import { GIconFont } from '@flash-global66/g-icon-font';
+import { useNamespace, CHANGE_EVENT } from '@flash-global66/g-utils';
+import { paginationPagerProps } from './pager';
 
 defineOptions({
   name: 'GPaginationPager',
-})
-const props = defineProps(paginationPagerProps)
-const emit = defineEmits([CHANGE_EVENT])
-const nsPager = useNamespace('pager')
-const nsIcon = useNamespace('icon')
+});
+const props = defineProps(paginationPagerProps);
+const emit = defineEmits([CHANGE_EVENT]);
+const nsPager = useNamespace('pager');
+const nsIcon = useNamespace('icon');
 
-const showPrevMore = ref(false)
-const showNextMore = ref(false)
-const quickPrevHover = ref(false)
-const quickNextHover = ref(false)
-const quickPrevFocus = ref(false)
-const quickNextFocus = ref(false)
+const showPrevMore = ref(false);
+const showNextMore = ref(false);
+const quickPrevHover = ref(false);
+const quickNextHover = ref(false);
+const quickPrevFocus = ref(false);
+const quickNextFocus = ref(false);
 const pagers = computed(() => {
-  const pagerCount = props.pagerCount
-  const halfPagerCount = (pagerCount - 1) / 2
-  const currentPage = Number(props.currentPage)
-  const pageCount = Number(props.pageCount)
-  let showPrevMore = false
-  let showNextMore = false
+  const pagerCount = props.pagerCount;
+  const halfPagerCount = (pagerCount - 1) / 2;
+  const currentPage = Number(props.currentPage);
+  const pageCount = Number(props.pageCount);
+  let showPrevMore = false;
+  let showNextMore = false;
   if (pageCount > pagerCount) {
     if (currentPage > pagerCount - halfPagerCount) {
-      showPrevMore = true
+      showPrevMore = true;
     }
     if (currentPage < pageCount - halfPagerCount) {
-      showNextMore = true
+      showNextMore = true;
     }
   }
-  const array: number[] = []
+  const array: number[] = [];
   if (showPrevMore && !showNextMore) {
-    const startPage = pageCount - (pagerCount - 2)
+    const startPage = pageCount - (pagerCount - 2);
     for (let i = startPage; i < pageCount; i++) {
-      array.push(i)
+      array.push(i);
     }
   } else if (!showPrevMore && showNextMore) {
     for (let i = 2; i < pagerCount; i++) {
-      array.push(i)
+      array.push(i);
     }
   } else if (showPrevMore && showNextMore) {
-    const offset = Math.floor(pagerCount / 2) - 1
+    const offset = Math.floor(pagerCount / 2) - 1;
     for (let i = currentPage - offset; i <= currentPage + offset; i++) {
-      array.push(i)
+      array.push(i);
     }
   } else {
     for (let i = 2; i < pageCount; i++) {
-      array.push(i)
+      array.push(i);
     }
   }
-  return array
-})
+  return array;
+});
 
 const prevMoreKls = computed(() => [
   'more',
   'btn-quickprev',
   nsIcon.b(),
   nsPager.is('disabled', props.disabled),
-])
+]);
 const nextMoreKls = computed(() => [
   'more',
   'btn-quicknext',
   nsIcon.b(),
   nsPager.is('disabled', props.disabled),
-])
+]);
 
-const tabindex = computed(() => (props.disabled ? -1 : 0))
+const tabindex = computed(() => (props.disabled ? -1 : 0));
 watchEffect(() => {
-  const halfPagerCount = (props.pagerCount - 1) / 2
-  showPrevMore.value = false
-  showNextMore.value = false
+  const halfPagerCount = (props.pagerCount - 1) / 2;
+  showPrevMore.value = false;
+  showNextMore.value = false;
   if (props.pageCount! > props.pagerCount) {
     if (props.currentPage > props.pagerCount - halfPagerCount) {
-      showPrevMore.value = true
+      showPrevMore.value = true;
     }
     if (props.currentPage < props.pageCount! - halfPagerCount) {
-      showNextMore.value = true
+      showNextMore.value = true;
     }
   }
-})
+});
 function onMouseEnter(forward = false) {
-  if (props.disabled) return
+  if (props.disabled) return;
   if (forward) {
-    quickPrevHover.value = true
+    quickPrevHover.value = true;
   } else {
-    quickNextHover.value = true
+    quickNextHover.value = true;
   }
 }
 function onFocus(forward = false) {
   if (forward) {
-    quickPrevFocus.value = true
+    quickPrevFocus.value = true;
   } else {
-    quickNextFocus.value = true
+    quickNextFocus.value = true;
   }
 }
 function onEnter(e: UIEvent) {
-  const target = e.target as HTMLElement
+  const target = e.target as HTMLElement;
   if (
     target.tagName.toLowerCase() === 'li' &&
     Array.from(target.classList).includes('number')
   ) {
-    const newPage = Number(target.textContent)
+    const newPage = Number(target.textContent);
     if (newPage !== props.currentPage) {
-      emit(CHANGE_EVENT, newPage)
+      emit(CHANGE_EVENT, newPage);
     }
   } else if (
     target.tagName.toLowerCase() === 'li' &&
     Array.from(target.classList).includes('more')
   ) {
-    onPagerClick(e)
+    onPagerClick(e);
   }
 }
 function onPagerClick(event: UIEvent) {
-  const target = event.target as HTMLElement
+  const target = event.target as HTMLElement;
   if (target.tagName.toLowerCase() === 'ul' || props.disabled) {
-    return
+    return;
   }
-  let newPage = Number(target.textContent)
-  const pageCount = props.pageCount!
-  const currentPage = props.currentPage
-  const pagerCountOffset = props.pagerCount - 2
+  let newPage = Number(target.textContent);
+  const pageCount = props.pageCount!;
+  const currentPage = props.currentPage;
+  const pagerCountOffset = props.pagerCount - 2;
   if (target.className.includes('more')) {
     if (target.className.includes('quickprev')) {
-      newPage = currentPage - pagerCountOffset
+      newPage = currentPage - pagerCountOffset;
     } else if (target.className.includes('quicknext')) {
-      newPage = currentPage + pagerCountOffset
+      newPage = currentPage + pagerCountOffset;
     }
   }
   if (!Number.isNaN(+newPage)) {
     if (newPage < 1) {
-      newPage = 1
+      newPage = 1;
     }
     if (newPage > pageCount) {
-      newPage = pageCount
+      newPage = pageCount;
     }
   }
   if (newPage !== currentPage) {
-    emit(CHANGE_EVENT, newPage)
+    emit(CHANGE_EVENT, newPage);
   }
 }
 </script>

--- a/components/pagination/src/components/prev.ts
+++ b/components/pagination/src/components/prev.ts
@@ -1,20 +1,19 @@
-import { buildProps, iconPropType } from 'element-plus/es/utils/index.mjs'
-import type { ExtractPropTypes, PropType } from 'vue'
-import type Prev from './prev.vue'
-import { IconString } from '@flash-global66/g-icon-font';
+import { buildProps } from '@flash-global66/g-utils';
+import type { ExtractPropTypes } from 'vue';
+import type Prev from './prev.vue';
 
 export const paginationPrevProps = buildProps({
   disabled: Boolean,
   currentPage: {
     type: Number,
     default: 1,
-  }
-} as const)
+  },
+} as const);
 
 export const paginationPrevEmits = {
   click: (evt: MouseEvent) => evt instanceof MouseEvent,
-}
+};
 
-export type PaginationPrevProps = ExtractPropTypes<typeof paginationPrevProps>
+export type PaginationPrevProps = ExtractPropTypes<typeof paginationPrevProps>;
 
-export type PrevInstance = InstanceType<typeof Prev> & unknown
+export type PrevInstance = InstanceType<typeof Prev> & unknown;

--- a/components/pagination/src/components/prev.vue
+++ b/components/pagination/src/components/prev.vue
@@ -12,21 +12,21 @@
 </template>
 
 <script lang="ts" setup>
-import { computed } from "vue";
-import { GIconFont } from "@flash-global66/g-icon-font";
-import { paginationPrevEmits, paginationPrevProps } from "./prev";
-import { useNamespace } from "element-plus";
+import { computed } from 'vue';
+import { GIconFont } from '@flash-global66/g-icon-font';
+import { paginationPrevEmits, paginationPrevProps } from './prev';
+import { useNamespace } from '@flash-global66/g-utils';
 
 defineOptions({
-  name: "GPaginationPrev",
+  name: 'GPaginationPrev',
 });
 
 const props = defineProps(paginationPrevProps);
 defineEmits(paginationPrevEmits);
 
-const ns = useNamespace("pagination");
+const ns = useNamespace('pagination');
 
 const internalDisabled = computed(
-  () => props.disabled || props.currentPage <= 1
+  () => props.disabled || props.currentPage <= 1,
 );
 </script>

--- a/components/pagination/src/pagination.ts
+++ b/components/pagination/src/pagination.ts
@@ -6,30 +6,26 @@ import {
   provide,
   ref,
   watch,
-} from 'vue'
+} from 'vue';
 import {
   buildProps,
   debugWarn,
   isNumber,
-} from 'element-plus/es/utils/index.mjs'
-import {
-  useGlobalSize,
   useNamespace,
-} from 'element-plus'
-import { CHANGE_EVENT } from 'element-plus/es/constants/index.mjs'
-import { elPaginationKey } from './constants'
+  CHANGE_EVENT,
+} from '@flash-global66/g-utils';
+import { elPaginationKey } from './constants';
 
-import Prev from './components/prev.vue'
-import Next from './components/next.vue'
-import Pager from './components/pager.vue'
-import type { ExtractPropTypes, PropType, VNode } from 'vue'
-import { IconString } from '@flash-global66/g-icon-font';
+import Prev from './components/prev.vue';
+import Next from './components/next.vue';
+import Pager from './components/pager.vue';
+import type { ExtractPropTypes } from 'vue';
 /**
  * It it user's responsibility to guarantee that the value of props.total... is number
  * (same as pageSize, currentPage, pageCount)
  * Otherwise we can reasonable infer that the corresponding field is absent
  */
-const isAbsent = (v: unknown): v is undefined => typeof v !== 'number'
+const isAbsent = (v: unknown): v is undefined => typeof v !== 'number';
 
 export const paginationProps = buildProps({
   align: {
@@ -61,7 +57,7 @@ export const paginationProps = buildProps({
         (value as number) > 4 &&
         (value as number) < 22 &&
         (value as number) % 2 === 1
-      )
+      );
     },
     default: 7,
   },
@@ -80,8 +76,8 @@ export const paginationProps = buildProps({
     type: Boolean,
     default: true,
   },
-} as const)
-export type PaginationProps = ExtractPropTypes<typeof paginationProps>
+} as const);
+export type PaginationProps = ExtractPropTypes<typeof paginationProps>;
 
 export const paginationEmits = {
   'update:current-page': (val: number) => isNumber(val),
@@ -90,130 +86,129 @@ export const paginationEmits = {
     isNumber(currentPage) && isNumber(pageSize),
   'prev-click': (val: number) => isNumber(val),
   'next-click': (val: number) => isNumber(val),
-}
-export type PaginationEmits = typeof paginationEmits
+};
+export type PaginationEmits = typeof paginationEmits;
 
-const componentName = 'GPagination'
+const componentName = 'GPagination';
 export default defineComponent({
   name: componentName,
 
   props: paginationProps,
   emits: paginationEmits,
 
-  setup(props, { emit, slots }) {
-    const ns = useNamespace('pagination')
-    const vnodeProps = getCurrentInstance()!.vnode.props || {}
-    const _globalSize = useGlobalSize()
+  setup(props, { emit }) {
+    const ns = useNamespace('pagination');
+    const vnodeProps = getCurrentInstance()!.vnode.props || {};
     // we can find @xxx="xxx" props on `vnodeProps` to check if user bind corresponding events
     const hasCurrentPageListener =
       'onUpdate:currentPage' in vnodeProps ||
       'onUpdate:current-page' in vnodeProps ||
-      'onCurrentChange' in vnodeProps
+      'onCurrentChange' in vnodeProps;
     const hasPageSizeListener =
       'onUpdate:pageSize' in vnodeProps ||
       'onUpdate:page-size' in vnodeProps ||
-      'onSizeChange' in vnodeProps
+      'onSizeChange' in vnodeProps;
     const assertValidUsage = computed(() => {
       // Users have to set either one, otherwise count of pages cannot be determined
-      if (isAbsent(props.total) && isAbsent(props.pageCount)) return false
+      if (isAbsent(props.total) && isAbsent(props.pageCount)) return false;
       // <el-pagination ...otherProps :current-page="xxx" /> without corresponding listener is forbidden now
       // Users have to use two way binding of `currentPage`
-      if (!isAbsent(props.currentPage) && !hasCurrentPageListener) return false
-      
-      return true
-    })
+      if (!isAbsent(props.currentPage) && !hasCurrentPageListener) return false;
 
-    const innerPageSize = ref(10)
-    const innerCurrentPage = ref(1)
+      return true;
+    });
+
+    const innerPageSize = ref(10);
+    const innerCurrentPage = ref(1);
 
     const pageSizeBridge = computed({
       get() {
-        return isAbsent(props.pageSize) ? innerPageSize.value : props.pageSize
+        return isAbsent(props.pageSize) ? innerPageSize.value : props.pageSize;
       },
       set(v: number) {
         if (isAbsent(props.pageSize)) {
-          innerPageSize.value = v
+          innerPageSize.value = v;
         }
         if (hasPageSizeListener) {
-          emit('update:page-size', v)
+          emit('update:page-size', v);
         }
       },
-    })
+    });
 
     const pageCountBridge = computed<number>(() => {
-      let pageCount = 0
+      let pageCount = 0;
       if (!isAbsent(props.pageCount)) {
-        pageCount = props.pageCount
+        pageCount = props.pageCount;
       } else if (!isAbsent(props.total)) {
-        pageCount = Math.max(1, Math.ceil(props.total / pageSizeBridge.value))
+        pageCount = Math.max(1, Math.ceil(props.total / pageSizeBridge.value));
       }
-      return pageCount
-    })
+      return pageCount;
+    });
 
     const currentPageBridge = computed<number>({
       get() {
         return isAbsent(props.currentPage)
           ? innerCurrentPage.value
-          : props.currentPage
+          : props.currentPage;
       },
       set(v) {
-        let newCurrentPage = v
+        let newCurrentPage = v;
         if (v < 1) {
-          newCurrentPage = 1
+          newCurrentPage = 1;
         } else if (v > pageCountBridge.value) {
-          newCurrentPage = pageCountBridge.value
+          newCurrentPage = pageCountBridge.value;
         }
         if (isAbsent(props.currentPage)) {
-          innerCurrentPage.value = newCurrentPage
+          innerCurrentPage.value = newCurrentPage;
         }
         if (hasCurrentPageListener) {
-          emit('update:current-page', newCurrentPage)
+          emit('update:current-page', newCurrentPage);
         }
       },
-    })
+    });
 
-    watch(pageCountBridge, (val) => {
-      if (currentPageBridge.value > val) currentPageBridge.value = val
-    })
+    watch(pageCountBridge, val => {
+      if (currentPageBridge.value > val) currentPageBridge.value = val;
+    });
 
     watch(
       [currentPageBridge, pageSizeBridge],
-      (value) => {
-        emit(CHANGE_EVENT, ...value)
+      value => {
+        emit(CHANGE_EVENT, ...value);
       },
-      { flush: 'post' }
-    )
+      { flush: 'post' },
+    );
 
     function handleCurrentChange(val: number) {
-      currentPageBridge.value = val
+      currentPageBridge.value = val;
     }
 
     function handleSizeChange(val: number) {
-      pageSizeBridge.value = val
-      const newPageCount = pageCountBridge.value
+      pageSizeBridge.value = val;
+      const newPageCount = pageCountBridge.value;
       if (currentPageBridge.value > newPageCount) {
-        currentPageBridge.value = newPageCount
+        currentPageBridge.value = newPageCount;
       }
     }
 
     function prev() {
-      if (props.disabled) return
-      currentPageBridge.value -= 1
-      emit('prev-click', currentPageBridge.value)
+      if (props.disabled) return;
+      currentPageBridge.value -= 1;
+      emit('prev-click', currentPageBridge.value);
     }
 
     function next() {
-      if (props.disabled) return
-      currentPageBridge.value += 1
-      emit('next-click', currentPageBridge.value)
+      if (props.disabled) return;
+      currentPageBridge.value += 1;
+      emit('next-click', currentPageBridge.value);
     }
 
     function addClass(element: any, cls: string) {
       if (element) {
         if (!element.props) {
-          element.props = {}
+          element.props = {};
         }
-        element.props.class = [element.props.class, cls].join(' ')
+        element.props.class = [element.props.class, cls].join(' ');
       }
     }
 
@@ -223,44 +218,47 @@ export default defineComponent({
       currentPage: currentPageBridge,
       changeEvent: handleCurrentChange,
       handleSizeChange,
-    })
+    });
 
     return () => {
       if (!assertValidUsage.value) {
-        debugWarn(componentName, 'Deprecated usages detected, please refer to the el-pagination documentation for more details')
-        return null
+        debugWarn(
+          componentName,
+          'Deprecated usages detected, please refer to the el-pagination documentation for more details',
+        );
+        return null;
       }
-      if (props.hideOnSinglePage && pageCountBridge.value <= 1) return null
+      if (props.hideOnSinglePage && pageCountBridge.value <= 1) return null;
 
       const prevComponent = h(Prev, {
         disabled: props.disabled,
         currentPage: currentPageBridge.value,
         onClick: prev,
-      })
-      
+      });
+
       const pagerComponent = h(Pager, {
         currentPage: currentPageBridge.value,
         pageCount: pageCountBridge.value,
         pagerCount: props.pagerCount,
         onChange: handleCurrentChange,
         disabled: props.disabled,
-      })
-      
+      });
+
       const nextComponent = h(Next, {
         disabled: props.disabled,
         currentPage: currentPageBridge.value,
         pageCount: pageCountBridge.value,
         onClick: next,
-      })
-      
-      addClass(prevComponent, ns.is('first'))
-      addClass(nextComponent, ns.is('last'))
-      
-      return h(
-        'div',
-        { class: [ns.b(), ns.m(props.align)] },
-        [prevComponent, pagerComponent, nextComponent]
-      )
-    }
+      });
+
+      addClass(prevComponent, ns.is('first'));
+      addClass(nextComponent, ns.is('last'));
+
+      return h('div', { class: [ns.b(), ns.m(props.align)] }, [
+        prevComponent,
+        pagerComponent,
+        nextComponent,
+      ]);
+    };
   },
-})
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1377,8 +1377,10 @@ __metadata:
 "@flash-global66/g-pagination@workspace:components/pagination":
   version: 0.0.0-use.local
   resolution: "@flash-global66/g-pagination@workspace:components/pagination"
+  dependencies:
+    "@flash-global66/g-icon-font": "npm:^0.25.15"
+    "@flash-global66/g-utils": "npm:^0.12.0"
   peerDependencies:
-    "@flash-global66/g-icon-button": ^0.1.1
     element-plus: ^2.9.0
     vue: ^3.2.0
   languageName: unknown


### PR DESCRIPTION
## ep-extraction-v5 · WU-1 · pagination

First slice of **ep-extraction-v5** (the 4 components deferred in v4). Migrates \`components/pagination\` off element-plus internals onto DS-native packages. Pure re-point + dead-code cleanup — **no behavior change, no public API change**.

### Changes
- **Repoint imports → \`@flash-global66/g-utils\`**: \`buildProps\`, \`debugWarn\`, \`isNumber\`, \`useNamespace\`, \`CHANGE_EVENT\`, \`withInstall\`, \`SFCWithInstall\` (across \`index.ts\`, \`pagination.ts\`, \`prev/next/pager.{ts,vue}\`).
- **Remove dead code** (forced by \`eslint --max-warnings 0\` once the files are re-staged; all provably unused): \`iconPropType\`, unused \`PropType\`/\`VNode\`/\`IconString\`, the \`slots\` setup param, and \`const _globalSize = useGlobalSize()\` (its only consumer). Removing \`_globalSize\` drops the sole \`g-hooks\` usage, so no \`g-hooks\` dependency is declared. \`useGlobalSize\` is pure (\`inject\` + \`computed\`), so removal is behavior-neutral.
- **package.json packaging** normalized to the tooltip/v4 convention: \`@flash-global66/g-icon-font\` (\`^0.25.15\`) and \`@flash-global66/g-utils\` (\`^0.12.0\`) in \`dependencies\`; dropped the stale/unused \`@flash-global66/g-icon-button\` peer; \`element-plus\` stays a peer (the styled component \`@use\`s \`element-plus/theme-chalk\` in \`pagination.styles.scss\`).

### Out of scope (flagged, not touched)
- \`pagination.styles.scss\` still \`@use\`s \`element-plus/theme-chalk/*\` — allowed for styled components; needs its own decision if we ever drop the element-plus peer entirely.
- No \`tests/\` dir exists for pagination (pre-existing gap). "No behavior change" rests on eslint + vue-tsc + adversarial diff review.

### Verification
- \`eslint --max-warnings 0\` on all 9 changed files: clean.
- \`vue-tsc --noEmit\` on the pagination project: clean (0 real type errors).
- No \`from 'element-plus'\` JS import survives (only the scss \`@use\`).
- \`elPaginationKey\` remains \`Symbol.for('gPaginationKey')\` (duplicate-copy safety).
- Fresh-context adversarial review: APPROVE.