### PR TITLE
feat(input-number): migrate off element-plus internals to g-utils/g-hooks

### DIFF
--- a/components/input-number/index.ts
+++ b/components/input-number/index.ts
@@ -1,12 +1,12 @@
-import { withInstall } from 'element-plus/es/utils/index.mjs'
-import InputNumber from './src/input-number.vue'
+import { withInstall } from '@flash-global66/g-utils';
+import InputNumber from './src/input-number.vue';
 
-import type { SFCWithInstall } from 'element-plus/es/utils/index.mjs'
+import type { SFCWithInstall } from '@flash-global66/g-utils';
 
 export const GInputNumber: SFCWithInstall<typeof InputNumber> =
-  withInstall(InputNumber)
+  withInstall(InputNumber);
 
-export default GInputNumber
-export * from './src/input-number'
+export default GInputNumber;
+export * from './src/input-number';
 
-export type InputNumberInstance = InstanceType<typeof InputNumber>
+export type InputNumberInstance = InstanceType<typeof InputNumber>;

--- a/components/input-number/package.json
+++ b/components/input-number/package.json
@@ -28,10 +28,15 @@
   "repository": {
     "url": "https://github.com/Flash-Global66/global-design-system.git"
   },
-  "peerDependencies": {
+  "dependencies": {
     "@flash-global66/g-config-provider": "^0.0.8",
-    "@flash-global66/g-form": "^0.1.0",
-    "@flash-global66/g-input": "^0.1.0",
+    "@flash-global66/g-form": "^0.2.16",
+    "@flash-global66/g-hooks": "^0.11.4",
+    "@flash-global66/g-icon-font": "^0.25.15",
+    "@flash-global66/g-input": "^0.3.20",
+    "@flash-global66/g-utils": "^0.12.0"
+  },
+  "peerDependencies": {
     "element-plus": "^2.9.0",
     "lodash-unified": "^1.0.3",
     "vue": "^3.2.0"

--- a/components/input-number/src/input-number.ts
+++ b/components/input-number/src/input-number.ts
@@ -1,14 +1,14 @@
-import { isNil } from 'lodash-unified'
-import { isNumber } from 'element-plus/es/utils/index.mjs'
+import { isNil } from 'lodash-unified';
 import {
+  isNumber,
   CHANGE_EVENT,
   INPUT_EVENT,
   UPDATE_MODEL_EVENT,
-} from 'element-plus/es/constants/index.mjs'
+} from '@flash-global66/g-utils';
 
-import type { HTMLAttributes } from 'vue'
-import type { ComponentSize } from 'element-plus/es/constants/index.mjs'
-import type InputNumber from './input-number.vue'
+import type { HTMLAttributes } from 'vue';
+import type { ComponentSize } from '@flash-global66/g-utils';
+import type InputNumber from './input-number.vue';
 
 /**
  * @description input-number component props
@@ -17,83 +17,83 @@ export interface InputNumberProps {
   /**
    * @description same as `id` in native input
    */
-  id?: string
+  id?: string;
   /**
    * @description incremental step
    */
-  step?: number
+  step?: number;
   /**
    * @description whether input value can only be multiple of step
    */
-  stepStrictly?: boolean
+  stepStrictly?: boolean;
   /**
    * @description the maximum allowed value
    */
-  max?: number
+  max?: number;
   /**
    * @description the minimum allowed value
    */
-  min?: number
+  min?: number;
   /**
    * @description binding value
    */
-  modelValue?: number | null
+  modelValue?: number | null;
   /**
    * @description same as `readonly` in native input
    */
-  readonly?: boolean
+  readonly?: boolean;
   /**
    * @description whether the component is disabled
    */
-  disabled?: boolean
+  disabled?: boolean;
   /**
    * @description size of the component
    */
-  size?: ComponentSize
+  size?: ComponentSize;
   /**
    * @description whether to enable the control buttons
    */
-  controls?: boolean
+  controls?: boolean;
   /**
    * @description position of the control buttons
    */
-  controlsPosition?: '' | 'right'
+  controlsPosition?: '' | 'right';
   /**
    * @description value should be set when input box is cleared
    */
-  valueOnClear?: 'min' | 'max' | number | null
+  valueOnClear?: 'min' | 'max' | number | null;
   /**
    * @description same as `name` in native input
    */
-  name?: string
+  name?: string;
   /**
    * @description same as `placeholder` in native input
    */
-  placeholder?: string
+  placeholder?: string;
   /**
    * @description precision of input value
    */
-  precision?: number
+  precision?: number;
   /**
    * @description whether to trigger form validation
    */
-  validateEvent?: boolean
+  validateEvent?: boolean;
   /**
    * @description native aria-label attribute
    */
-  ariaLabel?: string
+  ariaLabel?: string;
   /**
    * @description native input mode for virtual keyboards
    */
-  inputmode?: HTMLAttributes['inputmode']
+  inputmode?: HTMLAttributes['inputmode'];
   /**
    * @description alignment for the inner input text
    */
-  align?: 'left' | 'right' | 'center'
+  align?: 'left' | 'right' | 'center';
   /**
    * @description whether to disable scientific notation input (e.g. 'e', 'E')
    */
-  disabledScientific?: boolean
+  disabledScientific?: boolean;
 }
 
 export const inputNumberEmits = {
@@ -105,7 +105,7 @@ export const inputNumberEmits = {
     isNumber(val) || isNil(val),
   [UPDATE_MODEL_EVENT]: (val: number | undefined) =>
     isNumber(val) || isNil(val),
-}
-export type InputNumberEmits = typeof inputNumberEmits
+};
+export type InputNumberEmits = typeof inputNumberEmits;
 
