### PR TITLE
feat(collapse): migrate off element-plus internals; add Awaitable to g-utils

### DIFF
--- a/common/g-utils/src/types/utils.type.ts
+++ b/common/g-utils/src/types/utils.type.ts
@@ -28,6 +28,15 @@ export type EmitFn<E extends EmitsOptions> = SetupContext<E>['emit'];
 export type Arrayable<T> = T | T[];
 
 /**
+ * Representa un valor que puede resolverse de forma síncrona (`T`) o
+ * asíncrona (`Promise<T>`).
+ *
+ * Copiado del tipo `Awaitable<T>` de element-plus (`es/utils/typescript`),
+ * usado por hooks como `beforeCollapse` que aceptan un retorno sync o async.
+ */
+export type Awaitable<T> = Promise<T> | T;
+
+/**
  * Representa un valor que puede ser `T` o `null`.
  *
  * Copiado del tipo `Nullable<T>` de element-plus (`packages/utils/typescript`).

--- a/components/collapse/index.ts
+++ b/components/collapse/index.ts
@@ -1,19 +1,19 @@
-import { withInstall, withNoopInstall } from 'element-plus/es/utils/index'
+import { withInstall, withNoopInstall } from '@flash-global66/g-utils';
 
-import Collapse from './src/collapse.vue'
-import CollapseItem from './src/collapse-item.vue'
-import type { SFCWithInstall } from 'element-plus/es/utils/index'
+import Collapse from './src/collapse.vue';
+import CollapseItem from './src/collapse-item.vue';
+import type { SFCWithInstall } from '@flash-global66/g-utils';
 
 export const GCollapse: SFCWithInstall<typeof Collapse> & {
-  CollapseItem: typeof CollapseItem
+  CollapseItem: typeof CollapseItem;
 } = withInstall(Collapse, {
   CollapseItem,
-})
-export default GCollapse
+});
+export default GCollapse;
 export const GCollapseItem: SFCWithInstall<typeof CollapseItem> =
-  withNoopInstall(CollapseItem)
+  withNoopInstall(CollapseItem);
 
-export * from './src/collapse'
-export * from './src/collapse-item'
-export * from './src/constants'
-export type { CollapseInstance, CollapseItemInstance } from './src/instance'
+export * from './src/collapse';
+export * from './src/collapse-item';
+export * from './src/constants';
+export type { CollapseInstance, CollapseItemInstance } from './src/instance';

--- a/components/collapse/package.json
+++ b/components/collapse/package.json
@@ -28,11 +28,14 @@
   "repository": {
     "url": "https://github.com/Flash-Global66/global-design-system.git"
   },
+  "dependencies": {
+    "@flash-global66/g-collapse-transition": "^0.2.13",
+    "@flash-global66/g-hooks": "^0.11.4",
+    "@flash-global66/g-icon-font": "^0.25.15",
+    "@flash-global66/g-utils": "^0.12.0"
+  },
   "peerDependencies": {
-    "@flash-global66/g-collapse-transition": "^0.0.1",
-    "@flash-global66/g-icon-font": "^0.10.0",
     "element-plus": "^2.9.0",
-    "lodash-unified": "^1.0.3",
     "vue": "^3.2.0"
   },
   "gitHead": "581df2757ad066a5cdd5a2e64500ab33a68279ad"

--- a/components/collapse/src/collapse-item.ts
+++ b/components/collapse/src/collapse-item.ts
@@ -1,6 +1,6 @@
-import { buildProps, definePropType, iconPropType } from 'element-plus/es/utils/index'
-import type { ExtractPropTypes } from 'vue'
-import type { CollapseActiveName, IconsType } from './collapse'
+import { buildProps, definePropType } from '@flash-global66/g-utils';
+import type { ExtractPropTypes } from 'vue';
+import type { CollapseActiveName, IconsType } from './collapse';
 
 export const collapseItemProps = buildProps({
   /**
@@ -26,14 +26,14 @@ export const collapseItemProps = buildProps({
    */
   iconsRight: {
     type: definePropType<IconsType[]>(Array),
-    default: () => ([] as IconsType[]),
+    default: () => [] as IconsType[],
   },
   /**
    * @description icons to be displayed on the left side of the collapse item
    */
   iconsLeft: {
     type: definePropType<IconsType[]>(Array),
-    default: () => ([] as IconsType[]),
+    default: () => [] as IconsType[],
   },
   /**
    * @description description of the collapse item
@@ -69,6 +69,6 @@ export const collapseItemProps = buildProps({
   hideIcon: {
     type: Boolean,
     default: false,
-  }
-} as const)
-export type CollapseItemProps = ExtractPropTypes<typeof collapseItemProps>
+  },
+} as const);
+export type CollapseItemProps = ExtractPropTypes<typeof collapseItemProps>;

--- a/components/collapse/src/collapse.ts
+++ b/components/collapse/src/collapse.ts
@@ -4,37 +4,42 @@ import {
   isArray,
   isNumber,
   isString,
-  mutable
-} from 'element-plus/es/utils/index'
-import { CHANGE_EVENT, UPDATE_MODEL_EVENT } from 'element-plus'
-import type { ExtractPropTypes } from 'vue'
-import type { Arrayable, Awaitable } from 'element-plus/es/utils/index'
-import { IconString } from '@flash-global66/g-icon-font'
+  mutable,
+  CHANGE_EVENT,
+  UPDATE_MODEL_EVENT,
+} from '@flash-global66/g-utils';
+import type { ExtractPropTypes } from 'vue';
+import type { Arrayable, Awaitable } from '@flash-global66/g-utils';
+import { IconString } from '@flash-global66/g-icon-font';
 
-export type CollapseActiveName = string | number
-export type CollapseModelValue = Arrayable<CollapseActiveName>
+export type CollapseActiveName = string | number;
+export type CollapseModelValue = Arrayable<CollapseActiveName>;
 
-export type CollapseIconPositionType = 'left' | 'right'
+export type CollapseIconPositionType = 'left' | 'right';
 
 export type IconsType = {
-  icon: IconString
-  onClick?: (name: CollapseActiveName, icon: IconString, isActive: boolean) => void
-  spin?: boolean
-}
+  icon: IconString;
+  onClick?: (
+    name: CollapseActiveName,
+    icon: IconString,
+    isActive: boolean,
+  ) => void;
+  spin?: boolean;
+};
 
 export type CollapseItemType = {
-  title: string
-  name?: CollapseActiveName
-  iconsRight?: IconsType[]
-  disabled?: boolean
-  iconsLeft?: IconsType[]
-  description?: string
-  content?: string | (() => string)
-  hideIcon?: boolean
-}
+  title: string;
+  name?: CollapseActiveName;
+  iconsRight?: IconsType[];
+  disabled?: boolean;
+  iconsLeft?: IconsType[];
+  description?: string;
+  content?: string | (() => string);
+  hideIcon?: boolean;
+};
 
 export const emitChangeFn = (value: CollapseModelValue) =>
-  isNumber(value) || isString(value) || isArray(value)
+  isNumber(value) || isString(value) || isArray(value);
 
 export const collapseProps = buildProps({
   /**
@@ -46,34 +51,37 @@ export const collapseProps = buildProps({
    */
   modelValue: {
     type: definePropType<CollapseModelValue>([Array, String, Number]),
-    default: () => mutable([] as const)
+    default: () => mutable([] as const),
   },
   /**
    * @description set expand icon position
    */
   expandIconPosition: {
     type: definePropType<CollapseIconPositionType>([String]),
-    default: 'right'
+    default: 'right',
   },
   /**
    * @description before-collapse hook before the collapse state changes. If `false` is returned or a `Promise` is returned and then is rejected, will stop collapsing
    */
   beforeCollapse: {
-    type: definePropType<(name: CollapseActiveName) => Awaitable<boolean>>(Function)
+    type: definePropType<(name: CollapseActiveName) => Awaitable<boolean>>(
+      Function,
+    ),
   },
   /**
    * @description items of the collapse component
    */
   items: {
     type: definePropType<CollapseItemType[]>(Array),
-    default: () => mutable([] as const)
-  }
-} as const)
-export type CollapseProps = ExtractPropTypes<typeof collapseProps>
+    default: () => mutable([] as const),
+  },
+} as const);
+export type CollapseProps = ExtractPropTypes<typeof collapseProps>;
 
 export const collapseEmits = {
   [UPDATE_MODEL_EVENT]: emitChangeFn,
   [CHANGE_EVENT]: emitChangeFn,
-  'header-click': (name: CollapseActiveName) => isString(name) || isNumber(name)
-}
-export type CollapseEmits = typeof collapseEmits
+  'header-click': (name: CollapseActiveName) =>
+    isString(name) || isNumber(name),
+};
+export type CollapseEmits = typeof collapseEmits;

