### PR TITLE
chore(eslint): enforce element-plus import guard on migrated v5 packages

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -39,17 +39,10 @@ module.exports = {
         'components/form-item/**',
         'components/skeleton/**',
         'components/infinite-scroll/**',
-        // Deferred: need hooks/utilities outside this change's scope
-        // (useAriaProps, usePopper*, useSizeProp, useFormSize,
-        // useSameTarget, useEscapeKeydown, iconPropType) or embed a real
-        // element-plus component. (useLocale ported in WU-8/select —
-        // dropdown/date-picker/time-picker/table should re-point to
-        // @flash-global66/g-hooks instead of re-implementing.)
+        // Not yet migrated off element-plus internals; the guard stays
+        // lifted until it is ported. (ep-extraction-v5 migrated pagination,
+        // input-number, collapse and table — now guarded above.)
         'components/toast/**',
-        'components/table/**',
-        'components/pagination/**',
-        'components/input-number/**',
-        'components/collapse/**',
       ],
       rules: {
         'no-restricted-imports': [


### PR DESCRIPTION
## ep-extraction-v5 · eslint guard closeout

Now that all four v5 components (#271 pagination, #272 input-number, #273 collapse, #274 table) are migrated off element-plus internals and merged, remove them from the EP-guard \`excludedFiles\` in \`.eslintrc.cjs\` so the \`no-restricted-imports(element-plus)\` rule **enforces** they never reintroduce a direct element-plus dependency.

### Why a separate PR
The four v5 WUs deliberately left \`.eslintrc.cjs\` untouched to avoid a merge-conflict cascade across the stacked PRs (all four would have edited the same \`excludedFiles\` block — the exact conflict that bit v4's WU-12/WU-13). Consolidating the removal here, after all four are on main, is conflict-free.

### Changes
- Drop \`components/pagination/**\`, \`components/input-number/**\`, \`components/collapse/**\`, \`components/table/**\` from \`excludedFiles\`.
- Keep \`components/toast/**\` excluded (not yet migrated).
- Wrapper islands (badge, menu, config-provider, popover, radio-group, form-item, skeleton, infinite-scroll) remain excluded by design.

### Verification
- eslint on all four components under the new config: **zero** \`no-restricted-imports\`/element-plus violations.
- No real \`from 'element-plus'\` JS import remains in any of the four (only \`@use "element-plus/theme-chalk/..."\` in styled-component scss, which the JS-import guard does not cover).