-export type InputNumberInstance = InstanceType<typeof InputNumber> & unknown
+export type InputNumberInstance = InstanceType<typeof InputNumber> & unknown;

--- a/components/input-number/src/input-number.vue
+++ b/components/input-number/src/input-number.vue
@@ -72,41 +72,39 @@
 </template>
 
 <script lang="ts" setup>
-import { computed, onMounted, onUpdated, reactive, ref, watch } from 'vue'
-import { isNil } from 'lodash-unified'
-import { GInput } from '@flash-global66/g-input'
-import { GIconFont } from '@flash-global66/g-icon-font'
+import { computed, onMounted, onUpdated, reactive, ref, watch } from 'vue';
+import { isNil } from 'lodash-unified';
+import { GInput } from '@flash-global66/g-input';
+import { GIconFont } from '@flash-global66/g-icon-font';
 import {
   useFormDisabled,
   useFormItem,
-} from '@flash-global66/g-form'
+  useFormSize,
+} from '@flash-global66/g-form';
 
-import { getEventCode, getEventKey } from '../utils/index'
+import { getEventCode, getEventKey } from '../utils/index';
 import {
   CHANGE_EVENT,
   EVENT_CODE,
   INPUT_EVENT,
   UPDATE_MODEL_EVENT,
-  useFormSize,
-  useLocale,
   useNamespace,
   vRepeatClick,
-} from 'element-plus'
-import {
   debugWarn,
   isNumber,
   isString,
   isUndefined,
   throwError,
-} from 'element-plus/es/utils/index.mjs'
-import { inputNumberEmits } from './input-number'
+} from '@flash-global66/g-utils';
+import { useLocale } from '@flash-global66/g-hooks';
+import { inputNumberEmits } from './input-number';
 
-import type { InputInstance } from '@flash-global66/g-input'
-import type { InputNumberProps } from './input-number'
+import type { InputInstance } from '@flash-global66/g-input';
+import type { InputNumberProps } from './input-number';
 
 defineOptions({
   name: 'GInputNumber',
-})
+});
 
 const props = withDefaults(defineProps<InputNumberProps>(), {
   id: undefined,
@@ -122,311 +120,311 @@ const props = withDefaults(defineProps<InputNumberProps>(), {
   validateEvent: true,
   inputmode: undefined,
   align: 'center',
-})
-const emit = defineEmits(inputNumberEmits)
+});
+const emit = defineEmits(inputNumberEmits);
 
