### PR TITLE
refactor(styles): repoint dialog/overlay group off element-plus theme-chalk (ep-extraction-scss WU3 G3)

### DIFF
--- a/common/g-utils/package.json
+++ b/common/g-utils/package.json
@@ -15,7 +15,8 @@
     "./utils": "./styles/utils.scss",
     "./var-mixins": "./styles/var-mixins.scss",
     "./transition": "./styles/transition.scss",
-    "./icon": "./styles/icon.scss"
+    "./icon": "./styles/icon.scss",
+    "./popup": "./styles/popup.scss"
   },
   "sideEffects": [
     "**/*.scss",

--- a/common/g-utils/styles/popup.scss
+++ b/common/g-utils/styles/popup.scss
@@ -1,0 +1,47 @@
+@use 'tokens' as *;
+@use 'mixins' as *;
+@use 'var-mixins' as *;
+
+:root {
+  @include set-component-css-var('popup', $popup);
+}
+
+.v-modal-enter {
+  animation: v-modal-in getCssVar('transition-duration-fast') ease;
+}
+
+.v-modal-leave {
+  animation: v-modal-out getCssVar('transition-duration-fast') ease forwards;
+}
+
+@keyframes v-modal-in {
+  0% {
+    opacity: 0;
+  }
+  100% {
+  }
+}
+
+@keyframes v-modal-out {
+  0% {
+  }
+  100% {
+    opacity: 0;
+  }
+}
+
+.v-modal {
+  position: fixed;
+  left: 0;
+  top: 0;
+  width: 100%;
+  height: 100%;
+  opacity: getCssVar('popup-modal-opacity');
+  background: getCssVar('popup-modal-bg-color');
+}
+
+@include b(popup-parent) {
+  @include m(hidden) {
+    overflow: hidden;
+  }
+}

--- a/components/dialog-alert/src/dialog-alert.styles.scss
+++ b/components/dialog-alert/src/dialog-alert.styles.scss
@@ -1,9 +1,9 @@
 @use "sass:map";
 
-@use "element-plus/theme-chalk/src/mixins/mixins" as *;
-@use "element-plus/theme-chalk/src/mixins/utils" as *;
-@use "element-plus/theme-chalk/src/mixins/var" as *;
-@use "element-plus/theme-chalk/src/common/var" as *;
+@use "@flash-global66/g-utils/mixins" as *;
+@use "@flash-global66/g-utils/utils" as *;
+@use "@flash-global66/g-utils/var-mixins" as *;
+@use "@flash-global66/g-utils/tokens" as *;
 
 @include b(dialog-alert) {
   @include e(description) {

--- a/components/dialog/src/dialog.styles.scss
+++ b/components/dialog/src/dialog.styles.scss
@@ -1,10 +1,10 @@
 @use 'sass:map';
 
-@use 'element-plus/theme-chalk/src/mixins/mixins' as *;
-@use 'element-plus/theme-chalk/src/mixins/utils' as *;
-@use 'element-plus/theme-chalk/src/mixins/var' as *;
-@use 'element-plus/theme-chalk/src/common/var' as *;
-@use 'element-plus/theme-chalk/src/common/popup' as *;
+@use '@flash-global66/g-utils/mixins' as *;
+@use '@flash-global66/g-utils/utils' as *;
+@use '@flash-global66/g-utils/var-mixins' as *;
+@use '@flash-global66/g-utils/tokens' as *;
+@use '@flash-global66/g-utils/popup' as *;
 
 @include b('dialog') {
   @apply relative bg-sec-def-bg rounded-lg shadow-lg box-border p-8 break-words mx-auto;

--- a/components/overlay/overlay.styles.scss
+++ b/components/overlay/overlay.styles.scss
@@ -1,9 +1,9 @@
 @use "sass:map";
 
-@use "element-plus/theme-chalk/src/mixins/mixins" as *;
-@use "element-plus/theme-chalk/src/mixins/utils" as *; 
-@use "element-plus/theme-chalk/src/mixins/var" as *;
-@use "element-plus/theme-chalk/src/common/var" as *;
+@use "@flash-global66/g-utils/mixins" as *;
+@use "@flash-global66/g-utils/utils" as *; 
+@use "@flash-global66/g-utils/var-mixins" as *;
+@use "@flash-global66/g-utils/tokens" as *;
 
 @include b(overlay) {
   @apply fixed inset-0 overflow-auto bg-grey-800/80;

--- a/components/pagination/src/pagination.styles.scss
+++ b/components/pagination/src/pagination.styles.scss
@@ -1,9 +1,9 @@
 @use "sass:map";
 
-@use "element-plus/theme-chalk/src/mixins/mixins" as *;
-@use "element-plus/theme-chalk/src/mixins/utils" as *;
-@use "element-plus/theme-chalk/src/mixins/var" as *;
-@use "element-plus/theme-chalk/src/common/var" as *;
+@use "@flash-global66/g-utils/mixins" as *;
+@use "@flash-global66/g-utils/utils" as *;
+@use "@flash-global66/g-utils/var-mixins" as *;
+@use "@flash-global66/g-utils/tokens" as *;
 
 
 @mixin pagination-button {

--- a/components/quote/src/quote.styles.scss
+++ b/components/quote/src/quote.styles.scss
@@ -1,4 +1,4 @@
-@use "element-plus/theme-chalk/src/mixins/mixins" as *;
+@use "@flash-global66/g-utils/mixins" as *;
 
 // ─── Quote Container ────────────────────────────────────────────────────────
 

--- a/components/scrollbar/src/scrollbar.styles.scss
+++ b/components/scrollbar/src/scrollbar.styles.scss
@@ -1,8 +1,8 @@
 @use "sass:map";
 
-@use "element-plus/theme-chalk/src/mixins/mixins" as *;
-@use "element-plus/theme-chalk/src/mixins/var" as *;
-@use "element-plus/theme-chalk/src/common/var" as *;
+@use "@flash-global66/g-utils/mixins" as *;
+@use "@flash-global66/g-utils/var-mixins" as *;
+@use "@flash-global66/g-utils/tokens" as *;
 
 @include b(scrollbar) {
   @include set-component-css-var("scrollbar", $scrollbar);

--- a/components/toast/src/toast.styles.scss
+++ b/components/toast/src/toast.styles.scss
@@ -1,9 +1,9 @@
 @use 'sass:map';
 
-@use 'element-plus/theme-chalk/src/mixins/mixins' as *;
-@use 'element-plus/theme-chalk/src/mixins/utils' as *;
-@use 'element-plus/theme-chalk/src/mixins/var' as *;
-@use 'element-plus/theme-chalk/src/common/var' as *;
+@use '@flash-global66/g-utils/mixins' as *;
+@use '@flash-global66/g-utils/utils' as *;
+@use '@flash-global66/g-utils/var-mixins' as *;
+@use '@flash-global66/g-utils/tokens' as *;
 
 
 @include b(toast) {

--- a/scripts/scss-parity/baseline/dialog-alert.css
+++ b/scripts/scss-parity/baseline/dialog-alert.css
@@ -1,0 +1,8 @@
+/* Element Chalk Variables */
+.gui-dialog-alert__description {
+  @apply text-center text-4 font-normal text-secondary-txt hyphens-manual;
+}
+
+.gui-dialog-alert__checkboxes {
+  @apply mt-4 flex w-full flex-col gap-3 text-left text-3;
+}

--- a/scripts/scss-parity/baseline/dialog.css
+++ b/scripts/scss-parity/baseline/dialog.css
@@ -1,0 +1,235 @@
+/* Element Chalk Variables */
+:root {
+  --gui-popup-modal-bg-color: var(--gui-color-black);
+  --gui-popup-modal-opacity: 0.5;
+}
+
+.v-modal-enter {
+  animation: v-modal-in var(--gui-transition-duration-fast) ease;
+}
+
+.v-modal-leave {
+  animation: v-modal-out var(--gui-transition-duration-fast) ease forwards;
+}
+
+@keyframes v-modal-in {
+  0% {
+    opacity: 0;
+  }
+}
+@keyframes v-modal-out {
+  100% {
+    opacity: 0;
+  }
+}
+.v-modal {
+  position: fixed;
+  left: 0;
+  top: 0;
+  width: 100%;
+  height: 100%;
+  opacity: var(--gui-popup-modal-opacity);
+  background: var(--gui-popup-modal-bg-color);
+}
+
+.gui-popup-parent--hidden {
+  overflow: hidden;
+}
+
+.gui-dialog {
+  @apply relative bg-sec-def-bg rounded-lg shadow-lg box-border p-8 break-words mx-auto;
+}
+.gui-dialog.is-fullscreen {
+  @apply w-full h-full m-0 rounded-none overflow-auto;
+}
+
+.gui-dialog.is-default {
+  @apply max-w-md;
+}
+
+.gui-dialog.is-fixed {
+  width: var(--gui-dialog-width);
+  max-width: none;
+}
+
+.gui-dialog.is-adaptive {
+  width: fit-content;
+  min-width: min(theme("maxWidth.sm"), 100vw - 32px);
+  max-width: min(theme("maxWidth.4xl"), 100vw - 32px);
+}
+
+@media (max-width: theme("screens.sm")) {
+  .gui-dialog {
+    @apply mt-4 mb-4 mx-4 p-6 rounded-lg;
+  }
+  .gui-dialog.is-default {
+    width: calc(100% - 2rem);
+    max-width: none;
+    min-width: 0;
+  }
+  .gui-dialog.is-fixed {
+    width: calc(100% - 2rem);
+    max-width: none;
+    min-width: 0;
+  }
+  .gui-dialog.is-adaptive {
+    width: calc(100% - 2rem);
+    max-width: none;
+    min-width: 0;
+  }
+}
+.gui-dialog:focus {
+  @apply outline-none;
+}
+.gui-dialog.is-align-center {
+  @apply m-auto;
+}
+
+.gui-dialog__wrapper {
+  @apply fixed inset-0 overflow-auto m-0;
+}
+
+.gui-dialog.is-draggable {
+  @apply cursor-move relative;
+}
+.gui-dialog.is-draggable .gui-dialog__header {
+  @apply select-none;
+}
+
+.gui-dialog.is-dragging {
+  @apply cursor-move m-0;
+  transform: none;
+}
+.gui-dialog__header {
+  @apply relative;
+}
+.gui-dialog__header .header-content {
+  @apply absolute top-0 left-0 -translate-y-4;
+}
+.gui-dialog__header.show-close {
+  @apply pr-0;
+}
+
+.gui-dialog__headerbtn {
+  @apply absolute top-0 right-0 p-0 w-lg h-lg bg-transparent border-none outline-none
+      cursor-pointer flex items-center justify-center translate-x-4 -translate-y-4;
+}
+.gui-dialog__headerbtn .gui-dialog__close {
+  @apply text-terciary-txt text-6;
+}
+.gui-dialog__headerbtn:focus, .gui-dialog__headerbtn:hover {
+  @apply text-grey-100;
+}
+
+.gui-dialog__body {
+  @apply w-full mx-auto text-center;
+}
+.gui-dialog__body .content-wrapper {
+  @apply max-w-sm mx-auto;
+}
+
+.gui-dialog__footer {
+  @apply w-full mx-auto;
+}
+.gui-dialog__footer-buttons {
+  @apply w-full;
+}
+.gui-dialog__footer-buttons.layout-dual-row {
+  @apply grid gap-xs grid-cols-2;
+}
+.gui-dialog__footer-buttons.layout-dual-row > button:nth-child(3) {
+  @apply mt-xs mx-auto col-span-2 col-start-1;
+  max-width: 50%;
+}
+@media (max-width: theme("screens.sm")) {
+  .gui-dialog__footer-buttons.layout-dual-row {
+    @apply flex flex-col;
+  }
+  .gui-dialog__footer-buttons.layout-dual-row > button:nth-child(3) {
+    @apply max-w-full mx-0 mt-xxs;
+  }
+}
+.gui-dialog__footer-buttons.layout-single-column {
+  @apply flex flex-col gap-xs;
+}
+
+.gui-dialog__title {
+  @apply font-semibold text-8 text-primary-txt block mb-md;
+}
+
+.gui-dialog__image {
+  @apply mx-auto mb-lg flex flex-col items-center;
+}
+.is-adaptive .gui-dialog__image img {
+  @apply max-w-full h-auto w-auto;
+}
+
+.gui-dialog--center {
+  text-align: center;
+}
+.gui-dialog--center .gui-dialog__body {
+  text-align: center;
+}
+
+.gui-dialog--center .gui-dialog__footer {
+  text-align: center;
+}
+
+.gui-dialog__content {
+  @apply w-full text-center mb-lg text-secondary-txt;
+}
+
+.gui-overlay-dialog {
+  @apply fixed inset-0 overflow-auto flex items-center justify-center;
+}
+
+.dialog-fade-enter-active {
+  animation: modal-fade-in var(--gui-transition-duration);
+}
+.dialog-fade-enter-active .gui-overlay-dialog {
+  animation: dialog-fade-in var(--gui-transition-duration);
+}
+
+.dialog-fade-leave-active {
+  animation: modal-fade-out var(--gui-transition-duration);
+}
+.dialog-fade-leave-active .gui-overlay-dialog {
+  animation: dialog-fade-out var(--gui-transition-duration);
+}
+
+@keyframes dialog-fade-in {
+  0% {
+    transform: translate3d(0, -20px, 0);
+    opacity: 0;
+  }
+  100% {
+    transform: translate3d(0, 0, 0);
+    opacity: 1;
+  }
+}
+@keyframes dialog-fade-out {
+  0% {
+    transform: translate3d(0, 0, 0);
+    opacity: 1;
+  }
+  100% {
+    transform: translate3d(0, -20px, 0);
+    opacity: 0;
+  }
+}
+@keyframes modal-fade-in {
+  0% {
+    opacity: 0;
+  }
+  100% {
+    opacity: 1;
+  }
+}
+@keyframes modal-fade-out {
+  0% {
+    opacity: 1;
+  }
+  100% {
+    opacity: 0;
+  }
+}

--- a/scripts/scss-parity/baseline/g-utils-popup.css
+++ b/scripts/scss-parity/baseline/g-utils-popup.css
@@ -1,0 +1,37 @@
+/* Element Chalk Variables */
+:root {
+  --gui-popup-modal-bg-color: var(--gui-color-black);
+  --gui-popup-modal-opacity: 0.5;
+}
+
+.v-modal-enter {
+  animation: v-modal-in var(--gui-transition-duration-fast) ease;
+}
+
+.v-modal-leave {
+  animation: v-modal-out var(--gui-transition-duration-fast) ease forwards;
+}
+
+@keyframes v-modal-in {
+  0% {
+    opacity: 0;
+  }
+}
+@keyframes v-modal-out {
+  100% {
+    opacity: 0;
+  }
+}
+.v-modal {
+  position: fixed;
+  left: 0;
+  top: 0;
+  width: 100%;
+  height: 100%;
+  opacity: var(--gui-popup-modal-opacity);
+  background: var(--gui-popup-modal-bg-color);
+}
+
+.gui-popup-parent--hidden {
+  overflow: hidden;
+}

--- a/scripts/scss-parity/baseline/overlay.css
+++ b/scripts/scss-parity/baseline/overlay.css
@@ -1,0 +1,5 @@
+/* Element Chalk Variables */
+.gui-overlay {
+  @apply fixed inset-0 overflow-auto bg-grey-800/80;
+  pointer-events: auto;
+}

--- a/scripts/scss-parity/baseline/pagination.css
+++ b/scripts/scss-parity/baseline/pagination.css
@@ -1,0 +1,109 @@
+/* Element Chalk Variables */
+.gui-pagination {
+  @apply flex items-center gap-xxs text-primary-txt whitespace-nowrap text-2 font-medium;
+}
+.gui-pagination__btn-prev {
+  @apply flex justify-center items-center text-2 font-medium leading-none border-none rounded-md cursor-pointer text-center box-border text-primary-txt p-1;
+  min-width: 32px;
+  height: 32px;
+}
+.gui-pagination__btn-prev * {
+  @apply pointer-events-none;
+}
+.gui-pagination__btn-prev:focus {
+  @apply outline-none;
+}
+.gui-pagination__btn-prev:hover {
+  @apply text-everBlue-400;
+}
+.gui-pagination__btn-prev.is-active {
+  @apply text-everBlue-500 underline cursor-default font-semibold;
+}
+.gui-pagination__btn-prev.is-active.is-disabled {
+  @apply text-disabled-txt font-bold;
+}
+.gui-pagination__btn-prev:disabled, .gui-pagination__btn-prev.is-disabled {
+  @apply text-disabled-txt;
+  cursor: not-allowed;
+}
+.gui-pagination__btn-prev:focus-visible {
+  @apply outline-primary-def outline;
+  outline-offset: -1px;
+}
+.gui-pagination__btn-prev {
+  @apply text-5;
+}
+
+.gui-pagination__btn-next {
+  @apply flex justify-center items-center text-2 font-medium leading-none border-none rounded-md cursor-pointer text-center box-border text-primary-txt p-1;
+  min-width: 32px;
+  height: 32px;
+}
+.gui-pagination__btn-next * {
+  @apply pointer-events-none;
+}
+.gui-pagination__btn-next:focus {
+  @apply outline-none;
+}
+.gui-pagination__btn-next:hover {
+  @apply text-everBlue-400;
+}
+.gui-pagination__btn-next.is-active {
+  @apply text-everBlue-500 underline cursor-default font-semibold;
+}
+.gui-pagination__btn-next.is-active.is-disabled {
+  @apply text-disabled-txt font-bold;
+}
+.gui-pagination__btn-next:disabled, .gui-pagination__btn-next.is-disabled {
+  @apply text-disabled-txt;
+  cursor: not-allowed;
+}
+.gui-pagination__btn-next:focus-visible {
+  @apply outline-primary-def outline;
+  outline-offset: -1px;
+}
+.gui-pagination__btn-next {
+  @apply text-5;
+}
+
+.gui-pagination--right {
+  @apply justify-end;
+}
+
+.gui-pagination--center {
+  @apply justify-center;
+}
+
+.gui-pager {
+  @apply select-none list-none p-0 m-0 flex items-center gap-xxs;
+  list-style: none;
+  font-size: 0;
+}
+.gui-pager li {
+  @apply flex justify-center items-center text-2 font-medium leading-none border-none rounded-md cursor-pointer text-center box-border text-primary-txt p-1;
+  min-width: 32px;
+  height: 32px;
+}
+.gui-pager li * {
+  @apply pointer-events-none;
+}
+.gui-pager li:focus {
+  @apply outline-none;
+}
+.gui-pager li:hover {
+  @apply text-everBlue-400;
+}
+.gui-pager li.is-active {
+  @apply text-everBlue-500 underline cursor-default font-semibold;
+}
+.gui-pager li.is-active.is-disabled {
+  @apply text-disabled-txt font-bold;
+}
+.gui-pager li:disabled, .gui-pager li.is-disabled {
+  @apply text-disabled-txt;
+  cursor: not-allowed;
+}
+.gui-pager li:focus-visible {
+  @apply outline-primary-def outline;
+  outline-offset: -1px;
+}

--- a/scripts/scss-parity/baseline/quote.css
+++ b/scripts/scss-parity/baseline/quote.css
@@ -1,0 +1,231 @@
+.gui-quote {
+  @apply flex flex-col gap-xs;
+}
+.gui-quote__available {
+  @apply flex items-center gap-xxs px-xxs;
+  @apply text-2 font-medium text-terciary-txt;
+}
+
+.gui-quote__available-value {
+  @apply font-semibold text-secondary-txt;
+}
+
+.gui-quote__card {
+  @apply relative bg-white rounded-lg shadow-sm overflow-hidden;
+}
+.gui-quote__card.is-error {
+  @apply border border-error-bd shadow-none;
+}
+
+.gui-quote__card.is-error-with-action {
+  @apply border-b-0 rounded-b-none;
+}
+
+.gui-quote__card-group {
+  @apply flex flex-col;
+}
+
+.gui-quote__action {
+  @apply flex justify-center items-center px-md py-md;
+  @apply bg-everBlue-50 rounded-b-md;
+  @apply border-l border-r border-b border-error-bd;
+}
+
+.gui-quote__action-link {
+  @apply flex items-center gap-xxs
+      text-4 font-semibold text-primary-def
+      bg-transparent border-none cursor-pointer p-0;
+}
+.gui-quote__action-link svg {
+  @apply text-3;
+}
+.gui-quote__action-link:hover {
+  @apply underline;
+}
+
+.gui-quote__error-message {
+  @apply text-2 text-error-txt px-xxs;
+}
+
+.gui-quote__input-from {
+  @apply relative;
+}
+
+.gui-quote__input-to {
+  @apply relative;
+}
+
+.gui-quote__divider {
+  @apply relative h-px w-full bg-blue-50;
+}
+
+.gui-quote__swap-icon {
+  @apply flex items-center justify-center text-6;
+  transition: transform 0.4s ease;
+}
+
+.gui-quote__swap-btn {
+  @apply absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2
+      z-10 flex items-center justify-center
+      w-xl h-xl rounded-xl bg-everBlue-50
+      cursor-pointer border-none
+      transition-colors duration-200;
+}
+.gui-quote__swap-btn:hover:not(:disabled) {
+  @apply bg-everBlue-100;
+}
+.gui-quote__swap-btn:active:not(:disabled) {
+  @apply bg-everBlue-200;
+}
+.gui-quote__swap-btn:disabled {
+  @apply cursor-not-allowed opacity-50;
+}
+
+.gui-quote-input {
+  @apply flex flex-col gap-xxs justify-center px-md overflow-hidden;
+  height: 112px;
+  padding-top: 24px;
+  padding-bottom: 24px;
+}
+.gui-quote-input__label {
+  @apply text-4 font-medium text-secondary-txt;
+}
+
+.gui-quote-input__row {
+  @apply flex items-center gap-xs;
+  min-height: 36px;
+  transition: opacity 0.2s ease;
+}
+.gui-quote-input__row.is-fading {
+  opacity: 0;
+}
+
+.gui-quote-input__amount-wrapper {
+  @apply flex-1 min-w-0;
+}
+
+.gui-quote-input__amount {
+  @apply w-full text-9 font-bold text-primary-txt
+      appearance-none outline-none bg-transparent;
+  transition: font-size 0.15s ease;
+}
+@media (max-width: theme("screens.sm")) {
+  .gui-quote-input__amount {
+    @apply text-7;
+  }
+}
+.gui-quote-input__amount::placeholder {
+  @apply text-terciary-txt font-bold;
+}
+.gui-quote-input__amount.is-big {
+  @apply text-11;
+}
+@media (max-width: theme("screens.sm")) {
+  .gui-quote-input__amount.is-big {
+    @apply text-9;
+  }
+}
+
+.gui-quote-input__amount.is-empty {
+  @apply text-terciary-txt;
+}
+
+.gui-quote-input__amount.is-error {
+  @apply text-error-txt;
+}
+
+.gui-quote-input__amount.is-disabled {
+  @apply text-disabled-txt cursor-not-allowed;
+}
+.gui-quote-input__amount.is-disabled::placeholder {
+  @apply text-disabled-txt;
+}
+
+.gui-quote-input__currency {
+  @apply flex items-center gap-xxs bg-transparent border-none
+      cursor-pointer p-0 shrink-0 outline-none;
+}
+.gui-quote-input__currency:focus-visible {
+  @apply outline-none;
+}
+.gui-quote-input__currency.is-disabled {
+  @apply cursor-not-allowed;
+}
+
+.gui-quote-input__currency.is-open {
+  @apply px-md py-xs rounded-md;
+  outline: 1px solid var(--color-border-primary);
+  outline-offset: -1px;
+}
+
+.gui-quote-input__flag-group {
+  @apply flex items-center gap-xs;
+}
+
+.gui-quote-input__flag {
+  @apply flex items-center justify-center shrink-0;
+}
+
+.gui-quote-input__flag-img {
+  @apply w-4 h-4 rounded-full object-cover;
+}
+
+.gui-quote-input__currency-code {
+  @apply text-4 font-semibold text-primary-txt
+           bg-transparent border-none outline-none p-0;
+}
+.gui-quote-input__currency-code::placeholder {
+  @apply text-primary-txt font-semibold;
+}
+.gui-quote-input__currency-code.is-disabled {
+  @apply text-disabled-txt cursor-not-allowed;
+}
+.gui-quote-input__currency-code.is-disabled::placeholder {
+  @apply text-disabled-txt;
+}
+
+.gui-quote-input__arrow {
+  @apply flex items-center text-secondary-txt text-4;
+  transition: transform 0.2s ease;
+}
+.gui-quote-input__arrow.is-disabled {
+  @apply text-disabled-txt;
+}
+
+.gui-quote-input__arrow.is-open {
+  transform: rotate(180deg);
+}
+
+.gui-quote-input__dropdown {
+  @apply max-h-60 overflow-y-auto;
+}
+.gui-quote-input__dropdown .gui-dropdown-menu__item {
+  @apply p-2;
+  min-height: unset;
+}
+.gui-quote-input__dropdown .gui-dropdown-menu__item.is-active {
+  @apply bg-everBlue-50;
+}
+
+.gui-quote-input__dropdown-popper {
+  @apply w-72 rounded-lg shadow-md;
+}
+.gui-quote-input__dropdown-popper .gui-scrollbar__wrap {
+  @apply rounded-lg;
+}
+
+.gui-quote-input__dropdown-item {
+  @apply flex items-center gap-xs;
+}
+
+.gui-quote-input__dropdown-empty {
+  @apply px-md py-xs text-3 text-terciary-txt text-center;
+}
+
+.gui-quote-input__dropdown-label {
+  @apply flex items-center gap-xxs;
+}
+
+.gui-quote-input__dropdown-code {
+  @apply text-secondary-txt;
+}

--- a/scripts/scss-parity/baseline/scrollbar.css
+++ b/scripts/scss-parity/baseline/scrollbar.css
@@ -1,0 +1,70 @@
+/* Element Chalk Variables */
+.gui-scrollbar {
+  --gui-scrollbar-opacity: 0.3;
+  --gui-scrollbar-bg-color: var(--gui-text-color-secondary);
+  --gui-scrollbar-hover-opacity: 0.5;
+  --gui-scrollbar-hover-bg-color: var(--gui-text-color-secondary);
+}
+
+.gui-scrollbar {
+  overflow: hidden;
+  position: relative;
+  height: 100%;
+}
+.gui-scrollbar__wrap {
+  overflow: auto;
+  height: 100%;
+}
+.gui-scrollbar__wrap--hidden-default {
+  scrollbar-width: none;
+}
+.gui-scrollbar__wrap--hidden-default::-webkit-scrollbar {
+  display: none;
+}
+
+.gui-scrollbar__thumb {
+  @apply bg-grey-200;
+  position: relative;
+  display: block;
+  width: 0;
+  height: 0;
+  cursor: pointer;
+  border-radius: inherit;
+  transition: var(--gui-transition-duration) background-color;
+}
+.gui-scrollbar__thumb:hover {
+  @apply bg-grey-400;
+}
+
+.gui-scrollbar__bar {
+  position: absolute;
+  right: 2px;
+  bottom: 2px;
+  z-index: 1;
+  border-radius: 4px;
+}
+.gui-scrollbar__bar.is-vertical {
+  width: 6px;
+  top: 2px;
+}
+.gui-scrollbar__bar.is-vertical > div {
+  width: 100%;
+}
+
+.gui-scrollbar__bar.is-horizontal {
+  height: 6px;
+  left: 2px;
+}
+.gui-scrollbar__bar.is-horizontal > div {
+  height: 100%;
+}
+
+.gui-scrollbar-fade-enter-active {
+  transition: opacity 340ms ease-out;
+}
+.gui-scrollbar-fade-leave-active {
+  transition: opacity 120ms ease-out;
+}
+.gui-scrollbar-fade-enter-from, .gui-scrollbar-fade-leave-active {
+  opacity: 0;
+}

--- a/scripts/scss-parity/baseline/toast.css
+++ b/scripts/scss-parity/baseline/toast.css
@@ -1,0 +1,169 @@
+/* Element Chalk Variables */
+.gui-toast {
+  @apply flex items-center gap-xs px-sm rounded-md border w-96 box-border fixed overflow-hidden;
+  overflow-wrap: break-word;
+  z-index: 9999;
+  transition: top 300ms ease-out;
+}
+.gui-toast.right {
+  @apply right-4;
+}
+.gui-toast.left {
+  @apply left-4;
+}
+.gui-toast__group {
+  @apply flex-1 min-w-0 mx-0;
+}
+
+.gui-toast__content {
+  @apply leading-6 m-0 font-medium text-secondary-txt;
+}
+.gui-toast__content p {
+  @apply m-0;
+}
+
+.gui-toast__icon {
+  @apply shrink-0;
+}
+
+.gui-toast__closeBtn {
+  @apply cursor-pointer text-icon-secondary flex-shrink-0 ml-xs;
+}
+.gui-toast__closeBtn:hover {
+  @apply text-primary-def-hover;
+}
+
+.gui-toast__progress {
+  @apply absolute bottom-0 left-0 right-0 h-1 overflow-hidden;
+}
+
+.gui-toast__progress-bar {
+  @apply h-full w-0;
+  animation: progressFill linear forwards;
+}
+
+.gui-toast--success {
+  @apply border-success-bd bg-success-bg;
+}
+.gui-toast--success .gui-toast__icon {
+  @apply text-success-txt;
+}
+
+.gui-toast--success .gui-toast__progress {
+  @apply text-success-txt;
+}
+
+.gui-toast--success .gui-toast__progress-bar {
+  @apply bg-success-def;
+}
+
+.gui-toast--info {
+  @apply border-info-bd bg-info-bg;
+}
+.gui-toast--info .gui-toast__icon {
+  @apply text-info-txt;
+}
+
+.gui-toast--info .gui-toast__progress {
+  @apply text-info-txt;
+}
+
+.gui-toast--info .gui-toast__progress-bar {
+  @apply bg-info-def;
+}
+
+.gui-toast--warning {
+  @apply border-warning-bd bg-warning-bg;
+}
+.gui-toast--warning .gui-toast__icon {
+  @apply text-warning-txt;
+}
+
+.gui-toast--warning .gui-toast__progress {
+  @apply text-warning-txt;
+}
+
+.gui-toast--warning .gui-toast__progress-bar {
+  @apply bg-warning-def;
+}
+
+.gui-toast--error {
+  @apply border-error-bd bg-error-bg;
+}
+.gui-toast--error .gui-toast__icon {
+  @apply text-error-txt;
+}
+
+.gui-toast--error .gui-toast__progress {
+  @apply text-error-txt;
+}
+
+.gui-toast--error .gui-toast__progress-bar {
+  @apply bg-error-def;
+}
+
+.gui-toast--sm {
+  @apply min-h-14 py-2;
+}
+.gui-toast--sm .gui-toast__content {
+  @apply text-2;
+}
+
+.gui-toast--sm .gui-toast__icon {
+  @apply w-5 h-5 text-9;
+}
+
+.gui-toast--sm .gui-toast__closeBtn {
+  @apply w-4 h-4;
+}
+
+.gui-toast--md {
+  @apply min-h-16 py-3;
+}
+.gui-toast--md .gui-toast__content {
+  @apply text-4;
+}
+
+.gui-toast--md .gui-toast__icon {
+  @apply w-6 h-6 text-10;
+}
+
+.gui-toast--md .gui-toast__closeBtn {
+  @apply w-5 h-5;
+}
+
+@keyframes progressFill {
+  from {
+    width: 0%;
+  }
+  to {
+    width: 100%;
+  }
+}
+.gui-toast-fade-enter-active {
+  @apply transition-all ease-out duration-300;
+}
+
+.gui-toast-fade-leave-active {
+  @apply transition-all ease-in duration-300;
+}
+
+.gui-toast-fade-enter-from {
+  @apply opacity-0;
+}
+.gui-toast-fade-enter-from.right {
+  @apply translate-x-5;
+}
+.gui-toast-fade-enter-from.left {
+  @apply -translate-x-5;
+}
+
+.gui-toast-fade-leave-to {
+  @apply opacity-0;
+}
+.gui-toast-fade-leave-to.right {
+  @apply translate-x-5;
+}
+.gui-toast-fade-leave-to.left {
+  @apply -translate-x-5;
+}

--- a/scripts/scss-parity/targets.json
+++ b/scripts/scss-parity/targets.json
@@ -15,5 +15,13 @@
   "form": "components/form/src/form.styles.scss",
   "search-input": "components/search-input/src/search-input.styles.scss",
   "switch": "components/switch/src/switch.styles.scss",
-  "input-number": "components/input-number/src/input-number.styles.scss"
+  "input-number": "components/input-number/src/input-number.styles.scss",
+  "g-utils-popup": "common/g-utils/styles/popup.scss",
+  "dialog": "components/dialog/src/dialog.styles.scss",
+  "dialog-alert": "components/dialog-alert/src/dialog-alert.styles.scss",
+  "overlay": "components/overlay/overlay.styles.scss",
+  "scrollbar": "components/scrollbar/src/scrollbar.styles.scss",
+  "pagination": "components/pagination/src/pagination.styles.scss",
+  "quote": "components/quote/src/quote.styles.scss",
+  "toast": "components/toast/src/toast.styles.scss"
 }


### PR DESCRIPTION
## Qué

WU3 · Grupo 3 (dialog/overlay) de **ep-extraction-scss**. Repunta los SCSS de `dialog`, `dialog-alert`, `overlay`, `scrollbar`, `pagination`, `quote` y `toast` para consumir mixins/tokens compartidos desde `@flash-global66/g-utils` en lugar de `element-plus/theme-chalk`.

La lógica de estilos **no cambia**: cada archivo compila **byte-idéntico** a la fuente de element-plus en namespace `gui`.

## Puerto nuevo en g-utils: `./popup`

`dialog` importaba `element-plus/theme-chalk/src/common/popup`, que no tenía equivalente en g-utils. Se portó **byte-exacto** a `common/g-utils/styles/popup.scss` (nuevo export `./popup`), repuntando sus imports internos (`./var`→`tokens`, `mixins/mixins`→`mixins`, `mixins/var`→`var-mixins`). Emite las mismas CSS vars de popup, `.v-modal`, keyframes y `popup-parent`.

## Verificación

- **Byte-exacto**: cada archivo repuntado compilado (g-utils, namespace `gui`) es idéntico a su original de element-plus forzado a `gui`. 6/7 componentes + `popup` idénticos en standalone.
- **`quote`**: idéntico en contexto **agregado** (config-provider primero) — la única diferencia en standalone es el comentario banner `/* Element Chalk Variables */` que emite `common/var` como primer emisor y que el port de `tokens` omite a propósito; en el consumidor real ese banner lo emite una sola vez el bootstrap de config-provider.
- **Parity harness**: 25/25 targets OK (`node scripts/scss-parity.mjs`).
- Validación en b2b vía yarn link: pendiente antes del merge.

## Alcance

Sin cambios de API pública (props/emits/slots). Solo repunte de imports SCSS + puerto interno en g-utils. No toca los bridges de EP en config-provider (diferidos al slice final).