--- a/components/collapse/src/use-collapse-item.ts
+++ b/components/collapse/src/use-collapse-item.ts
@@ -1,22 +1,27 @@
-import { computed, inject, ref, unref } from 'vue'
-import { useIdInjection, useNamespace } from 'element-plus'
-import { collapseContextKey } from './constants'
+import { computed, inject, ref, unref } from 'vue';
+import { useNamespace } from '@flash-global66/g-utils';
+import { useIdInjection } from '@flash-global66/g-hooks';
+import { collapseContextKey } from './constants';
 
-import type { CollapseItemProps } from './collapse-item'
+import type { CollapseItemProps } from './collapse-item';
 
 export const useCollapseItem = (props: CollapseItemProps) => {
-  const collapse = inject(collapseContextKey)
-  const { namespace } = useNamespace('collapse')
+  const collapse = inject(collapseContextKey);
+  const { namespace } = useNamespace('collapse');
 
-  const focusing = ref(false)
-  const isClick = ref(false)
-  const idInjection = useIdInjection()
-  const id = computed(() => idInjection.current++)
+  const focusing = ref(false);
+  const isClick = ref(false);
+  const idInjection = useIdInjection();
+  const id = computed(() => idInjection.current++);
   const name = computed(() => {
-    return props.name ?? `${namespace.value}-id-${idInjection.prefix}-${unref(id)}`
-  })
+    return (
+      props.name ?? `${namespace.value}-id-${idInjection.prefix}-${unref(id)}`
+    );
+  });
 