-const { t } = useLocale()
-const ns = useNamespace('input-number')
-const input = ref<InputInstance>()
+const { t } = useLocale();
+const ns = useNamespace('input-number');
+const input = ref<InputInstance>();
 
 interface Data {
-  currentValue: number | null | undefined
-  userInput: null | number | string
+  currentValue: number | null | undefined;
+  userInput: null | number | string;
 }
 const data = reactive<Data>({
   currentValue: props.modelValue,
   userInput: null,
-})
+});
 
-const { formItem } = useFormItem()
+const { formItem } = useFormItem();
 
 const minDisabled = computed(
-  () => isNumber(props.modelValue) && props.modelValue <= props.min
-)
+  () => isNumber(props.modelValue) && props.modelValue <= props.min,
+);
 const maxDisabled = computed(
-  () => isNumber(props.modelValue) && props.modelValue >= props.max
-)
+  () => isNumber(props.modelValue) && props.modelValue >= props.max,
+);
 
 const numPrecision = computed(() => {
-  const stepPrecision = getPrecision(props.step)
+  const stepPrecision = getPrecision(props.step);
   if (!isUndefined(props.precision)) {
     if (stepPrecision > props.precision) {
       debugWarn(
         'InputNumber',
-        'precision should not be less than the decimal places of step'
-      )
+        'precision should not be less than the decimal places of step',
+      );
     }
-    return props.precision
+    return props.precision;
   } else {
-    return Math.max(getPrecision(props.modelValue), stepPrecision)
+    return Math.max(getPrecision(props.modelValue), stepPrecision);
   }
-})
+});
 const controlsAtRight = computed(() => {
-  return props.controls && props.controlsPosition === 'right'
-})
+  return props.controls && props.controlsPosition === 'right';
+});
 
-const inputNumberSize = useFormSize()
-const inputNumberDisabled = useFormDisabled()
+const inputNumberSize = useFormSize();
+const inputNumberDisabled = useFormDisabled();
 
 const displayValue = computed(() => {
   if (data.userInput !== null) {
-    return data.userInput
+    return data.userInput;
   }
-  let currentValue: number | string | undefined | null = data.currentValue
-  if (isNil(currentValue)) return ''
+  let currentValue: number | string | undefined | null = data.currentValue;
+  if (isNil(currentValue)) return '';
   if (isNumber(currentValue)) {
-    if (Number.isNaN(currentValue)) return ''
+    if (Number.isNaN(currentValue)) return '';
     if (!isUndefined(props.precision)) {
-      currentValue = currentValue.toFixed(props.precision)
+      currentValue = currentValue.toFixed(props.precision);
     }
   }
-  return currentValue
-})
+  return currentValue;
+});
 const toPrecision = (num: number, pre?: number) => {
-  if (isUndefined(pre)) pre = numPrecision.value
-  if (pre === 0) return Math.round(num)
-  let snum = String(num)
-  const pointPos = snum.indexOf('.')
-  if (pointPos === -1) return num
-  const nums = snum.replace('.', '').split('')
-  const datum = nums[pointPos + pre]
-  if (!datum) return num
-  const length = snum.length
+  if (isUndefined(pre)) pre = numPrecision.value;
+  if (pre === 0) return Math.round(num);
+  let snum = String(num);
+  const pointPos = snum.indexOf('.');
+  if (pointPos === -1) return num;
+  const nums = snum.replace('.', '').split('');
+  const datum = nums[pointPos + pre];
+  if (!datum) return num;
+  const length = snum.length;
   if (snum.charAt(length - 1) === '5') {
-    snum = `${snum.slice(0, Math.max(0, length - 1))}6`
+    snum = `${snum.slice(0, Math.max(0, length - 1))}6`;
   }
-  return Number.parseFloat(Number(snum).toFixed(pre))
-}
+  return Number.parseFloat(Number(snum).toFixed(pre));
+};
 const getPrecision = (value: number | null | undefined) => {
-  if (isNil(value)) return 0
-  const valueString = value.toString()
-  const dotPosition = valueString.indexOf('.')
-  let precision = 0
+  if (isNil(value)) return 0;
+  const valueString = value.toString();
+  const dotPosition = valueString.indexOf('.');
+  let precision = 0;
   if (dotPosition !== -1) {
-    precision = valueString.length - dotPosition - 1
+    precision = valueString.length - dotPosition - 1;
   }
-  return precision
-}
+  return precision;
+};
 const ensurePrecision = (val: number, coefficient: 1 | -1 = 1) => {
-  if (!isNumber(val)) return data.currentValue
+  if (!isNumber(val)) return data.currentValue;
   if (val >= Number.MAX_SAFE_INTEGER && coefficient === 1) {
     debugWarn(
       'InputNumber',
-      'The value has reached the maximum safe integer limit.'
-    )
-    return val
+      'The value has reached the maximum safe integer limit.',
+    );
+    return val;
   } else if (val <= Number.MIN_SAFE_INTEGER && coefficient === -1) {
     debugWarn(
       'InputNumber',
-      'The value has reached the minimum safe integer limit.'
-    )
-    return val
+      'The value has reached the minimum safe integer limit.',
+    );
+    return val;
   }
 
   // Solve the accuracy problem of JS decimal calculation by converting the value to integer.
