### PR TITLE
refactor(styles): repoint form family off element-plus (ep-extraction-scss WU3 G2)

### DIFF
--- a/components/form/src/form.styles.scss
+++ b/components/form/src/form.styles.scss
@@ -1,9 +1,9 @@
 @use "sass:map";
 
-@use "element-plus/theme-chalk/src/mixins/mixins" as *;
-@use "element-plus/theme-chalk/src/mixins/utils" as *;
-@use "element-plus/theme-chalk/src/mixins/var" as *;
-@use "element-plus/theme-chalk/src/common/var" as *;
+@use "@flash-global66/g-utils/mixins" as *;
+@use "@flash-global66/g-utils/utils" as *;
+@use "@flash-global66/g-utils/var-mixins" as *;
+@use "@flash-global66/g-utils/tokens" as *;
 
 @include b("form-item") {
   @include e("content-error") {

--- a/components/input/src/input.styles.scss
+++ b/components/input/src/input.styles.scss
@@ -1,9 +1,9 @@
 @use "sass:map";
 
-@use "element-plus/theme-chalk/src/mixins/mixins" as *;
-@use "element-plus/theme-chalk/src/mixins/utils" as *;
-@use "element-plus/theme-chalk/src/mixins/var" as *;
-@use "element-plus/theme-chalk/src/common/var" as *;
+@use "@flash-global66/g-utils/mixins" as *;
+@use "@flash-global66/g-utils/utils" as *;
+@use "@flash-global66/g-utils/var-mixins" as *;
+@use "@flash-global66/g-utils/tokens" as *;
 
 @include b("input") {
   @apply flex flex-col gap-xxs;

--- a/components/search-input/src/search-input.styles.scss
+++ b/components/search-input/src/search-input.styles.scss
@@ -1,9 +1,9 @@
 @use "sass:map";
 
-@use "element-plus/theme-chalk/src/mixins/mixins" as *;
-@use "element-plus/theme-chalk/src/mixins/utils" as *;
-@use "element-plus/theme-chalk/src/mixins/var" as *;
-@use "element-plus/theme-chalk/src/common/var" as *;
+@use "@flash-global66/g-utils/mixins" as *;
+@use "@flash-global66/g-utils/utils" as *;
+@use "@flash-global66/g-utils/var-mixins" as *;
+@use "@flash-global66/g-utils/tokens" as *;
 
 @include b(search-input) {
   @apply w-full;

--- a/components/switch/src/switch.styles.scss
+++ b/components/switch/src/switch.styles.scss
@@ -1,9 +1,9 @@
 @use 'sass:map';
 
-@use 'element-plus/theme-chalk/src/mixins/mixins' as *;
-@use 'element-plus/theme-chalk/src/mixins/utils' as *;
-@use 'element-plus/theme-chalk/src/mixins/var' as *;
-@use 'element-plus/theme-chalk/src/common/var' as *;
+@use '@flash-global66/g-utils/mixins' as *;
+@use '@flash-global66/g-utils/utils' as *;
+@use '@flash-global66/g-utils/var-mixins' as *;
+@use '@flash-global66/g-utils/tokens' as *;
 
 $switch-height: () !default;
 $switch-height: map.merge(

--- a/scripts/scss-parity/baseline/form.css
+++ b/scripts/scss-parity/baseline/form.css
@@ -1,0 +1,8 @@
+/* Element Chalk Variables */
+.gui-form-item__content-error {
+  min-height: 18px;
+}
+
+.gui-form-item__error {
+  @apply flex text-error-txt font-medium text-2 px-xs;
+}

--- a/scripts/scss-parity/baseline/input.css
+++ b/scripts/scss-parity/baseline/input.css
@@ -1,0 +1,141 @@
+/* Element Chalk Variables */
+.gui-input {
+  @apply flex flex-col gap-xxs;
+}
+.gui-input__wrapper {
+  @apply relative flex bg-white py-sm px-xs border border-disabled-bd rounded-md h-12;
+}
+
+.gui-input__label {
+  @apply absolute text-terciary-txt text-4 transition-all duration-200 ease-in font-medium;
+  top: 50%;
+  transform: translateY(-50%);
+}
+
+.gui-input__prefix-icon {
+  @apply pr-2;
+}
+
+.gui-input__sufix-icon {
+  @apply pl-2;
+}
+
+.gui-input.is-focus .gui-input__label {
+  @apply text-2 font-medium;
+  background: linear-gradient(180deg, transparent 40%, white 0);
+  top: 0;
+  transform: translateY(-50%);
+  padding: 0 2px;
+  left: 5px;
+}
+
+.gui-input.is-focus .gui-input__inner::placeholder {
+  @apply opacity-100;
+}
+
+.gui-input.is-complete .gui-input__label {
+  @apply text-2 font-medium;
+  background: linear-gradient(180deg, transparent 40%, white 0);
+  top: 0;
+  transform: translateY(-50%);
+  padding: 0 2px;
+  left: 5px;
+}
+
+.gui-input.is-complete .gui-input__inner::placeholder {
+  @apply opacity-100;
+}
+
+.gui-input.is-focus .gui-input__label {
+  @apply text-everBlue-500;
+}
+
+.gui-input.is-focus .gui-input__wrapper {
+  @apply border-everBlue-500;
+}
+
+.gui-input.is-focus .gui-input__inner {
+  @apply caret-everBlue-500;
+}
+
+.gui-input.is-complete .gui-input__label {
+  @apply text-secondary-txt;
+}
+
+.gui-input.is-complete .gui-input__wrapper {
+  @apply border-secondary-bd;
+}
+
+.gui-input.is-disabled .gui-input__label {
+  @apply text-disabled-txt;
+  background: linear-gradient(180deg, transparent 40%, #eff0f2 0);
+}
+
+.gui-input.is-disabled .gui-input__wrapper {
+  @apply bg-primary-def-disabled border-grey-400;
+}
+
+.gui-input.is-disabled .gui-input__inner {
+  @apply text-disabled-txt;
+}
+
+.gui-input.is-error .gui-input__label {
+  @apply text-error-txt;
+}
+
+.gui-input.is-error .gui-input__wrapper {
+  @apply border-error-bd;
+}
+
+.gui-input.is-error .gui-input__help {
+  @apply text-error-txt;
+}
+
+.gui-input.is-exceed .gui-input__help-count {
+  @apply text-error-txt;
+}
+
+.gui-input.is-event {
+  @apply cursor-pointer;
+}
+.gui-input.is-event .gui-input__inner {
+  @apply cursor-pointer;
+}
+
+.gui-input:not(.is-focus):not(.is-complete) .gui-input__inner::placeholder {
+  @apply opacity-0;
+}
+
+.gui-input:not(.is-focus):not(.is-complete):not(.is-label) .gui-input__inner::placeholder {
+  @apply opacity-100;
+}
+
+.gui-input__inner {
+  @apply w-full text-primary-txt font-medium text-4 appearance-none outline-none relative;
+}
+.gui-input__inner:focus {
+  @apply outline-none;
+}
+.gui-input__inner[type=password]::-ms-reveal {
+  @apply hidden;
+}
+.gui-input__inner::placeholder {
+  @apply transition-all duration-200 ease-in text-terciary-txt;
+}
+
+.gui-input__icon {
+  @apply text-6 text-grey-500 select-none w-5;
+}
+
+.gui-input__icon-password {
+  @apply cursor-pointer;
+}
+
+.gui-input__help {
+  @apply flex gap-xxs justify-between text-2 font-medium text-disabled-txt px-xs;
+  min-height: 18px;
+}
+
+.gui-input__help-text {
+  @apply line-clamp-2;
+}

--- a/scripts/scss-parity/baseline/search-input.css
+++ b/scripts/scss-parity/baseline/search-input.css
@@ -1,0 +1,34 @@
+/* Element Chalk Variables */
+.gui-search-input {
+  @apply w-full;
+}
+.gui-search-input__input .gui-input__icon {
+  @apply cursor-pointer;
+}
+
+.gui-search-input__icon-container {
+  @apply flex items-center justify-center w-5 h-5 cursor-pointer;
+}
+
+.gui-search-input__icon {
+  @apply text-grey-500;
+}
+
+.gui-search-input.is-preloading {
+  @apply pointer-events-none;
+}
+
+.gui-search-input.is-disabled {
+  @apply cursor-not-allowed;
+}
+.gui-search-input.is-disabled .gui-search-input__icon {
+  @apply cursor-not-allowed;
+}
+
+.gui-search-input.is-disabled .gui-input__inner {
+  @apply cursor-not-allowed;
+}
+
+.gui-search-input.is-loading .gui-input__inner {
+  @apply cursor-wait;
+}

--- a/scripts/scss-parity/baseline/switch.css
+++ b/scripts/scss-parity/baseline/switch.css
@@ -1,0 +1,165 @@
+/* Element Chalk Variables */
+.gui-switch {
+  --gui-switch-on-color: var(--gui-color-primary);
+  --gui-switch-off-color: var(--gui-border-color);
+}
+
+.gui-switch {
+  @apply inline-flex items-center relative text-3;
+  height: 30px;
+  vertical-align: middle;
+}
+.gui-switch__label {
+  @apply inline-block font-medium cursor-pointer text-secondary-txt;
+  transition: var(--gui-transition-duration-fast);
+  vertical-align: middle;
+}
+.gui-switch__label.is-active {
+  @apply text-primary-def;
+}
+
+.gui-switch__label--left {
+  @apply mr-2;
+}
+
+.gui-switch__label--right {
+  @apply ml-2;
+}
+
+.gui-switch__label * {
+  line-height: 1;
+  @apply inline-block;
+}
+.gui-switch__label .gui-icon {
+  height: inherit;
+}
+.gui-switch__label .gui-icon svg {
+  vertical-align: middle;
+}
+
+.gui-switch__input {
+  @apply absolute opacity-0;
+  width: 0;
+  height: 0;
+  margin: 0;
+}
+.gui-switch__input:focus-visible ~ .gui-switch__core {
+  @apply outline-2 outline-primary-def outline-offset-1;
+  outline-style: solid;
+}
+
+.gui-switch__core {
+  @apply inline-flex relative items-center border border-solid cursor-pointer;
+  border-radius: 15px;
+  min-width: 56px;
+  height: 30px;
+  border-color: var(--gui-switch-border-color, var(--gui-switch-off-color));
+  outline: none;
+  box-sizing: border-box;
+  background: var(--gui-switch-off-color);
+  @apply border-disab-lt-bd bg-disab-lt-bg;
+  transition: border-color var(--gui-transition-duration), background-color var(--gui-transition-duration);
+}
+.gui-switch__core .gui-switch__inner {
+  @apply w-full h-full flex justify-center items-center overflow-hidden;
+  transition: all var(--gui-transition-duration);
+  padding: 0 4px 0 calc(24px + 2px);
+}
+.gui-switch__core .gui-switch__inner .is-icon,
+.gui-switch__core .gui-switch__inner .is-text {
+  @apply text-xs text-white flex items-center justify-center;
+  user-select: none;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
+  flex-shrink: 1;
+}
+.gui-switch__core .gui-switch__action {
+  @apply absolute flex justify-center items-center bg-white;
+  left: 3px;
+  border-radius: var(--gui-border-radius-circle);
+  transition: all var(--gui-transition-duration);
+  width: 24px;
+  height: 24px;
+  @apply text-disab-lt-txt;
+}
+
+.gui-switch.is-checked .gui-switch__core {
+  @apply border-primary-bd bg-primary-def;
+}
+.gui-switch.is-checked .gui-switch__core .gui-switch__action {
+  left: calc(100% - 27px);
+  @apply text-primary-def;
+}
+.gui-switch.is-checked .gui-switch__core .gui-switch__inner {
+  padding: 0 calc(24px + 2px) 0 4px;
+}
+
+.gui-switch.is-disabled .gui-switch__core, .gui-switch.is-disabled .gui-switch__label {
+  @apply cursor-not-allowed;
+}
+.gui-switch.is-disabled .gui-switch__core {
+  @apply bg-grey-200 border-grey-200;
+}
+.gui-switch.is-disabled .gui-switch__action {
+  @apply bg-grey-100;
+}
+
+.gui-switch--wide .gui-switch__label.gui-switch__label--left span {
+  left: 10px;
+}
+.gui-switch--wide .gui-switch__label.gui-switch__label--right span {
+  right: 10px;
+}
+
+.gui-switch .label-fade-enter-from, .gui-switch .label-fade-leave-active {
+  opacity: 0;
+}
+.gui-switch--large {
+  height: 36px;
+}
+.gui-switch--large .gui-switch__core {
+  min-width: 67px;
+  height: 36px;
+  border-radius: 18px;
+}
+.gui-switch--large .gui-switch__core .gui-switch__inner {
+  padding: 0 6px 0 calc(30px + 2px);
+}
+.gui-switch--large .gui-switch__core .gui-switch__action {
+  width: 30px;
+  height: 30px;
+  left: 4px;
+}
+
+.gui-switch--large.is-checked .gui-switch__core .gui-switch__action {
+  left: calc(100% - 33px);
+}
+.gui-switch--large.is-checked .gui-switch__core .gui-switch__inner {
+  padding: 0 calc(30px + 2px) 0 6px;
+}
+
+.gui-switch--small {
+  height: 24px;
+}
+.gui-switch--small .gui-switch__core {
+  min-width: 45px;
+  height: 24px;
+  border-radius: 12px;
+}
+.gui-switch--small .gui-switch__core .gui-switch__inner {
+  padding: 0 2px 0 calc(18px + 2px);
+}
+.gui-switch--small .gui-switch__core .gui-switch__action {
+  width: 18px;
+  height: 18px;
+  left: 2px;
+}
+
+.gui-switch--small.is-checked .gui-switch__core .gui-switch__action {
+  left: calc(100% - 21px);
+}
+.gui-switch--small.is-checked .gui-switch__core .gui-switch__inner {
+  padding: 0 calc(18px + 2px) 0 2px;
+}

--- a/scripts/scss-parity/targets.json
+++ b/scripts/scss-parity/targets.json
@@ -10,5 +10,9 @@
   "inline": "components/inline/src/inline.styles.scss",
   "image": "components/image/src/image.styles.scss",
   "icon-button": "components/icon-button/src/icon-button.styles.scss",
-  "attach-file": "components/attach-file/src/attach-file.styles.scss"
+  "attach-file": "components/attach-file/src/attach-file.styles.scss",
+  "input": "components/input/src/input.styles.scss",
+  "form": "components/form/src/form.styles.scss",
+  "search-input": "components/search-input/src/search-input.styles.scss",
+  "switch": "components/switch/src/switch.styles.scss"
 }


### PR DESCRIPTION
## Qué
WU3 · Grupo 2: repoint de imports de mixins/tokens compartidos de la familia form, de `element-plus/theme-chalk` a `@flash-global66/g-utils`. Solo cambia el origen del import; la lógica no se toca.

Componentes: `input`, `form`, `search-input`, `switch`.

## Mapeo
`mixins/mixins`→`g-utils/mixins`, `mixins/utils`→`g-utils/utils`, `mixins/var`→`g-utils/var-mixins`, `common/var`→`g-utils/tokens`.

## Verificación
Cada archivo byte-exact (repoint gui == element-plus source a namespace gui). Agregados como targets del harness. `yarn scss:parity` 16/16 OK. Sin cambio visual/API.

## Nota
`input-number` se difiere: además importa `config-provider/config.styles.scss` (caso especial que requiere sacar ese import + verificación en contexto agregado). Se hace aparte con cuidado.

Base `main` (tiene WU1/WU2/G1).