-  const isActive = computed(() => collapse?.activeNames.value.includes(unref(name)))
+  const isActive = computed(() =>
+    collapse?.activeNames.value.includes(unref(name)),
+  );
 
   const iconsLeft = computed(() => {
     return [
@@ -25,14 +30,14 @@ export const useCollapseItem = (props: CollapseItemProps) => {
             {
               icon: 'regular angle-right',
               onClick: () => {
-                collapse?.handleItemClick(unref(name))
-              }
-            }
+                collapse?.handleItemClick(unref(name));
+              },
+            },
           ]
         : []),
-      ...(props.iconsLeft || [])
-    ]
-  })
+      ...(props.iconsLeft || []),
+    ];
+  });
 
   const iconsRight = computed(() => {
     return [
@@ -41,19 +46,22 @@ export const useCollapseItem = (props: CollapseItemProps) => {
             {
               icon: 'regular angle-right',
               onClick: () => {
-                collapse?.handleItemClick(unref(name))
-              }
-            }
+                collapse?.handleItemClick(unref(name));
+              },
+            },
           ]
         : []),
-      ...(props.iconsRight || [])
-    ].slice().reverse()
-  })
+      ...(props.iconsRight || []),
+    ]
+      .slice()
+      .reverse();
+  });
 
   const content = computed(() => {
-    const isString = typeof props.content === 'string'
-    return isString ? props.content : props.content?.() || ''
-  })
+    return typeof props.content === 'string'
+      ? props.content
+      : props.content?.() || '';
+  });
 
   const slotProps = computed(() => ({
     isActive: isActive.value,
@@ -63,42 +71,42 @@ export const useCollapseItem = (props: CollapseItemProps) => {
     disabled: props.disabled,
     headerOnly: props.headerOnly,
     expandIconPosition: props.expandIconPosition,
-      hideIcon: props.hideIcon,
+    hideIcon: props.hideIcon,
     iconsLeft: iconsLeft.value,
     iconsRight: iconsRight.value,
-    focusing: focusing.value
-  }))
+    focusing: focusing.value,
+  }));
 
   const handleFocus = () => {
     setTimeout(() => {
       if (!isClick.value) {
-        focusing.value = true
+        focusing.value = true;
       } else {
-        isClick.value = false
+        isClick.value = false;
       }
-    }, 50)
-  }
+    }, 50);
+  };
 
   const handleHeaderClick = () => {
-    if (props.disabled) return
-    
+    if (props.disabled) return;
+
     if (props.headerOnly) {
-      collapse?.handleHeaderOnlyClick?.(unref(name))
+      collapse?.handleHeaderOnlyClick?.(unref(name));
     } else {
-      collapse?.handleItemClick(unref(name))
+      collapse?.handleItemClick(unref(name));
     }
 
-    focusing.value = false
-    isClick.value = true
-  }
+    focusing.value = false;
+    isClick.value = true;
+  };
 
   const handleEnterClick = () => {
     if (props.headerOnly) {
-      collapse?.handleHeaderOnlyClick?.(unref(name))
+      collapse?.handleHeaderOnlyClick?.(unref(name));
     } else {
-      collapse?.handleItemClick(unref(name))
+      collapse?.handleItemClick(unref(name));
     }
-  }
+  };
 
   return {
     focusing,
@@ -111,37 +119,46 @@ export const useCollapseItem = (props: CollapseItemProps) => {
     iconsRight,
     content,
     name,
-    slotProps
-  }
-}
+    slotProps,
+  };
+};
 
 export const useCollapseItemDOM = (
   props: CollapseItemProps,
-  { focusing, isActive, id }: Partial<ReturnType<typeof useCollapseItem>>
+  { focusing, isActive, id }: Partial<ReturnType<typeof useCollapseItem>>,
 ) => {
-  const ns = useNamespace('collapse')
+  const ns = useNamespace('collapse');
 
   const rootKls = computed(() => [
     ns.b('item'),
     ns.is('active', unref(isActive)),
-    ns.is('disabled', props.disabled)
-  ])
+    ns.is('disabled', props.disabled),
+  ]);
   const headKls = computed(() => [
     ns.be('item', 'header'),
     ns.is('active', unref(isActive)),
-    { focusing: unref(focusing) && !props.disabled }
-  ])
-  const iconsLeftKls = computed(() => [ns.bem('item', 'header', 'icon-left')])
-  const iconsRightKls = computed(() => [ns.bem('item', 'header', 'icon-right')])
-  const contentHeaderKls = computed(() => [ns.bem('item', 'header', 'content')])
-  const arrowKls = computed(() => [ns.be('item', 'arrow'), ns.is('active', unref(isActive))])
-  const itemTitleKls = computed(() => [ns.be('item', 'title')])
-  const itemDescriptionKls = computed(() => [ns.be('item', 'description')])
-  const contentHeaderTextKls = computed(() => [ns.bem('item', 'header', 'text')])
-  const itemWrapperKls = computed(() => ns.be('item', 'wrap'))
-  const itemContentKls = computed(() => ns.be('item', 'content'))
-  const scopedContentId = computed(() => ns.b(`content-${unref(id)}`))
-  const scopedHeadId = computed(() => ns.b(`head-${unref(id)}`))
+    { focusing: unref(focusing) && !props.disabled },
+  ]);
+  const iconsLeftKls = computed(() => [ns.bem('item', 'header', 'icon-left')]);
+  const iconsRightKls = computed(() => [
+    ns.bem('item', 'header', 'icon-right'),
+  ]);
+  const contentHeaderKls = computed(() => [
+    ns.bem('item', 'header', 'content'),
+  ]);
+  const arrowKls = computed(() => [
+    ns.be('item', 'arrow'),
+    ns.is('active', unref(isActive)),
+  ]);
+  const itemTitleKls = computed(() => [ns.be('item', 'title')]);
+  const itemDescriptionKls = computed(() => [ns.be('item', 'description')]);
+  const contentHeaderTextKls = computed(() => [
+    ns.bem('item', 'header', 'text'),
+  ]);
+  const itemWrapperKls = computed(() => ns.be('item', 'wrap'));
+  const itemContentKls = computed(() => ns.be('item', 'content'));
+  const scopedContentId = computed(() => ns.b(`content-${unref(id)}`));
+  const scopedHeadId = computed(() => ns.b(`head-${unref(id)}`));
 
   return {
     itemTitleKls,
@@ -156,6 +173,6 @@ export const useCollapseItemDOM = (
     iconsLeftKls,
     iconsRightKls,
     contentHeaderKls,
-    contentHeaderTextKls
-  }
-}
+    contentHeaderTextKls,
+  };
+};