-  return toPrecision(val + props.step * coefficient)
-}
+  return toPrecision(val + props.step * coefficient);
+};
 const handleKeydown = (event: KeyboardEvent | Event) => {
-  const code = getEventCode(event as KeyboardEvent)
-  const key = getEventKey(event as KeyboardEvent)
+  const code = getEventCode(event as KeyboardEvent);
+  const key = getEventKey(event as KeyboardEvent);
 
   if (props.disabledScientific && ['e', 'E'].includes(key)) {
-    event.preventDefault()
-    return
+    event.preventDefault();
+    return;
   }
 
   switch (code) {
     case EVENT_CODE.up: {
-      event.preventDefault()
-      increase()
-      break
+      event.preventDefault();
+      increase();
+      break;
     }
     case EVENT_CODE.down: {
-      event.preventDefault()
-      decrease()
-      break
+      event.preventDefault();
+      decrease();
+      break;
     }
   }
-}
+};
 const increase = () => {
-  if (props.readonly || inputNumberDisabled.value || maxDisabled.value) return
-  const value = Number(displayValue.value) || 0
-  const newVal = ensurePrecision(value)
-  setCurrentValue(newVal)
-  emit(INPUT_EVENT, data.currentValue)
-  setCurrentValueToModelValue()
-}
+  if (props.readonly || inputNumberDisabled.value || maxDisabled.value) return;
+  const value = Number(displayValue.value) || 0;
+  const newVal = ensurePrecision(value);
+  setCurrentValue(newVal);
+  emit(INPUT_EVENT, data.currentValue);
+  setCurrentValueToModelValue();
+};
 const decrease = () => {
-  if (props.readonly || inputNumberDisabled.value || minDisabled.value) return
-  const value = Number(displayValue.value) || 0
-  const newVal = ensurePrecision(value, -1)
-  setCurrentValue(newVal)
-  emit(INPUT_EVENT, data.currentValue)
-  setCurrentValueToModelValue()
-}
+  if (props.readonly || inputNumberDisabled.value || minDisabled.value) return;
+  const value = Number(displayValue.value) || 0;
+  const newVal = ensurePrecision(value, -1);
+  setCurrentValue(newVal);
+  emit(INPUT_EVENT, data.currentValue);
+  setCurrentValueToModelValue();
+};
 const verifyValue = (
   value: number | string | null | undefined,
-  update?: boolean
+  update?: boolean,
 ): number | null | undefined => {
-  const { max, min, step, precision, stepStrictly, valueOnClear } = props
+  const { max, min, step, precision, stepStrictly, valueOnClear } = props;
   if (max < min) {
-    throwError('InputNumber', 'min should not be greater than max.')
+    throwError('InputNumber', 'min should not be greater than max.');
   }
-  let newVal = Number(value)
+  let newVal = Number(value);
   if (isNil(value) || Number.isNaN(newVal)) {
-    return null
+    return null;
   }
   if (value === '') {
     if (valueOnClear === null) {
-      return null
+      return null;
     }
-    newVal = isString(valueOnClear) ? { min, max }[valueOnClear] : valueOnClear
+    newVal = isString(valueOnClear) ? { min, max }[valueOnClear] : valueOnClear;
   }
   if (stepStrictly) {
     newVal = toPrecision(
       Math.round(toPrecision(newVal / step)) * step,
-      precision
-    )
+      precision,
+    );
     if (newVal !== value) {
-      update && emit(UPDATE_MODEL_EVENT, newVal)
+      update && emit(UPDATE_MODEL_EVENT, newVal);
     }
   }
   if (!isUndefined(precision)) {
-    newVal = toPrecision(newVal, precision)
+    newVal = toPrecision(newVal, precision);
   }
   if (newVal > max || newVal < min) {
-    newVal = newVal > max ? max : min
-    update && emit(UPDATE_MODEL_EVENT, newVal)
+    newVal = newVal > max ? max : min;
+    update && emit(UPDATE_MODEL_EVENT, newVal);
   }
