### PR TITLE
refactor(styles): repoint 8 components off element-plus (ep-extraction-scss WU3 G1)

### DIFF
--- a/common/g-utils/package.json
+++ b/common/g-utils/package.json
@@ -13,6 +13,7 @@
     "./base": "./styles/base.scss",
     "./function": "./styles/function.scss",
     "./utils": "./styles/utils.scss",
+    "./var-mixins": "./styles/var-mixins.scss",
     "./transition": "./styles/transition.scss",
     "./icon": "./styles/icon.scss"
   },

--- a/components/attach-file/src/attach-file.styles.scss
+++ b/components/attach-file/src/attach-file.styles.scss
@@ -1,9 +1,9 @@
 @use "sass:map";
 
-@use "element-plus/theme-chalk/src/mixins/mixins" as *;
-@use "element-plus/theme-chalk/src/mixins/utils" as *;
-@use "element-plus/theme-chalk/src/mixins/var" as *;
-@use "element-plus/theme-chalk/src/common/var" as *;
+@use "@flash-global66/g-utils/mixins" as *;
+@use "@flash-global66/g-utils/utils" as *;
+@use "@flash-global66/g-utils/var-mixins" as *;
+@use "@flash-global66/g-utils/tokens" as *;
 
 @include b('attach-file') {
   @apply w-full;

--- a/components/chip/src/chip.styles.scss
+++ b/components/chip/src/chip.styles.scss
@@ -1,9 +1,9 @@
 @use "sass:map";
 
-@use 'element-plus/theme-chalk/src/mixins/mixins' as *;
-@use 'element-plus/theme-chalk/src/mixins/utils' as *;
-@use 'element-plus/theme-chalk/src/mixins/var' as *;
-@use 'element-plus/theme-chalk/src/common/var' as *;
+@use '@flash-global66/g-utils/mixins' as *;
+@use '@flash-global66/g-utils/utils' as *;
+@use '@flash-global66/g-utils/var-mixins' as *;
+@use '@flash-global66/g-utils/tokens' as *;
 
 @include b('chip') {
   @apply flex items-center justify-center w-min font-medium select-none transition-all duration-200 cursor-pointer;

--- a/components/country-flag/src/country-flag.styles.scss
+++ b/components/country-flag/src/country-flag.styles.scss
@@ -1,8 +1,8 @@
 @use 'sass:map';
-@use 'element-plus/theme-chalk/src/mixins/mixins' as *;
-@use 'element-plus/theme-chalk/src/mixins/utils' as *;
-@use 'element-plus/theme-chalk/src/mixins/var' as *;
-@use 'element-plus/theme-chalk/src/common/var' as *;
+@use '@flash-global66/g-utils/mixins' as *;
+@use '@flash-global66/g-utils/utils' as *;
+@use '@flash-global66/g-utils/var-mixins' as *;
+@use '@flash-global66/g-utils/tokens' as *;
 
 @include b(country-flag) {
   @apply block object-contain w-full h-full max-w-full max-h-full;

--- a/components/icon-button/src/icon-button.styles.scss
+++ b/components/icon-button/src/icon-button.styles.scss
@@ -1,8 +1,8 @@
 @use "sass:map";
-@use "element-plus/theme-chalk/src/mixins/mixins" as *;
-@use "element-plus/theme-chalk/src/mixins/utils" as *;
-@use "element-plus/theme-chalk/src/mixins/var" as *;
-@use "element-plus/theme-chalk/src/common/var" as *;
+@use "@flash-global66/g-utils/mixins" as *;
+@use "@flash-global66/g-utils/utils" as *;
+@use "@flash-global66/g-utils/var-mixins" as *;
+@use "@flash-global66/g-utils/tokens" as *;
 
 @mixin ripple-animation(
   $duration: 0.6s,

--- a/components/image/src/image.styles.scss
+++ b/components/image/src/image.styles.scss
@@ -1,8 +1,8 @@
 @use 'sass:map';
-@use 'element-plus/theme-chalk/src/mixins/mixins' as *;
-@use 'element-plus/theme-chalk/src/mixins/utils' as *;
-@use 'element-plus/theme-chalk/src/mixins/var' as *;
-@use 'element-plus/theme-chalk/src/common/var' as *;
+@use '@flash-global66/g-utils/mixins' as *;
+@use '@flash-global66/g-utils/utils' as *;
+@use '@flash-global66/g-utils/var-mixins' as *;
+@use '@flash-global66/g-utils/tokens' as *;
 
 @include b(image) {
   @apply block object-contain w-full h-full max-w-full max-h-full;

--- a/components/inline/src/inline.styles.scss
+++ b/components/inline/src/inline.styles.scss
@@ -1,9 +1,9 @@
 @use "sass:map";
 
-@use "element-plus/theme-chalk/src/mixins/mixins" as *;
-@use "element-plus/theme-chalk/src/mixins/utils" as *;
-@use "element-plus/theme-chalk/src/mixins/var" as *;
-@use "element-plus/theme-chalk/src/common/var" as *;
+@use "@flash-global66/g-utils/mixins" as *;
+@use "@flash-global66/g-utils/utils" as *;
+@use "@flash-global66/g-utils/var-mixins" as *;
+@use "@flash-global66/g-utils/tokens" as *;
 
 @include b("inline") {
   $transition-bezier: cubic-bezier(0.42, 0, 0.58, 1);

--- a/components/link/src/link.styles.scss
+++ b/components/link/src/link.styles.scss
@@ -1,9 +1,9 @@
 @use "sass:map";
 
-@use "element-plus/theme-chalk/src/mixins/mixins" as *;
-@use "element-plus/theme-chalk/src/mixins/utils" as *;
-@use "element-plus/theme-chalk/src/mixins/var" as *;
-@use "element-plus/theme-chalk/src/common/var" as *;
+@use "@flash-global66/g-utils/mixins" as *;
+@use "@flash-global66/g-utils/utils" as *;
+@use "@flash-global66/g-utils/var-mixins" as *;
+@use "@flash-global66/g-utils/tokens" as *;
 
 @include b(link) {
   @apply inline-flex flex-row items-center justify-center;

--- a/components/logo/src/logo.styles.scss
+++ b/components/logo/src/logo.styles.scss
@@ -1,8 +1,8 @@
 @use 'sass:map';
-@use 'element-plus/theme-chalk/src/mixins/mixins' as *;
-@use 'element-plus/theme-chalk/src/mixins/utils' as *;
-@use 'element-plus/theme-chalk/src/mixins/var' as *;
-@use 'element-plus/theme-chalk/src/common/var' as *;
+@use '@flash-global66/g-utils/mixins' as *;
+@use '@flash-global66/g-utils/utils' as *;
+@use '@flash-global66/g-utils/var-mixins' as *;
+@use '@flash-global66/g-utils/tokens' as *;
 
 @include b(logo) {
   @apply block object-contain max-w-full max-h-full;

--- a/scripts/scss-parity/baseline/attach-file.css
+++ b/scripts/scss-parity/baseline/attach-file.css
@@ -1,0 +1,279 @@
+/* Element Chalk Variables */
+.gui-attach-file {
+  @apply w-full;
+}
+.gui-attach-file__drop-zone {
+  @apply relative border-2 border-dashed border-secondary-bd rounded-lg p-2xl text-center transition-colors duration-200;
+}
+.gui-attach-file__drop-zone:hover:not(.gui-attach-file__drop-zone.is-disabled):not(.gui-attach-file__drop-zone.is-dragging) {
+  @apply border-primary-bd;
+}
+.gui-attach-file__drop-zone.is-dragging {
+  @apply border-primary-def bg-sec-def-bg shadow-lg;
+  transform: scale(1.05);
+  transition: transform 0.2s ease-in-out, box-shadow 0.2s ease-in-out;
+}
+
+.gui-attach-file__drop-zone.is-disabled {
+  @apply opacity-50 cursor-not-allowed;
+}
+
+.gui-attach-file__text-content {
+  @apply space-y-xs;
+}
+
+.gui-attach-file__main-text {
+  @apply text-secondary-txt;
+}
+
+.gui-attach-file__file-input {
+  @apply hidden;
+}
+
+.gui-attach-file__file-list {
+  @apply space-y-xs bg-sec-def-bg rounded-sm;
+}
+.gui-attach-file__item {
+  @apply flex items-center gap-xs;
+}
+.gui-attach-file__item:last-child {
+  @apply mb-0;
+}
+
+.gui-attach-file__item-content {
+  @apply flex items-center flex-1 gap-xs min-w-0;
+}
+
+.gui-attach-file__file-status-icon {
+  @apply w-lg h-lg flex items-center justify-center;
+}
+.gui-attach-file__icon {
+  @apply flex-shrink-0 text-3;
+}
+.gui-attach-file__icon.is-success {
+  @apply text-success-def;
+}
+
+.gui-attach-file__icon.is-error {
+  @apply text-error-def;
+}
+
+.gui-attach-file__icon.is-loading {
+  @apply text-primary-def;
+}
+
+.gui-attach-file__file-name {
+  @apply truncate flex-1 text-secondary-txt text-2;
+}
+.gui-attach-file__file-name.is-error {
+  @apply text-error-def;
+}
+
+.gui-attach-file__file-name.is-success {
+  @apply text-secondary-txt;
+}
+
+.gui-attach-file__item-actions {
+  @apply flex items-center gap-xs;
+}
+
+.gui-attach-file__file-size {
+  @apply text-disab-lt-txt text-2;
+}
+
+.gui-attach-file__file-list--clean {
+  @apply mt-xs;
+}
+.gui-attach-file__file-list--boxed {
+  @apply bg-sec-def-bg rounded-sm mt-lg py-sm px-md;
+}
+
+.gui-attach-file__default-state {
+  @apply flex w-full items-center py-sm px-md rounded-sm border border-grey-50 bg-sec-def-bg;
+}
+.gui-attach-file__content {
+  @apply flex flex-col flex-1 min-w-0;
+}
+
+.gui-attach-file__title {
+  @apply text-3 font-semibold leading-snug text-secondary-txt;
+}
+
+.gui-attach-file__info-text {
+  @apply text-2 font-medium text-disab-lt-txt;
+}
+
+.gui-attach-file__hidden-input {
+  @apply hidden;
+}
+
+.gui-attach-file__default-type {
+  @apply w-full;
+}
+
+.gui-attach-file__drag-drop-type {
+  @apply w-full;
+}
+.gui-attach-file__drop-zone {
+  @apply relative border-2 border-dashed border-primary-def rounded-lg p-2xl text-center transition-colors duration-200 bg-sec-def-bg;
+}
+.gui-attach-file__drop-zone.is-dragging {
+  @apply border-primary-def bg-sec-def-bg;
+}
+
+.gui-attach-file__drop-zone.is-disabled {
+  @apply opacity-50 cursor-not-allowed;
+}
+
+.gui-attach-file__drop-zone:hover:not(.is-disabled):not(.is-dragging):not(.is-error) {
+  @apply border-primary-bd;
+}
+
+.gui-attach-file__text-content {
+  @apply space-y-xs;
+}
+
+.gui-attach-file__main-text {
+  @apply text-secondary-txt text-5 font-medium;
+}
+
+.gui-attach-file__upload-button {
+  @apply text-primary-def hover:text-primary-def-hover font-bold focus:outline-none underline;
+}
+.gui-attach-file__upload-button:disabled {
+  @apply cursor-not-allowed opacity-50;
+}
+
+.gui-attach-file__restriction-text {
+  @apply text-3 text-terciary-txt;
+}
+
+.gui-attach-file__hidden-input {
+  @apply hidden;
+}
+
+.gui-attach-file__loading-state {
+  @apply flex w-full items-start py-sm px-md gap-md rounded-sm border border-grey-50 bg-sec-def-bg;
+}
+.gui-attach-file__content {
+  @apply flex flex-col flex-1 min-w-0;
+}
+
+.gui-attach-file__title {
+  @apply text-secondary-txt font-semibold text-3;
+}
+
+.gui-attach-file__info-text {
+  @apply text-disab-lt-txt text-2;
+}
+
+.gui-attach-file__progress-wrapper {
+  @apply pt-xs;
+}
+
+.gui-attach-file__file-info {
+  @apply flex items-center justify-between text-disab-lt-txt text-2 pt-xxs;
+}
+
+.gui-attach-file__file-name {
+  @apply truncate text-disab-lt-txt;
+}
+
+.gui-attach-file__file-size {
+  @apply ml-auto text-disab-lt-txt;
+}
+
+.gui-attach-file__files-list {
+  @apply pt-xxs;
+}
+
+.gui-attach-file__files-container {
+  @apply space-y-xs;
+}
+
+.gui-attach-file__file-item {
+  @apply flex items-center gap-xs;
+}
+
+.gui-attach-file__file-item-content {
+  @apply flex-1 min-w-0;
+}
+
+.gui-attach-file__file-item-progress {
+  @apply pt-xs;
+}
+
+.gui-attach-file__file-item-info {
+  @apply flex justify-between items-center text-disab-lt-txt text-2 pt-xxs;
+}
+
+.gui-attach-file__file-item-name {
+  @apply truncate;
+}
+
+.gui-attach-file__file-item-size {
+  @apply flex-shrink-0;
+}
+
+.gui-attach-file__content {
+  @apply w-full rounded-sm py-sm px-md border border-grey-50 bg-sec-def-bg;
+}
+.gui-attach-file__header {
+  @apply flex items-center justify-between gap-md;
+}
+
+.gui-attach-file__header-content {
+  @apply flex flex-col flex-1;
+}
+
+.gui-attach-file__title {
+  @apply text-secondary-txt text-3 font-semibold;
+}
+
+.gui-attach-file__info-text {
+  @apply text-disab-lt-txt text-2;
+}
+
+.gui-attach-file__download-link {
+  @apply text-everBlue-500 font-montserrat text-2 font-bold underline;
+}
+
+.gui-attach-file__extra-content {
+  @apply mt-sm;
+}
+
+.gui-attach-file__validation-errors {
+  @apply mt-xs;
+}
+.gui-attach-file__error-text {
+  @apply text-1 text-error-def font-medium;
+}
+
+.gui-attach-file__file-item {
+  animation: slideIn 0.2s ease-out;
+}
+
+@keyframes slideIn {
+  from {
+    opacity: 0;
+    transform: translateY(-10px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+@media (max-width: 640px) {
+  .gui-attach-file__drop-zone {
+    @apply p-6;
+  }
+  .gui-attach-file__upload-icon {
+    @apply h-10 w-10;
+  }
+  .gui-attach-file__file-item {
+    @apply p-xxs;
+  }
+  .gui-attach-file__file-actions {
+    @apply space-x-xxs;
+  }
+}

--- a/scripts/scss-parity/baseline/chip.css
+++ b/scripts/scss-parity/baseline/chip.css
@@ -1,0 +1,143 @@
+/* Element Chalk Variables */
+.gui-chip {
+  @apply flex items-center justify-center w-min font-medium select-none transition-all duration-200 cursor-pointer;
+  white-space: nowrap;
+}
+.gui-chip__sm {
+  @apply py-xxs px-sm text-2 gap-xxs rounded-full;
+}
+.gui-chip__sm--prefix-icon {
+  @apply w-3 h-3 flex justify-center items-center;
+}
+.gui-chip__sm--prefix-icon .g-icon-font {
+  @apply text-1 align-super;
+}
+
+.gui-chip__sm--suffix-icon {
+  @apply w-3 h-3 flex justify-center items-center;
+}
+.gui-chip__sm--suffix-icon .g-icon-font {
+  @apply text-1 align-super;
+}
+
+.gui-chip__md {
+  @apply py-xxs px-md text-3 gap-xxs rounded-full;
+}
+.gui-chip__md--prefix-icon {
+  @apply w-[14px] h-[14px] flex justify-center items-center;
+}
+.gui-chip__md--prefix-icon .g-icon-font {
+  @apply text-2 align-super;
+}
+
+.gui-chip__md--suffix-icon {
+  @apply w-[14px] h-[14px] flex justify-center items-center;
+}
+.gui-chip__md--suffix-icon .g-icon-font {
+  @apply text-2 align-super;
+}
+
+.gui-chip--primary {
+  @apply rounded-full;
+}
+
+.gui-chip--secondary {
+  @apply rounded;
+}
+
+.gui-chip--solid {
+  @apply bg-grey-100 text-primary-txt border-none;
+}
+.gui-chip--solid .g-icon-font {
+  @apply text-icon-primary;
+}
+.gui-chip--solid:hover {
+  @apply bg-nightBlue-200 text-primary-txt;
+}
+.gui-chip--solid:hover .g-icon-font {
+  @apply text-icon-primary;
+}
+.gui-chip--solid:active {
+  @apply bg-primary-def-press text-inverse-txt;
+}
+.gui-chip--solid:active .g-icon-font {
+  @apply text-icon-inverse;
+}
+.gui-chip--solid:disabled, .gui-chip--solid.is-disabled {
+  @apply bg-grey-50 text-disab-lt-txt pointer-events-none;
+}
+.gui-chip--solid:disabled .g-icon-font, .gui-chip--solid.is-disabled .g-icon-font {
+  @apply text-icon-disab-lt;
+}
+.gui-chip--solid.is-selected {
+  @apply bg-grey-100 text-primary-txt border-none;
+}
+.gui-chip--solid.is-selected .g-icon-font {
+  @apply text-icon-primary;
+}
+.gui-chip--solid.is-selected:hover {
+  @apply bg-nightBlue-200 text-primary-txt;
+}
+.gui-chip--solid.is-selected:hover .g-icon-font {
+  @apply text-icon-primary;
+}
+
+.gui-chip--outline {
+  @apply bg-transparent text-primary-txt border border-everBlue-200;
+}
+.gui-chip--outline .g-icon-font {
+  @apply text-icon-primary;
+}
+.gui-chip--outline:hover {
+  @apply bg-everBlue-100 text-primary-txt border-everBlue-100;
+}
+.gui-chip--outline:hover .g-icon-font {
+  @apply text-icon-primary;
+}
+.gui-chip--outline:focus-visible {
+  @apply bg-primary-def text-inverse-txt border-primary-def;
+}
+.gui-chip--outline:focus-visible .g-icon-font {
+  @apply text-icon-inverse;
+}
+.gui-chip--outline:active {
+  @apply bg-primary-def-press text-inverse-txt border-primary-def-press;
+}
+.gui-chip--outline:active .g-icon-font {
+  @apply text-icon-inverse;
+}
+.gui-chip--outline:disabled, .gui-chip--outline.is-disabled {
+  @apply bg-transparent text-disabled-txt border-disab-lt-bd pointer-events-none;
+}
+.gui-chip--outline:disabled .g-icon-font, .gui-chip--outline.is-disabled .g-icon-font {
+  @apply text-icon-disab-lt;
+}
+.gui-chip--outline.is-selected {
+  @apply bg-primary-def text-inverse-txt border-primary-def;
+}
+.gui-chip--outline.is-selected .g-icon-font {
+  @apply text-icon-inverse;
+}
+.gui-chip--outline.is-selected:hover {
+  @apply bg-primary-def-press text-inverse-txt border-primary-def-press;
+}
+.gui-chip--outline.is-selected:hover .g-icon-font {
+  @apply text-icon-inverse;
+}
+
+.gui-chip__content {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.gui-chip__close {
+  @apply m-0 ml-0 cursor-pointer !important;
+}
+.gui-chip__close:hover {
+  @apply bg-inherit text-inherit !important;
+}
+
+.gui-chip__dropdown-icon {
+  transition: transform 0.2s ease-in-out;
+}

--- a/scripts/scss-parity/baseline/country-flag.css
+++ b/scripts/scss-parity/baseline/country-flag.css
@@ -1,0 +1,23 @@
+/* Element Chalk Variables */
+.gui-country-flag {
+  @apply block object-contain w-full h-full max-w-full max-h-full;
+}
+.gui-country-flag__container {
+  @apply flex items-center justify-center box-border overflow-hidden rounded-full;
+}
+
+.gui-country-flag__placeholder {
+  @apply flex items-center justify-center bg-primary-bg rounded-full w-full h-full text-center p-2 text-terciary-txt;
+}
+.gui-country-flag__placeholder.text-size-xs, .gui-country-flag__placeholder.text-size-sm {
+  @apply text-2;
+}
+.gui-country-flag__placeholder.text-size-md {
+  @apply text-3;
+}
+.gui-country-flag__placeholder.text-size-lg, .gui-country-flag__placeholder.text-size-xl {
+  @apply text-4;
+}
+.gui-country-flag__placeholder.text-size-2xl, .gui-country-flag__placeholder.text-size-3xl {
+  @apply text-10;
+}

--- a/scripts/scss-parity/baseline/icon-button.css
+++ b/scripts/scss-parity/baseline/icon-button.css
@@ -1,0 +1,124 @@
+/* Element Chalk Variables */
+.gui-icon-button {
+  @apply rounded-full h-12 w-12 duration-200 relative;
+}
+.gui-icon-button.is-disabled {
+  @apply cursor-not-allowed;
+}
+
+.gui-icon-button--variant-grey {
+  @apply bg-transparent text-grey-500;
+}
+.gui-icon-button--variant-grey:hover:not(.is-disabled) .hover-effect {
+  @apply bg-grey-100;
+}
+.gui-icon-button--variant-grey:active:not(.is-disabled) .hover-effect {
+  @apply bg-grey-400;
+}
+.gui-icon-button--variant-grey.is-disabled {
+  @apply bg-transparent text-disabled-txt;
+}
+.gui-icon-button--variant-grey.gui-icon-button--border {
+  --color-border: theme(colors.grey.500);
+  border-color: var(--color-border);
+}
+
+.gui-icon-button--variant-black {
+  @apply bg-transparent text-grey-700;
+}
+.gui-icon-button--variant-black:hover:not(.is-disabled) .hover-effect {
+  @apply bg-grey-100;
+}
+.gui-icon-button--variant-black:active:not(.is-disabled) .hover-effect {
+  @apply bg-grey-400;
+}
+.gui-icon-button--variant-black.is-disabled {
+  @apply bg-transparent text-disabled-txt;
+}
+.gui-icon-button--variant-black.gui-icon-button--border {
+  --color-border: theme(colors.grey.700);
+  border-color: var(--color-border);
+}
+
+.gui-icon-button--variant-blue {
+  @apply bg-transparent text-primary-def;
+}
+.gui-icon-button--variant-blue:hover:not(.is-disabled) .hover-effect {
+  @apply bg-nightBlue-400;
+}
+.gui-icon-button--variant-blue:active:not(.is-disabled) .hover-effect {
+  @apply bg-nightBlue-700;
+}
+.gui-icon-button--variant-blue.is-disabled {
+  @apply bg-transparent text-disabled-txt;
+}
+.gui-icon-button--variant-blue.gui-icon-button--border {
+  --color-border: theme(colors.primary-def);
+  border-color: var(--color-border);
+}
+
+.gui-icon-button--border {
+  @apply rounded-sm border;
+}
+.gui-icon-button--border.is-disabled {
+  --color-border-disabled: theme(colors.grey.300);
+  border-color: var(--color-border-disabled);
+}
+.gui-icon-button--border .hover-effect {
+  @apply rounded-sm;
+}
+
+.gui-icon-button--rounded {
+  @apply rounded-full;
+}
+.gui-icon-button--rounded .hover-effect {
+  @apply rounded-full;
+}
+
+.gui-icon-button--small {
+  @apply h-8 w-8;
+}
+.gui-icon-button--small .gui-icon-button__icon {
+  height: 1em;
+  vertical-align: -0.2em;
+}
+
+.gui-icon-button--medium .gui-icon-button__icon {
+  height: 1.25em;
+  vertical-align: -0.3em;
+}
+
+.gui-icon-button:active .hover-effect {
+  @apply bg-primary-def-press;
+}
+.gui-icon-button:hover .hover-effect {
+  @apply w-full h-full;
+}
+
+.hover-effect {
+  @apply absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 w-0 h-0 rounded-full bg-center bg-opacity-20 opacity-20 ease-out;
+  transition: background 0.8s, width 0.4s, height 0.4s;
+}
+.gui-icon-button__ripple {
+  @apply absolute rounded-full pointer-events-none z-10 bg-white;
+  width: 100px;
+  height: 100px;
+  margin-left: -50px;
+  margin-top: -50px;
+  transform-origin: center;
+}
+
+@keyframes ripple-effect {
+  0% {
+    transform: scale(0);
+    opacity: 0.35;
+  }
+  100% {
+    transform: scale(2);
+    opacity: 0;
+  }
+}
+.ripple-enter-active,
+.ripple-leave-active {
+  animation: ripple-effect 0.6s ease-out forwards;
+}

--- a/scripts/scss-parity/baseline/image.css
+++ b/scripts/scss-parity/baseline/image.css
@@ -1,0 +1,23 @@
+/* Element Chalk Variables */
+.gui-image {
+  @apply block object-contain w-full h-full max-w-full max-h-full;
+}
+.gui-image__container {
+  @apply flex items-center justify-center box-border overflow-hidden;
+}
+
+.gui-image__placeholder {
+  @apply flex items-center justify-center bg-primary-bg rounded-sm w-full h-full text-center p-2 text-terciary-txt;
+}
+.gui-image__placeholder.text-size-xs, .gui-image__placeholder.text-size-sm {
+  @apply text-2;
+}
+.gui-image__placeholder.text-size-md {
+  @apply text-3;
+}
+.gui-image__placeholder.text-size-lg, .gui-image__placeholder.text-size-xl {
+  @apply text-4;
+}
+.gui-image__placeholder.text-size-xxl, .gui-image__placeholder.text-size-xxxl {
+  @apply text-10;
+}

--- a/scripts/scss-parity/baseline/inline.css
+++ b/scripts/scss-parity/baseline/inline.css
@@ -1,0 +1,142 @@
+/* Element Chalk Variables */
+.gui-inline {
+  @apply border rounded-md p-sm flex gap-xs items-center relative;
+}
+.gui-inline__title {
+  @apply text-3 font-semibold line-clamp-2 text-primary-txt mb-xxs;
+}
+
+.gui-inline__description {
+  @apply text-2 text-secondary-txt font-medium;
+}
+
+.gui-inline__links {
+  @apply flex items-center gap-xs mt-xs;
+}
+
+.gui-inline__link {
+  @apply text-2 underline text-grey-700 font-medium;
+}
+.gui-inline__link--arrow {
+  @apply font-semibold flex items-center gap-xs;
+  text-decoration: none;
+}
+
+.gui-inline__link-arrow {
+  @apply text-2;
+}
+
+.gui-inline__icon-fill {
+  display: flex;
+  min-width: 2rem;
+  min-height: 2rem;
+  padding: 0.25rem;
+  justify-content: center;
+  align-items: center;
+  gap: 0.625rem;
+  border-radius: 0.25rem;
+  background: rgba(236, 240, 249, 0.4);
+  flex-shrink: 0;
+}
+
+.gui-inline__icon {
+  @apply text-6;
+}
+
+.gui-inline__close {
+  @apply absolute right-xs top-xs cursor-pointer text-4 text-secondary-txt;
+}
+
+.gui-inline--fade-enter-active {
+  transition: all 0.4s cubic-bezier(0.42, 0, 0.58, 1);
+}
+
+.gui-inline--fade-leave-active {
+  transition: all 0.4s cubic-bezier(0.42, 0, 0.58, 1);
+}
+
+.gui-inline--fade-enter-from {
+  @apply opacity-0 -translate-y-5;
+}
+
+.gui-inline--fade-leave-to {
+  @apply opacity-0 -translate-y-5;
+}
+
+.gui-inline--md .gui-inline__title {
+  @apply text-4;
+}
+
+.gui-inline--md .gui-inline__description {
+  @apply text-3;
+}
+
+.gui-inline--shadow {
+  box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.12);
+}
+
+.gui-inline--no-border {
+  border: none;
+}
+
+.gui-inline--icon-align-top {
+  @apply items-start;
+}
+
+.gui-inline--icon-align-medium {
+  @apply items-center;
+}
+
+.gui-inline--icon-align-bottom {
+  @apply items-end;
+}
+
+.gui-inline--success {
+  @apply border-success-bd bg-success-bg;
+}
+.gui-inline--success .gui-inline__icon {
+  @apply text-success-txt;
+}
+
+.gui-inline--info {
+  @apply border-info-bd bg-info-bg;
+}
+.gui-inline--info .gui-inline__icon {
+  @apply text-info-txt;
+}
+
+.gui-inline--warning {
+  @apply border-warning-bd bg-warning-bg;
+}
+.gui-inline--warning .gui-inline__icon {
+  @apply text-warning-txt;
+}
+
+.gui-inline--error {
+  @apply border-error-bd bg-error-bg;
+}
+.gui-inline--error .gui-inline__icon {
+  @apply text-error-txt;
+}
+
+.gui-inline--card {
+  border: none;
+  border-radius: var(--Radius-md, 0.5rem);
+  background: var(--background-secondary, #FFF);
+  box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.12);
+}
+.gui-inline--card .gui-inline__title {
+  @apply text-grey-700;
+}
+
+.gui-inline--card .gui-inline__description {
+  @apply text-grey-500;
+}
+
+.gui-inline--card .gui-inline__icon {
+  @apply text-everBlue-500;
+}
+
+.gui-inline--card .gui-inline__link {
+  @apply text-everBlue-500;
+}

--- a/scripts/scss-parity/baseline/link.css
+++ b/scripts/scss-parity/baseline/link.css
@@ -1,0 +1,156 @@
+/* Element Chalk Variables */
+.gui-link {
+  @apply inline-flex flex-row items-center justify-center;
+  @apply relative no-underline outline-none;
+  @apply cursor-pointer p-0;
+  @apply font-semibold;
+  /* Size variations */
+}
+.gui-link.gui-link--sm {
+  @apply text-2;
+}
+.gui-link.gui-link--sm .gui-link__icon-right {
+  @apply text-3;
+}
+
+.gui-link.gui-link--md {
+  @apply text-3;
+}
+.gui-link.gui-link--md .gui-link__icon-right {
+  @apply text-3;
+}
+
+.gui-link.gui-link--lg {
+  @apply text-4;
+}
+.gui-link.gui-link--lg .gui-link__icon-right {
+  @apply text-7;
+}
+
+.gui-link__icon-left {
+  @apply flex items-center justify-center mr-xxs;
+}
+
+.gui-link__icon-right {
+  @apply flex items-center justify-center ml-xxs;
+}
+
+.gui-link__inner {
+  @apply inline-flex justify-center items-center;
+  @apply relative;
+}
+
+.gui-link.is-disabled {
+  @apply text-disabled-txt cursor-not-allowed;
+}
+.gui-link.is-disabled .gui-link__inner:after {
+  @apply border-disabled-bd;
+}
+
+.gui-link {
+  /* Primary link - everBlue color palette */
+}
+.gui-link.gui-link--primary {
+  @apply text-everBlue-500;
+}
+.gui-link.gui-link--primary:not(.is-disabled):hover {
+  @apply text-everBlue-700;
+}
+.gui-link.gui-link--primary:active {
+  @apply text-everBlue-400;
+}
+.gui-link.gui-link--primary {
+  /* Underline styles for primary links */
+}
+.gui-link.gui-link--primary.is-underline .gui-link__inner:after {
+  content: "";
+  @apply absolute left-0 right-0 h-0 bottom-0;
+  @apply border-b border-everBlue-500;
+}
+.gui-link.gui-link--primary.is-underline:hover .gui-link__inner:after {
+  @apply border-everBlue-700;
+}
+.gui-link.gui-link--primary.is-underline:active .gui-link__inner:after {
+  @apply border-everBlue-400;
+}
+
+.gui-link {
+  /* Secondary link - grey color palette */
+}
+.gui-link.gui-link--secondary {
+  @apply text-grey-700;
+}
+.gui-link.gui-link--secondary:not(.is-disabled):hover {
+  @apply text-grey-900;
+}
+.gui-link.gui-link--secondary:active {
+  @apply text-grey-500;
+}
+.gui-link.gui-link--secondary {
+  /* Underline styles for secondary links */
+}
+.gui-link.gui-link--secondary.is-underline .gui-link__inner:after {
+  content: "";
+  @apply absolute left-0 right-0 h-0 bottom-0;
+  @apply border-b border-grey-700;
+}
+.gui-link.gui-link--secondary.is-underline:hover .gui-link__inner:after {
+  @apply border-grey-900;
+}
+.gui-link.gui-link--secondary.is-underline:active .gui-link__inner:after {
+  @apply border-grey-500;
+}
+
+.gui-link {
+  /* Tertiary link - white color palette */
+}
+.gui-link.gui-link--tertiary {
+  @apply text-white;
+}
+.gui-link.gui-link--tertiary:not(.is-disabled):hover {
+  @apply text-nightBlue-200;
+}
+.gui-link.gui-link--tertiary:active {
+  @apply text-white;
+}
+.gui-link.gui-link--tertiary {
+  /* Underline styles for tertiary links */
+}
+.gui-link.gui-link--tertiary.is-underline .gui-link__inner:after {
+  content: "";
+  @apply absolute left-0 right-0 h-0 bottom-0;
+  @apply border-b border-white;
+}
+.gui-link.gui-link--tertiary.is-underline:hover .gui-link__inner:after {
+  @apply border-nightBlue-200;
+}
+.gui-link.gui-link--tertiary.is-underline:active .gui-link__inner:after {
+  @apply border-white;
+}
+
+.gui-link {
+  /* Inline status - For links within text */
+}
+.gui-link.gui-link--inline {
+  @apply text-secondary-txt;
+}
+.gui-link.gui-link--inline:hover {
+  @apply text-grey-400;
+}
+.gui-link.gui-link--inline:active {
+  @apply text-grey-600;
+}
+.gui-link.gui-link--inline {
+  /* Underline styles for inline links */
+}
+.gui-link.gui-link--inline.is-underline .gui-link__inner:after {
+  content: "";
+  @apply absolute left-0 right-0 h-0 bottom-0;
+  @apply border-b border-grey-700;
+}
+.gui-link.gui-link--inline.is-underline:hover .gui-link__inner:after {
+  @apply border-grey-400;
+}
+.gui-link.gui-link--inline.is-underline:active .gui-link__inner:after {
+  @apply border-grey-600;
+}

--- a/scripts/scss-parity/baseline/logo.css
+++ b/scripts/scss-parity/baseline/logo.css
@@ -1,0 +1,30 @@
+/* Element Chalk Variables */
+.gui-logo {
+  @apply block object-contain max-w-full max-h-full;
+}
+.gui-logo__container {
+  @apply flex items-center justify-center box-border;
+}
+
+.gui-logo__color {
+  @apply inline-block shrink-0;
+}
+
+.gui-logo__placeholder {
+  @apply flex items-center justify-center bg-primary-bg rounded-sm w-full h-full text-center p-2 text-terciary-txt font-medium leading-none;
+}
+.gui-logo__placeholder.text-size-2xs {
+  @apply text-1 p-0.5;
+}
+.gui-logo__placeholder.text-size-xs, .gui-logo__placeholder.text-size-sm {
+  @apply text-2;
+}
+.gui-logo__placeholder.text-size-md {
+  @apply text-3;
+}
+.gui-logo__placeholder.text-size-lg, .gui-logo__placeholder.text-size-xl {
+  @apply text-4;
+}
+.gui-logo__placeholder.text-size-2xl, .gui-logo__placeholder.text-size-3xl {
+  @apply text-10;
+}

--- a/scripts/scss-parity/targets.json
+++ b/scripts/scss-parity/targets.json
@@ -2,5 +2,13 @@
   "g-utils-base": "common/g-utils/styles/base.scss",
   "g-utils-utils": "common/g-utils/styles/utils.scss",
   "g-utils-tokens": "common/g-utils/styles/tokens.scss",
-  "config-provider": "components/config-provider/config.styles.scss"
+  "config-provider": "components/config-provider/config.styles.scss",
+  "chip": "components/chip/src/chip.styles.scss",
+  "country-flag": "components/country-flag/src/country-flag.styles.scss",
+  "link": "components/link/src/link.styles.scss",
+  "logo": "components/logo/src/logo.styles.scss",
+  "inline": "components/inline/src/inline.styles.scss",
+  "image": "components/image/src/image.styles.scss",
+  "icon-button": "components/icon-button/src/icon-button.styles.scss",
+  "attach-file": "components/attach-file/src/attach-file.styles.scss"
 }


### PR DESCRIPTION
## Qué

WU3 · Grupo 1 de **ep-extraction-scss**: repoint de los imports de mixins/tokens compartidos de 8 componentes single-file, de `element-plus/theme-chalk` a `@flash-global66/g-utils`. **Solo cambia el origen del import; la lógica de estilos no se toca.**

Componentes: `chip`, `country-flag`, `link`, `logo`, `inline`, `image`, `icon-button`, `attach-file`.

## Mapeo
- `mixins/mixins` → `g-utils/mixins`
- `mixins/utils` → `g-utils/utils`
- `mixins/var` → `g-utils/var-mixins`
- `common/var` → `g-utils/tokens`

Agrega el export faltante `./var-mixins` a `g-utils`.

## Verificación byte-exact
Cada archivo: la salida del repoint (g-utils, namespace `gui`) es **idéntica** a la del source element-plus compilado a namespace `gui` (WU1 ya probó que los módulos g-utils == EP byte a byte). Los 8 quedan como targets del harness de paridad con baseline. `yarn scss:parity` 12/12 OK. Sin cambio visual/API.

## Contexto
Parte de sacar el DS de element-plus. Base `main` (ya tiene WU1 g-utils + WU2 config-provider). Próximos grupos: form family, overlay/misc; luego pickers + full-component (WU4).