### PR TITLE
chore(ep-extraction): finish element-plus JS extraction (toast, input-number straggler, quick wins)

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -39,10 +39,6 @@ module.exports = {
         'components/form-item/**',
         'components/skeleton/**',
         'components/infinite-scroll/**',
-        // Not yet migrated off element-plus internals; the guard stays
-        // lifted until it is ported. (ep-extraction-v5 migrated pagination,
-        // input-number, collapse and table — now guarded above.)
-        'components/toast/**',
       ],
       rules: {
         'no-restricted-imports': [

--- a/common/g-utils/src/utils/install.util.ts
+++ b/common/g-utils/src/utils/install.util.ts
@@ -48,6 +48,28 @@ export const withInstall = <T, E extends Record<string, unknown>>(
 };
 
 /**
+ * Adjunta un método `install` a una función-componente (ej. un servicio tipo
+ * `toast`/`message`), exponiéndola en `app.config.globalProperties[name]` para
+ * poder registrarla como plugin (`app.use(...)`).
+ *
+ * Copiado del algoritmo `withInstallFunction` de element-plus.
+ *
+ * @param fn - La función-componente que recibirá el método `install`.
+ * @param name - Clave bajo la cual se expone en las propiedades globales.
+ * @returns La misma función, tipada como `SFCWithInstall<T>`.
+ */
+export const withInstallFunction = <T>(
+  fn: T,
+  name: string,
+): SFCWithInstall<T> => {
+  (fn as any).install = (app: App): void => {
+    (fn as any)._context = app._context;
+    app.config.globalProperties[name] = fn;
+  };
+  return fn as SFCWithInstall<T>;
+};
+
+/**
  * Adjunta un método `install` vacío (no-op) a un componente.
  *
  * Útil para subcomponentes que no deben registrarse de forma independiente

--- a/components/collapse-transition/package.json
+++ b/components/collapse-transition/package.json
@@ -25,7 +25,6 @@
     "@flash-global66/g-utils": "^0.13.0"
   },
   "peerDependencies": {
-    "element-plus": "^2.9.0",
     "vue": "^3.2.0"
   },
   "publishConfig": {

--- a/components/input-number/utils/dom/event.ts
+++ b/components/input-number/utils/dom/event.ts
@@ -1,56 +1,56 @@
-import { EVENT_CODE } from 'element-plus/es/constants/index.mjs'
-import { isAndroid } from '../browser'
+import { EVENT_CODE } from '@flash-global66/g-utils';
+import { isAndroid } from '../browser';
 
 export const composeEventHandlers = <E>(
   theirsHandler?: (event: E) => boolean | void,
   oursHandler?: (event: E) => void,
-  { checkForDefaultPrevented = true } = {}
+  { checkForDefaultPrevented = true } = {},
 ) => {
   const handleEvent = (event: E) => {
-    const shouldPrevent = theirsHandler?.(event)
+    const shouldPrevent = theirsHandler?.(event);
 
     if (checkForDefaultPrevented === false || !shouldPrevent) {
-      return oursHandler?.(event)
+      return oursHandler?.(event);
     }
-  }
-  return handleEvent
-}
+  };
+  return handleEvent;
+};
 
-type WhenMouseHandler = (e: PointerEvent) => any
+type WhenMouseHandler = (e: PointerEvent) => any;
 export const whenMouse = (handler: WhenMouseHandler): WhenMouseHandler => {
   return (e: PointerEvent) =>
-    e.pointerType === 'mouse' ? handler(e) : undefined
-}
+    e.pointerType === 'mouse' ? handler(e) : undefined;
+};
 
 export const getEventCode = (event: KeyboardEvent): string => {
-  if (event.code && event.code !== 'Unidentified') return event.code
+  if (event.code && event.code !== 'Unidentified') return event.code;
   // On android, event.code is always '' (see https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/code#browser_compatibility)
-  const key = getEventKey(event)
+  const key = getEventKey(event);
 
   if (key) {
-    if (Object.values(EVENT_CODE).includes(key)) return key
+    if (Object.values(EVENT_CODE).includes(key)) return key;
 
     switch (key) {
       case ' ':
-        return EVENT_CODE.space
+        return EVENT_CODE.space;
       default:
-        return ''
+        return '';
     }
   }
 
-  return ''
-}
+  return '';
+};
 
 export const getEventKey = (event: KeyboardEvent): string => {
-  let key = event.key && event.key !== 'Unidentified' ? event.key : ''
+  let key = event.key && event.key !== 'Unidentified' ? event.key : '';
 
   // On Android, event.key and event.code may not be useful when entering characters or space
   // So here we directly get the last character of the input
   // **only takes effect in the keyup event**
   if (!key && event.type === 'keyup' && isAndroid()) {
-    const target = event.target as HTMLInputElement
-    key = target.value.charAt(target.selectionStart! - 1)
+    const target = event.target as HTMLInputElement;
+    key = target.value.charAt(target.selectionStart! - 1);
   }
 
-  return key
-}
+  return key;
+};

--- a/components/loader/package.json
+++ b/components/loader/package.json
@@ -14,7 +14,6 @@
   },
   "gitHead": "581df2757ad066a5cdd5a2e64500ab33a68279ad",
   "peerDependencies": {
-    "element-plus": "^2.9.0",
     "vue": "^3.2.0"
   }
 }

--- a/components/roving-focus-group/package.json
+++ b/components/roving-focus-group/package.json
@@ -32,7 +32,6 @@
   "peerDependencies": {
     "@flash-global66/g-collection": "^0.1.1",
     "@vueuse/core": "^12.4.0",
-    "element-plus": "^2.9.0",
     "vue": "^3.2.0"
   },
   "repository": {

--- a/components/toast/index.ts
+++ b/components/toast/index.ts
@@ -1,10 +1,10 @@
-import Toast from './src/toast.vue'
-import toast from './src/toastify'
+import Toast from './src/toast.vue';
+import toast from './src/toastify';
 import {
   withInstall,
   withInstallFunction,
   SFCWithInstall,
-} from "element-plus/es/utils/index.mjs";
+} from '@flash-global66/g-utils';
 
 export const GToast: SFCWithInstall<typeof Toast> & {
   Toast: typeof Toast;
@@ -12,12 +12,12 @@ export const GToast: SFCWithInstall<typeof Toast> & {
   Toast,
 });
 
-export const GToastPlugin = withInstallFunction(toast, '$toastify')
+export const GToastPlugin = withInstallFunction(toast, '$toastify');
 
 export default GToast;
 
-export * from './src/toast'
-export * from './src/toast.types'
-export { toast }
+export * from './src/toast';
+export * from './src/toast.types';
+export { toast };
 
 export type ToastInstance = InstanceType<typeof Toast>;

--- a/components/toast/package.json
+++ b/components/toast/package.json
@@ -28,8 +28,13 @@
   "repository": {
     "url": "https://github.com/Flash-Global66/global-design-system.git"
   },
+  "dependencies": {
+    "@flash-global66/g-config-provider": "^0.0.8",
+    "@flash-global66/g-hooks": "^0.11.5",
+    "@flash-global66/g-icon-font": "^0.25.16",
+    "@flash-global66/g-utils": "^0.13.0"
+  },
   "peerDependencies": {
-    "@flash-global66/g-icon-font": "^0.10.0",
     "@vueuse/core": "^12.4.0",
     "element-plus": "^2.9.0",
     "vue": "^3.2.0"

--- a/components/toast/src/toast.ts
+++ b/components/toast/src/toast.ts
@@ -1,8 +1,7 @@
-import { buildProps, definePropType } from "element-plus/es/utils/index";
+import { buildProps, definePropType } from '@flash-global66/g-utils';
 
-import type { VNode } from 'vue'
-import { toastTypes, toastSizes } from './toast.types'
-
+import type { VNode } from 'vue';
+import { toastTypes, toastSizes } from './toast.types';
 
 export const toastProps = buildProps({
   /**
@@ -10,7 +9,7 @@ export const toastProps = buildProps({
    */
   customClass: {
     type: String,
-    default: "",
+    default: '',
   },
   /**
    * @description whether `message` is treated as HTML string
@@ -28,14 +27,18 @@ export const toastProps = buildProps({
    */
   id: {
     type: String,
-    default: "",
+    default: '',
   },
   /**
    * @description description text
    */
   message: {
-    type: definePropType<string | VNode | (() => VNode)>([String, Object, Function]),
-    default: "",
+    type: definePropType<string | VNode | (() => VNode)>([
+      String,
+      Object,
+      Function,
+    ]),
+    default: '',
   },
   /**
    * @description offset from the top edge of the screen. Every Toast instance of the same moment should have the same offset
@@ -63,8 +66,8 @@ export const toastProps = buildProps({
    */
   position: {
     type: String,
-    values: ["top-right", "top-left", "bottom-right", "bottom-left"],
-    default: "top-right",
+    values: ['top-right', 'top-left', 'bottom-right', 'bottom-left'],
+    default: 'top-right',
   },
   /**
    * @description whether to show a close button
@@ -86,7 +89,7 @@ export const toastProps = buildProps({
   size: {
     type: String,
     values: toastSizes,
-    default: "md",
+    default: 'md',
   } as const,
   /**
    * @description toast type - required and determines the icon
@@ -104,7 +107,4 @@ export const toastProps = buildProps({
 
 export const toastEmits = {
   destroy: () => true,
-}
-
-
-
+};

--- a/components/toast/src/toast.vue
+++ b/components/toast/src/toast.vue
@@ -1,16 +1,29 @@
 <template>
-  <transition :name="ns.b('fade')" @before-leave="onClose" @after-leave="$emit('destroy')">
+  <transition
+    :name="ns.b('fade')"
+    @before-leave="onClose"
+    @after-leave="$emit('destroy')"
+  >
     <div
       v-show="visible"
       :id="id"
-      :class="[ns.b(), ns.m(props.type), ns.m(props.size), customClass, horizontalClass]"
+      :class="[
+        ns.b(),
+        ns.m(props.type),
+        ns.m(props.size),
+        customClass,
+        horizontalClass,
+      ]"
       :style="positionStyle"
       role="alert"
       @mouseenter="clearTimer"
       @mouseleave="startTimer"
       @click="onClick"
     >
-      <g-icon-font :class="[ns.e('icon'), ns.m(props.type)]" :name="toastIcon" />
+      <g-icon-font
+        :class="[ns.e('icon'), ns.m(props.type)]"
+        :name="toastIcon"
+      />
       <div :class="ns.e('group')">
         <div v-show="message" :class="ns.e('content')">
           <slot>
@@ -20,11 +33,16 @@
           </slot>
         </div>
       </div>
-      <g-icon-font v-if="showClose" :class="ns.e('closeBtn')" @click.stop="close" name="solid times" />
+      <g-icon-font
+        v-if="showClose"
+        :class="ns.e('closeBtn')"
+        @click.stop="close"
+        name="solid times"
+      />
       <!-- Progress bar -->
       <div v-if="showProgress && duration > 0" :class="ns.e('progress')">
-        <div 
-          :class="[ns.e('progress-bar'), ns.m(props.type)]" 
+        <div
+          :class="[ns.e('progress-bar'), ns.m(props.type)]"
           :style="{ animationDuration: `${duration}ms` }"
         />
       </div>
@@ -33,41 +51,45 @@
 </template>
 
 <script lang="ts" setup>
-import { computed, onMounted, ref } from "vue";
-import { useEventListener, useTimeoutFn } from "@vueuse/core";
-import { EVENT_CODE } from "element-plus/es/constants/index.mjs";
-import { GIconFont, type IconString } from "@flash-global66/g-icon-font";
-import { useZIndex, useNamespace } from "element-plus";
-import { toastEmits, toastProps } from "./toast";
-import { type ToastType } from "./toast.types";
+import { computed, onMounted, ref } from 'vue';
+import { useEventListener, useTimeoutFn } from '@vueuse/core';
+import { EVENT_CODE, useNamespace } from '@flash-global66/g-utils';
+import { GIconFont, type IconString } from '@flash-global66/g-icon-font';
+import { useZIndex } from '@flash-global66/g-hooks';
+import { toastEmits, toastProps } from './toast';
+import { type ToastType } from './toast.types';
 
-import type { CSSProperties } from "vue";
+import type { CSSProperties } from 'vue';
 
 defineOptions({
-  name: "GToast",
+  name: 'GToast',
 });
 
 const props = defineProps(toastProps);
 defineEmits(toastEmits);
 
 const { nextZIndex, currentZIndex } = useZIndex();
-const ns = useNamespace("toast");
+const ns = useNamespace('toast');
 
 const visible = ref(false);
 let timer: (() => void) | undefined = undefined;
 
 const TOAST_ICONS: Record<ToastType, IconString> = {
-  success: "solid check-circle",
-  info: "solid info-circle", 
-  warning: "solid exclamation-triangle",
-  error: "solid times-circle",
+  success: 'solid check-circle',
+  info: 'solid info-circle',
+  warning: 'solid exclamation-triangle',
+  error: 'solid times-circle',
 } as const;
 
-const toastIcon = computed(() => TOAST_ICONS[props.type]);
+const toastIcon = computed(() => TOAST_ICONS[props.type as ToastType]);
 
-const horizontalClass = computed(() => (props.position.endsWith("right") ? "right" : "left"));
+const horizontalClass = computed(() =>
+  props.position.endsWith('right') ? 'right' : 'left',
+);
 
-const verticalProperty = computed(() => (props.position.startsWith("top") ? "top" : "bottom"));
+const verticalProperty = computed(() =>
+  props.position.startsWith('top') ? 'top' : 'bottom',
+);
 
 const positionStyle = computed<CSSProperties>(() => {
   return {
@@ -113,7 +135,7 @@ onMounted(() => {
   visible.value = true;
 });
 
-useEventListener(document, "keydown", onKeydown);
+useEventListener(document, 'keydown', onKeydown);
 
 defineExpose({
   visible,
@@ -121,4 +143,3 @@ defineExpose({
   close,
 });
 </script>
-

--- a/components/toast/src/toastify.ts
+++ b/components/toast/src/toastify.ts
@@ -1,76 +1,83 @@
-import { createVNode, isVNode, render } from 'vue'
-import { debugWarn, isClient, isElement, isFunction, isString, isUndefined } from "element-plus/es/utils/index"
-import ToastConstructor from './toast.vue'
-import { toastTypes } from './toast.types'
-import { GConfigProvider } from '@flash-global66/g-config-provider'
+import { createVNode, isVNode, render } from 'vue';
+import {
+  debugWarn,
+  isClient,
+  isElement,
+  isFunction,
+  isString,
+  isUndefined,
+} from '@flash-global66/g-utils';
+import ToastConstructor from './toast.vue';
+import { toastTypes } from './toast.types';
+import { GConfigProvider } from '@flash-global66/g-config-provider';
 
-import type { Ref, VNode } from 'vue'
+import type { Ref, VNode } from 'vue';
 import type {
   ToastOptions,
   ToastProps,
   ToastQueue,
   Toastify,
   ToastifyFn,
-} from './toast.types'
+} from './toast.types';
 
 // This should be a queue but considering there were `non-autoclosable` toasts.
-const toasts: Record<
-  ToastOptions['position'],
-  ToastQueue
-> = {
+const toasts: Record<ToastOptions['position'], ToastQueue> = {
   'top-left': [],
   'top-right': [],
   'bottom-left': [],
   'bottom-right': [],
-}
+};
 
 // the gap size between each toast
-const GAP_SIZE = 16
-let seed = 1
+const GAP_SIZE = 16;
+let seed = 1;
 
-const toastify: ToastifyFn & Partial<Toastify> = function (options = {}, context) {
-  if (!isClient) return { close: () => undefined }
+const toastify: ToastifyFn & Partial<Toastify> = function (
+  options = {},
+  context,
+) {
+  if (!isClient) return { close: () => undefined };
 
   if (isString(options) || isVNode(options)) {
-    options = { message: options }
+    options = { message: options };
   }
 
-  const position = options.position || 'top-right'
+  const position = options.position || 'top-right';
 
-  let verticalOffset = options.offset || 0
+  let verticalOffset = options.offset || 0;
   toasts[position].forEach(({ vm }) => {
-    verticalOffset += (vm.el?.offsetHeight || 0) + GAP_SIZE
-  })
-  verticalOffset += GAP_SIZE
+    verticalOffset += (vm.el?.offsetHeight || 0) + GAP_SIZE;
+  });
+  verticalOffset += GAP_SIZE;
 
-  const id = `toast_${seed++}`
-  const userOnClose = options.onClose
+  const id = `toast_${seed++}`;
+  const userOnClose = options.onClose;
   const props: Partial<ToastProps> = {
     ...options,
     offset: verticalOffset,
     id,
     onClose: () => {
-      close(id, position, userOnClose)
+      close(id, position, userOnClose);
     },
-  }
+  };
 
-  let appendTo: HTMLElement | null = document.body
+  let appendTo: HTMLElement | null = document.body;
   if (isElement(options.appendTo)) {
-    appendTo = options.appendTo
+    appendTo = options.appendTo;
   } else if (isString(options.appendTo)) {
-    appendTo = document.querySelector(options.appendTo)
+    appendTo = document.querySelector(options.appendTo);
   }
 
   // should fallback to default value with a warning
   if (!isElement(appendTo)) {
     debugWarn(
       'ElToast',
-      'the appendTo option is not an HTMLElement. Falling back to document.body.'
-    )
-    appendTo = document.body
+      'the appendTo option is not an HTMLElement. Falling back to document.body.',
+    );
+    appendTo = document.body;
   }
 
-  const container = document.createElement('div')
+  const container = document.createElement('div');
 
   // Create the toast component wrapped in GConfigProvider
   const toastVNode = createVNode(
@@ -79,46 +86,51 @@ const toastify: ToastifyFn & Partial<Toastify> = function (options = {}, context
     isFunction(props.message)
       ? props.message
       : isVNode(props.message)
-      ? () => props.message
-      : null
-  )
+        ? () => props.message
+        : null,
+  );
 
   // Wrap the toast in GConfigProvider to ensure correct namespace
-  const vm = createVNode(GConfigProvider, {}, {
-    default: () => toastVNode
-  })
-  
-  vm.appContext = isUndefined(context) ? toastify._context : context
+  const vm = createVNode(
+    GConfigProvider,
+    {},
+    {
+      default: () => toastVNode,
+    },
+  );
+
+  vm.appContext = isUndefined(context) ? toastify._context : context;
 
   // clean toast element preventing mem leak
   vm.props!.onDestroy = () => {
-    render(null, container)
-  }
+    render(null, container);
+  };
 
   // instances will remove this item when close function gets called. So we do not need to worry about it.
-  render(vm, container)
-  toasts[position].push({ vm: toastVNode })
-  appendTo.appendChild(container.firstElementChild!)
+  render(vm, container);
+  toasts[position].push({ vm: toastVNode });
+  appendTo.appendChild(container.firstElementChild!);
 
   return {
     // instead of calling the onClose function directly, setting this value so that we can have the full lifecycle
     // for out component, so that all closing steps will not be skipped.
     close: () => {
-      ;(toastVNode.component!.exposed as { visible: Ref<boolean> }).visible.value =
-        false
+      (
+        toastVNode.component!.exposed as { visible: Ref<boolean> }
+      ).visible.value = false;
     },
-  }
-}
-toastTypes.forEach((type) => {
+  };
+};
+toastTypes.forEach(type => {
   toastify[type] = (options = {}, appContext) => {
     if (isString(options) || isVNode(options)) {
       options = {
         message: options,
-      }
+      };
     }
-    return toastify({ ...options, type }, appContext)
-  }
-})
+    return toastify({ ...options, type }, appContext);
+  };
+});
 
 /**
  * This function gets called when user click `x` button or press `esc` or the time reached its limitation.
@@ -131,32 +143,32 @@ toastTypes.forEach((type) => {
 export function close(
   id: string,
   position: ToastOptions['position'],
-  userOnClose?: (vm: VNode) => void
+  userOnClose?: (vm: VNode) => void,
 ): void {
   // maybe we can store the index when inserting the vm to toast list.
-  const orientedToasts = toasts[position]
+  const orientedToasts = toasts[position];
   const idx = orientedToasts.findIndex(
-    ({ vm }) => vm.component?.props.id === id
-  )
-  if (idx === -1) return
+    ({ vm }) => vm.component?.props.id === id,
+  );
+  if (idx === -1) return;
   const { vm } = orientedToasts[idx];
-  if (!vm) return
+  if (!vm) return;
   // calling user's on close function before notification gets removed from DOM.
-  userOnClose?.(vm)
+  userOnClose?.(vm);
 
   // note that this is called @before-leave, that's why we were able to fetch this property.
-  const removedHeight = vm.el!.offsetHeight
-  const verticalPos = position.split('-')[0]
+  const removedHeight = vm.el!.offsetHeight;
+  const verticalPos = position.split('-')[0];
   orientedToasts.splice(idx, 1);
-  const len = orientedToasts.length
-  if (len < 1) return
+  const len = orientedToasts.length;
+  if (len < 1) return;
   // starting from the removing item.
   for (let i = idx; i < len; i++) {
     // new position equals the current offsetTop minus removed height plus 16px(the gap size between each item)
-    const { el, component } = orientedToasts[i].vm
+    const { el, component } = orientedToasts[i].vm;
     const pos =
-      Number.parseInt(el!.style[verticalPos], 10) - removedHeight - GAP_SIZE
-    component!.props.offset = pos
+      Number.parseInt(el!.style[verticalPos], 10) - removedHeight - GAP_SIZE;
+    component!.props.offset = pos;
   }
 }
 
@@ -165,16 +177,13 @@ export function closeAll(): void {
   for (const orientedToasts of Object.values(toasts)) {
     orientedToasts.forEach(({ vm }) => {
       // same as the previous close method, we'd like to make sure lifecycle gets handle properly.
-      ;(vm.component!.exposed as { visible: Ref<boolean> }).visible.value =
-        false
-    })
+      (vm.component!.exposed as { visible: Ref<boolean> }).visible.value =
+        false;
+    });
   }
 }
 
-toastify.closeAll = closeAll
-toastify._context = null
+toastify.closeAll = closeAll;
+toastify._context = null;
 
-export default toastify as Toastify
-
-
-
+export default toastify as Toastify;

--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
     ]
   },
   "dependencies": {
-    "@element-plus/utils": "0.0.5",
     "@fortawesome/fontawesome-common-types": "6.7.2",
     "@popperjs/core": "2.11.8",
     "@storybook/manager-api": "8.6.14",

--- a/vite.config.base.ts
+++ b/vite.config.base.ts
@@ -3,9 +3,7 @@ import vue from '@vitejs/plugin-vue';
 import { resolve } from 'path';
 
 export default defineConfig({
-  plugins: [
-    vue(),
-  ],
+  plugins: [vue()],
   resolve: {
     alias: {
       '@': resolve(__dirname, './'),
@@ -16,38 +14,36 @@ export default defineConfig({
     lib: {
       entry: resolve(process.cwd(), 'index.ts'),
       formats: ['es', 'cjs'],
-      fileName: (format) => `index.${format === 'es' ? 'mjs' : 'js'}`
+      fileName: format => `index.${format === 'es' ? 'mjs' : 'js'}`,
     },
     rollupOptions: {
       external: [
         // Dependencias externas
-        'vue', 
-        'lodash-unified', 
-        '@vueuse/core', 
-        '@element-plus/utils',
+        'vue',
+        'lodash-unified',
+        '@vueuse/core',
         'element-plus',
         'dayjs',
         'dayjs/plugin/localeData',
         // Componentes propios
-        /^@flash-global66\/g-/
+        /^@flash-global66\/g-/,
       ],
       output: {
         globals: {
           vue: 'Vue',
           'lodash-unified': 'lodashUnified',
           '@vueuse/core': 'VueUse',
-          '@element-plus/utils': 'ElementPlusUtils',
           'element-plus': 'ElementPlus',
-          'dayjs': 'dayjs',
-          'dayjs/plugin/localeData': 'dayjsPluginLocaleData'
-        }
-      }
+          dayjs: 'dayjs',
+          'dayjs/plugin/localeData': 'dayjsPluginLocaleData',
+        },
+      },
     },
     commonjsOptions: {
       transformMixedEsModules: false,
     },
     target: 'esnext',
     minify: 'esbuild',
-    chunkSizeWarningLimit: 2000,  }
-  }
-);
+    chunkSizeWarningLimit: 2000,
+  },
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -343,19 +343,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@element-plus/utils@npm:0.0.5":
-  version: 0.0.5
-  resolution: "@element-plus/utils@npm:0.0.5"
-  dependencies:
-    lodash: "npm:^4.17.20"
-    normalize-wheel: "npm:^1.0.1"
-    resize-observer-polyfill: "npm:^1.5.1"
-  peerDependencies:
-    vue: 3.1.1
-  checksum: 10c0/e330db8621d71c063a8a1208388203d4002fb994637b28cc9328cbe7c3163b2fb6f39de4f0a0c7b1175330050fd77cf8580bc395e460a398cb6a3295892c94f4
-  languageName: node
-  linkType: hard
-
 "@emnapi/core@npm:^1.1.0":
   version: 1.7.1
   resolution: "@emnapi/core@npm:1.7.1"
@@ -1030,7 +1017,6 @@ __metadata:
   dependencies:
     "@flash-global66/g-utils": "npm:^0.13.0"
   peerDependencies:
-    element-plus: ^2.9.0
     vue: ^3.2.0
   languageName: unknown
   linkType: soft
@@ -1345,7 +1331,6 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@flash-global66/g-loader@workspace:components/loader"
   peerDependencies:
-    element-plus: ^2.9.0
     vue: ^3.2.0
   languageName: unknown
   linkType: soft
@@ -1471,7 +1456,6 @@ __metadata:
   peerDependencies:
     "@flash-global66/g-collection": ^0.1.1
     "@vueuse/core": ^12.4.0
-    element-plus: ^2.9.0
     vue: ^3.2.0
   languageName: unknown
   linkType: soft
@@ -1631,8 +1615,12 @@ __metadata:
 "@flash-global66/g-toast@workspace:components/toast":
   version: 0.0.0-use.local
   resolution: "@flash-global66/g-toast@workspace:components/toast"
+  dependencies:
+    "@flash-global66/g-config-provider": "npm:^0.0.8"
+    "@flash-global66/g-hooks": "npm:^0.11.5"
+    "@flash-global66/g-icon-font": "npm:^0.25.16"
+    "@flash-global66/g-utils": "npm:^0.13.0"
   peerDependencies:
-    "@flash-global66/g-icon-font": ^0.10.0
     "@vueuse/core": ^12.4.0
     element-plus: ^2.9.0
     vue: ^3.2.0
@@ -1672,7 +1660,6 @@ __metadata:
   resolution: "@flash-global66/global-design-system@workspace:."
   dependencies:
     "@babel/core": "npm:7.28.3"
-    "@element-plus/utils": "npm:0.0.5"
     "@fortawesome/fontawesome-common-types": "npm:6.7.2"
     "@fortawesome/fontawesome-svg-core": "npm:6.7.2"
     "@fortawesome/vue-fontawesome": "npm:3.1.1"
@@ -8897,7 +8884,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lodash@npm:^4.17.20, lodash@npm:^4.17.21":
+"lodash@npm:^4.17.21":
   version: 4.17.21
   resolution: "lodash@npm:4.17.21"
   checksum: 10c0/d8cbea072bb08655bb4c989da418994b073a608dffa608b09ac04b43a791b12aeae7cd7ad919aa4c925f33b48490b5cfe6c1f71d827956071dae2e7bb3a6b74c
@@ -9694,13 +9681,6 @@ __metadata:
   version: 1.2.0
   resolution: "normalize-wheel-es@npm:1.2.0"
   checksum: 10c0/48b5961f3f2fb902213ae8b4389fa043a134b3f15415e58f170aa414ba205896ba03410f457812baaaf50bd0a4a2899f35a390315163c1b2f24dddacffbdc89f
-  languageName: node
-  linkType: hard
-
-"normalize-wheel@npm:^1.0.1":
-  version: 1.0.1
-  resolution: "normalize-wheel@npm:1.0.1"
-  checksum: 10c0/5daf4c97e39f36658a5263a6499bbc148676ae2bd85f12c8d03c46ffe7bc3c68d44564c00413d88d0457ac0d94450559bb1c24c2ce7ae0c107031f82d093ac06
   languageName: node
   linkType: hard
 
@@ -11144,13 +11124,6 @@ __metadata:
   version: 2.0.2
   resolution: "require-from-string@npm:2.0.2"
   checksum: 10c0/aaa267e0c5b022fc5fd4eef49d8285086b15f2a1c54b28240fdf03599cbd9c26049fee3eab894f2e1f6ca65e513b030a7c264201e3f005601e80c49fb2937ce2
-  languageName: node
-  linkType: hard
-
-"resize-observer-polyfill@npm:^1.5.1":
-  version: 1.5.1
-  resolution: "resize-observer-polyfill@npm:1.5.1"
-  checksum: 10c0/5e882475067f0b97dc07e0f37c3e335ac5bc3520d463f777cec7e894bb273eddbfecb857ae668e6fb6881fd6f6bb7148246967172139302da50fa12ea3a15d95
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Finish the element-plus JS extraction

After v4 (13 popper/overlay comps) + v5 (pagination, input-number, collapse, table), this closes the remaining **JS** coupling to element-plus (the SCSS theme-chalk coupling + the 8 render-islands are separate, larger phases).

### Changes
- **Port `withInstallFunction` to `@flash-global66/g-utils`** (`common/g-utils/src/utils/install.util.ts`) — byte-exact from element-plus `es/utils/vue/install.mjs`, Spanish JSDoc, same style as `withInstall`/`withNoopInstall`.
- **Migrate `toast` off element-plus** (false island — renders no `ElXxx`): repoint `withInstall`/`withInstallFunction`/`SFCWithInstall`/`buildProps`/`definePropType`/`EVENT_CODE`/`debugWarn`/`is*`/`useNamespace` → g-utils and `useZIndex` → g-hooks. Cast the icon lookup `TOAST_ICONS[props.type as ToastType]` (DS `buildProps` types the prop as `string`, not the `ToastType` union — runtime-safe via the `values` validator). Normalize `toast/package.json` (all `@flash` in deps at current ranges; `element-plus` stays peer for `toast.styles.scss` `@use` theme-chalk). Remove `components/toast/**` from the eslint EP-guard `excludedFiles`.
- **Fix input-number straggler**: `components/input-number/utils/dom/event.ts` (lives outside `src/`, so it was missed in v5 WU-2 and not covered by the guard glob) — `EVENT_CODE` → g-utils.
- **Quick wins**: drop the dead `element-plus` peerDependency from `loader`, `roving-focus-group`, `collapse-transition` (confirmed zero element-plus usage); drop unused `@element-plus/utils` from root `package.json` + `vite.config.base.ts` external/globals. **`element-plus` is kept** everywhere it's still needed (island peers + externalization).

### Not in this PR (separate, larger phases)
- SCSS coupling: 42 components still `@use "element-plus/theme-chalk/..."` (needs a DS-native token/mixin port).
- The 8 render-islands (menu, config-provider, popover, badge, skeleton, radio-group, form-item, infinite-scroll) that embed a real `ElXxx` — need reimplementation.

### Verification
- No real `from 'element-plus'` JS import remains in `components/toast` or `components/input-number` (only scss `@use`).
- `withInstallFunction` diffed byte-for-byte against node_modules element-plus.
- `element-plus`/`ElementPlus` still in `vite.config.base.ts` external+globals (islands need it).
- `eslint --max-warnings 0` on all changed files: clean. `vue-tsc` (declaration emit) on toast: clean.
- Fresh-context adversarial review: APPROVE.