--- a/components/collapse/src/use-collapse.ts
+++ b/components/collapse/src/use-collapse.ts
@@ -1,102 +1,117 @@
-import { computed, provide, ref, watch } from 'vue'
+import { computed, provide, ref, watch } from 'vue';
 import {
   debugWarn,
   ensureArray,
   isBoolean,
   isPromise,
-  throwError
-} from 'element-plus/es/utils/index'
-import { useNamespace, CHANGE_EVENT, UPDATE_MODEL_EVENT } from 'element-plus'
-import { collapseContextKey } from './constants'
+  throwError,
+  useNamespace,
+  CHANGE_EVENT,
+  UPDATE_MODEL_EVENT,
+} from '@flash-global66/g-utils';
+import { collapseContextKey } from './constants';
 
-import type { SetupContext } from 'vue'
-import type { CollapseActiveName, CollapseEmits, CollapseProps } from './collapse'
+import type { SetupContext } from 'vue';
+import type {
+  CollapseActiveName,
+  CollapseEmits,
+  CollapseProps,
+} from './collapse';
 
-const SCOPE = 'GCollapse'
-export const useCollapse = (props: CollapseProps, emit: SetupContext<CollapseEmits>['emit']) => {
-  const activeNames = ref(ensureArray(props.modelValue))
+const SCOPE = 'GCollapse';
+export const useCollapse = (
+  props: CollapseProps,
+  emit: SetupContext<CollapseEmits>['emit'],
+) => {
+  const activeNames = ref(ensureArray(props.modelValue));
 
   const setActiveNames = (_activeNames: CollapseActiveName[]) => {
-    activeNames.value = _activeNames
-    const value = props.accordion ? activeNames.value[0] : activeNames.value
-    emit(UPDATE_MODEL_EVENT, value)
-    emit(CHANGE_EVENT, value)
-  }
+    activeNames.value = _activeNames;
+    const value = props.accordion ? activeNames.value[0] : activeNames.value;
+    emit(UPDATE_MODEL_EVENT, value);
+    emit(CHANGE_EVENT, value);
+  };
 
   const handleChange = (name: CollapseActiveName) => {
     if (props.accordion) {
-      setActiveNames([activeNames.value[0] === name ? '' : name])
+      setActiveNames([activeNames.value[0] === name ? '' : name]);
     } else {
-      const _activeNames = [...activeNames.value]
-      const index = _activeNames.indexOf(name)
+      const _activeNames = [...activeNames.value];
+      const index = _activeNames.indexOf(name);
 
       if (index > -1) {
-        _activeNames.splice(index, 1)
+        _activeNames.splice(index, 1);
       } else {
-        _activeNames.push(name)
+        _activeNames.push(name);
       }
-      setActiveNames(_activeNames)
+      setActiveNames(_activeNames);
     }
-  }
+  };
 
   const handleItemClick = async (name: CollapseActiveName) => {
-    const { beforeCollapse } = props
+    const { beforeCollapse } = props;
     if (!beforeCollapse) {
-      handleChange(name)
-      return
+      handleChange(name);
+      return;
     }
 
-    const shouldChange = beforeCollapse(name)
-    const isPromiseOrBool = [isPromise(shouldChange), isBoolean(shouldChange)].includes(true)
+    const shouldChange = beforeCollapse(name);
+    const isPromiseOrBool = [
+      isPromise(shouldChange),
+      isBoolean(shouldChange),
+    ].includes(true);
     if (!isPromiseOrBool) {
-      throwError(SCOPE, 'beforeCollapse must return type `Promise<boolean>` or `boolean`')
+      throwError(
+        SCOPE,
+        'beforeCollapse must return type `Promise<boolean>` or `boolean`',
+      );
     }
 
     if (isPromise(shouldChange)) {
       shouldChange
-        .then((result) => {
+        .then(result => {
           if (result !== false) {
-            handleChange(name)
+            handleChange(name);
           }
         })
-        .catch((e) => {
-          debugWarn(SCOPE, `some error occurred: ${e}`)
-        })
+        .catch(e => {
+          debugWarn(SCOPE, `some error occurred: ${e}`);
+        });
     } else if (shouldChange) {
-      handleChange(name)
+      handleChange(name);
     }
-  }
+  };
 
   const handleHeaderOnlyClick = (name: CollapseActiveName) => {
-    emit('header-click', name)
-  }
+    emit('header-click', name);
+  };
 
   watch(
     () => props.modelValue,
     () => (activeNames.value = ensureArray(props.modelValue)),
-    { deep: true }
-  )
+    { deep: true },
+  );
 
   provide(collapseContextKey, {
     activeNames,
     handleItemClick,
-    handleHeaderOnlyClick
-  })
+    handleHeaderOnlyClick,
+  });
   return {
     activeNames,
-    setActiveNames
-  }
-}
+    setActiveNames,
+  };
+};
 
 export const useCollapseDOM = (props: CollapseProps) => {
-  const ns = useNamespace('collapse')
+  const ns = useNamespace('collapse');
 
-  const rootKls = computed(() => [ns.b()])
+  const rootKls = computed(() => [ns.b()]);
 
   return {
     rootKls,
     expandIconPosition: computed(() => {
-      return props.expandIconPosition
-    })
-  }
-}
+      return props.expandIconPosition;
+    }),
+  };
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -1024,7 +1024,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@flash-global66/g-collapse-transition@workspace:components/collapse-transition":
+"@flash-global66/g-collapse-transition@npm:^0.2.13, @flash-global66/g-collapse-transition@workspace:components/collapse-transition":
   version: 0.0.0-use.local
   resolution: "@flash-global66/g-collapse-transition@workspace:components/collapse-transition"
   dependencies:
@@ -1038,11 +1038,13 @@ __metadata:
 "@flash-global66/g-collapse@workspace:components/collapse":
   version: 0.0.0-use.local
   resolution: "@flash-global66/g-collapse@workspace:components/collapse"
+  dependencies:
+    "@flash-global66/g-collapse-transition": "npm:^0.2.13"
+    "@flash-global66/g-hooks": "npm:^0.11.4"
+    "@flash-global66/g-icon-font": "npm:^0.25.15"
+    "@flash-global66/g-utils": "npm:^0.12.0"
   peerDependencies:
-    "@flash-global66/g-collapse-transition": ^0.0.1
-    "@flash-global66/g-icon-font": ^0.10.0
     element-plus: ^2.9.0
-    lodash-unified: ^1.0.3
     vue: ^3.2.0
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
## ep-extraction-v5 · WU-3 · collapse

Third slice of **ep-extraction-v5**. Migrates \`components/collapse\` off element-plus internals and adds one new shared type to \`g-utils\`.

### Changes
- **New g-utils type**: \`Awaitable<T> = Promise<T> | T\` in \`common/g-utils/src/types/utils.type.ts\` (byte-exact from element-plus \`es/utils/typescript.d.ts\`, Spanish JSDoc). Consumed by collapse's \`beforeCollapse\` prop; exported via the g-utils barrel.
- **Repoint → \`@flash-global66/g-utils\`**: \`buildProps\`, \`definePropType\`, \`isArray\`, \`isNumber\`, \`isString\`, \`mutable\`, \`ensureArray\`, \`isBoolean\`, \`isPromise\`, \`debugWarn\`, \`throwError\`, \`CHANGE_EVENT\`, \`UPDATE_MODEL_EVENT\`, \`useNamespace\`, \`withInstall\`, \`withNoopInstall\`, types \`Arrayable\`/\`SFCWithInstall\`.
- **Repoint → \`@flash-global66/g-hooks\`**: \`useIdInjection\`.
- Removed dead \`iconPropType\` import.
- **Narrowing fix** (\`use-collapse-item.ts\` \`content\` computed): DS \`buildProps\` (\`WritableProps<T>\`, PR #258) types \`props.content\` precisely as \`string | (() => string)\`, so the old intermediate \`isString\` boolean no longer narrowed \`props.content?.()\` → TS2349. Inlined the \`typeof\` check so TS narrows the else-branch. **Runtime behavior unchanged.**
- **package.json**: all 4 \`@flash\` packages in \`dependencies\` with current ranges (fixes stale \`g-icon-font ^0.10.0\` → \`^0.25.15\` and \`g-collapse-transition ^0.0.1\` → \`^0.2.13\`), drops unused \`lodash-unified\` peer. \`element-plus\`+\`vue\` stay peers.

### Verification
- \`eslint --max-warnings 0\` on all 6 changed source files: clean.
- \`vue-tsc\`: no real type errors (only environmental TS7016 + a pre-existing g-collapse-transition exports-resolution note present on main too).
- No \`from 'element-plus'\` JS import survives (only scss \`@use\`).
- \`Awaitable\` port diffed byte-for-byte against node_modules element-plus.
- Fresh-context adversarial review: APPROVE (verified narrowing behavior-equivalence + byte-exact port).