-  return newVal
-}
+  return newVal;
+};
 const setCurrentValue = (
   value: number | string | null | undefined,
-  emitChange = true
+  emitChange = true,
 ) => {
-  const oldVal = data.currentValue
-  const newVal = verifyValue(value)
+  const oldVal = data.currentValue;
+  const newVal = verifyValue(value);
   if (!emitChange) {
-    emit(UPDATE_MODEL_EVENT, newVal!)
-    return
+    emit(UPDATE_MODEL_EVENT, newVal!);
+    return;
   }
-  data.userInput = null
-  if (oldVal === newVal && value) return
-  emit(UPDATE_MODEL_EVENT, newVal!)
+  data.userInput = null;
+  if (oldVal === newVal && value) return;
+  emit(UPDATE_MODEL_EVENT, newVal!);
   if (oldVal !== newVal) {
-    emit(CHANGE_EVENT, newVal!, oldVal!)
+    emit(CHANGE_EVENT, newVal!, oldVal!);
   }
   if (props.validateEvent) {
-    formItem?.validate?.('change').catch((err) => debugWarn(err))
+    formItem?.validate?.('change').catch(err => debugWarn(err));
   }
-  data.currentValue = newVal
-}
+  data.currentValue = newVal;
+};
 const handleInput = (value: string) => {
-  data.userInput = value
-  const newVal = value === '' ? null : Number(value)
-  emit(INPUT_EVENT, newVal)
-  setCurrentValue(newVal, false)
-}
+  data.userInput = value;
+  const newVal = value === '' ? null : Number(value);
+  emit(INPUT_EVENT, newVal);
+  setCurrentValue(newVal, false);
+};
 const handleInputChange = (value: string) => {
-  const newVal = value !== '' ? Number(value) : ''
+  const newVal = value !== '' ? Number(value) : '';
   if ((isNumber(newVal) && !Number.isNaN(newVal)) || value === '') {
-    setCurrentValue(newVal)
+    setCurrentValue(newVal);
   }
-  setCurrentValueToModelValue()
-  data.userInput = null
-}
+  setCurrentValueToModelValue();
+  data.userInput = null;
+};
 
 const focus = () => {
-  input.value?.focus?.()
-}
+  input.value?.focus?.();
+};
 
 const blur = () => {
-  input.value?.blur?.()
-}
+  input.value?.blur?.();
+};
 
 const handleFocus = (event: MouseEvent | FocusEvent) => {
-  emit('focus', event)
-}
+  emit('focus', event);
+};
 
 const handleBlur = (event: MouseEvent | FocusEvent) => {
-  data.userInput = null
+  data.userInput = null;
   // When non-numeric content is entered into a numeric input box,
   // the content displayed on the page is not cleared after the value is cleared. #18533
   // https://bugzilla.mozilla.org/show_bug.cgi?id=1398528
   if (data.currentValue === null && input.value?.ref) {
-    input.value.ref.value = ''
+    input.value.ref.value = '';
   }
-  emit('blur', event)
+  emit('blur', event);
   if (props.validateEvent) {
-    formItem?.validate?.('blur').catch((err) => debugWarn(err))
+    formItem?.validate?.('blur').catch(err => debugWarn(err));
   }
-}
+};
 
 const setCurrentValueToModelValue = () => {
   if (data.currentValue !== props.modelValue) {
-    data.currentValue = props.modelValue
+    data.currentValue = props.modelValue;
   }
-}
+};
 const handleWheel = (e: WheelEvent) => {
-  if (document.activeElement === e.target) e.preventDefault()
-}
+  if (document.activeElement === e.target) e.preventDefault();
+};
 
 watch(
   () => props.modelValue,
   (value, oldValue) => {
-    const newValue = verifyValue(value, true)
+    const newValue = verifyValue(value, true);
     if (data.userInput === null && newValue !== oldValue) {
-      data.currentValue = newValue
+      data.currentValue = newValue;
     }
   },
-  { immediate: true }
-)
+  { immediate: true },
+);
 
 watch(
   () => props.precision,
   () => {
-    data.currentValue = verifyValue(props.modelValue)
-  }
-)
+    data.currentValue = verifyValue(props.modelValue);
+  },
+);
 onMounted(() => {
-  const { min, max, modelValue } = props
-  const innerInput = input.value?.ref as HTMLInputElement
-  if (!innerInput) return
-  innerInput.setAttribute('role', 'spinbutton')
+  const { min, max, modelValue } = props;
+  const innerInput = input.value?.ref as HTMLInputElement;
+  if (!innerInput) return;
+  innerInput.setAttribute('role', 'spinbutton');
   if (Number.isFinite(max)) {
-    innerInput.setAttribute('aria-valuemax', String(max))
+    innerInput.setAttribute('aria-valuemax', String(max));
   } else {
-    innerInput.removeAttribute('aria-valuemax')
+    innerInput.removeAttribute('aria-valuemax');
   }
   if (Number.isFinite(min)) {
-    innerInput.setAttribute('aria-valuemin', String(min))
+    innerInput.setAttribute('aria-valuemin', String(min));
   } else {
-    innerInput.removeAttribute('aria-valuemin')
+    innerInput.removeAttribute('aria-valuemin');
   }
   innerInput.setAttribute(
     'aria-valuenow',
     data.currentValue || data.currentValue === 0
       ? String(data.currentValue)
-      : ''
-  )
-  innerInput.setAttribute('aria-disabled', String(inputNumberDisabled.value))
+      : '',
+  );
+  innerInput.setAttribute('aria-disabled', String(inputNumberDisabled.value));
   if (!isNumber(modelValue) && modelValue != null) {
-    let val: number | null = Number(modelValue)
+    let val: number | null = Number(modelValue);
     if (Number.isNaN(val)) {
-      val = null
+      val = null;
     }
-    emit(UPDATE_MODEL_EVENT, val!)
+    emit(UPDATE_MODEL_EVENT, val!);
   }
-  innerInput.addEventListener('wheel', handleWheel, { passive: false })
-})
+  innerInput.addEventListener('wheel', handleWheel, { passive: false });
+});
 onUpdated(() => {
-  const innerInput = input.value?.ref as HTMLInputElement
-  innerInput?.setAttribute('aria-valuenow', `${data.currentValue ?? ''}`)
-})
+  const innerInput = input.value?.ref as HTMLInputElement;
+  innerInput?.setAttribute('aria-valuenow', `${data.currentValue ?? ''}`);
+});
 defineExpose({
   /** @description get focus the input component */
   focus,
   /** @description remove focus the input component */
   blur,
-})
+});
 </script>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1053,7 +1053,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@flash-global66/g-config-provider@workspace:components/config-provider":
+"@flash-global66/g-config-provider@npm:^0.0.8, @flash-global66/g-config-provider@workspace:components/config-provider":
   version: 0.0.0-use.local
   resolution: "@flash-global66/g-config-provider@workspace:components/config-provider"
   languageName: unknown
@@ -1282,10 +1282,14 @@ __metadata:
 "@flash-global66/g-input-number@workspace:components/input-number":
   version: 0.0.0-use.local
   resolution: "@flash-global66/g-input-number@workspace:components/input-number"
+  dependencies:
+    "@flash-global66/g-config-provider": "npm:^0.0.8"
+    "@flash-global66/g-form": "npm:^0.2.16"
+    "@flash-global66/g-hooks": "npm:^0.11.4"
+    "@flash-global66/g-icon-font": "npm:^0.25.15"
+    "@flash-global66/g-input": "npm:^0.3.20"
+    "@flash-global66/g-utils": "npm:^0.12.0"
   peerDependencies:
-    "@flash-global66/g-config-provider": ^0.0.8
-    "@flash-global66/g-form": ^0.1.0
-    "@flash-global66/g-input": ^0.1.0
     element-plus: ^2.9.0
     lodash-unified: ^1.0.3
     vue: ^3.2.0


### PR DESCRIPTION
## ep-extraction-v5 · WU-2 · input-number

Second slice of **ep-extraction-v5**. Migrates \`components/input-number\` off element-plus internals onto DS-native packages. Pure re-point — **no behavior change, no public API change**.

### Changes
- **→ \`@flash-global66/g-utils\`**: \`isNumber\`, \`isString\`, \`isUndefined\`, \`debugWarn\`, \`throwError\`, \`EVENT_CODE\`, \`CHANGE_EVENT\`, \`INPUT_EVENT\`, \`UPDATE_MODEL_EVENT\`, \`ComponentSize\` (type), \`useNamespace\`, \`vRepeatClick\`, \`withInstall\`, \`SFCWithInstall\`.
- **→ \`@flash-global66/g-hooks\`**: \`useLocale\`.
- **→ \`@flash-global66/g-form\`**: \`useFormSize\` — it was mistakenly imported from \`element-plus\` even though the sibling form hooks (\`useFormDisabled\`, \`useFormItem\`) already came from g-form. Now consistent.
- **package.json**: all \`@flash-global66\` packages moved into \`dependencies\` with ranges aligned to current workspace versions. This also **fixes stale peer ranges** (\`g-form ^0.1.0\`, \`g-input ^0.1.0\` → \`^0.2.16\`, \`^0.3.20\`). \`element-plus\`, \`lodash-unified\`, \`vue\` stay as peers.

### Out of scope (flagged, not touched)
- \`input-number.styles.scss\` keeps \`@use "element-plus/theme-chalk/..."\` (styled component) and \`@use "@flash-global66/g-config-provider/config.styles.scss"\` (g-config-provider declared in deps).
- Pre-existing English JSDoc/inline comments untouched (no new comments added).

### Verification
- \`eslint --max-warnings 0\` on all 3 changed source files: clean.
- \`vue-tsc\`: no real type errors (only environmental TS7016 for buildable deps' local dist, resolved in CI).
- No \`from 'element-plus'\` JS import survives (only scss \`@use\`).
- All 6 declared \`@flash\` deps satisfy current workspace versions.
- Fresh-context adversarial review: APPROVE.