### PR TITLE
refactor(styles): port element-plus popper theme into g-utils, repoint popper (ep-extraction-scss WU4 S1)

### DIFF
--- a/common/g-utils/package.json
+++ b/common/g-utils/package.json
@@ -16,7 +16,8 @@
     "./var-mixins": "./styles/var-mixins.scss",
     "./transition": "./styles/transition.scss",
     "./icon": "./styles/icon.scss",
-    "./popup": "./styles/popup.scss"
+    "./popup": "./styles/popup.scss",
+    "./popper": "./styles/popper.scss"
   },
   "sideEffects": [
     "**/*.scss",

--- a/common/g-utils/styles/popper.scss
+++ b/common/g-utils/styles/popper.scss
@@ -1,0 +1,106 @@
+@use 'mixins' as *;
+@use 'var-mixins' as *;
+@use 'tokens' as *;
+
+@include b(popper) {
+  @include set-component-css-var('popper', $popper);
+}
+
+@include b(popper) {
+  position: absolute;
+  border-radius: getCssVar('popper', 'border-radius');
+  padding: 5px 11px;
+  z-index: 2000;
+  font-size: 12px;
+  line-height: 20px;
+  min-width: 10px;
+  overflow-wrap: break-word;
+  visibility: visible;
+
+  $arrow-selector: #{& + '__arrow'};
+
+  @include when(dark) {
+    color: getCssVar('bg-color');
+    background: getCssVar('text-color', 'primary');
+    border: 1px solid getCssVar('text-color', 'primary');
+
+    > #{$arrow-selector}::before {
+      border: 1px solid getCssVar('text-color', 'primary');
+      background: getCssVar('text-color', 'primary');
+      right: 0;
+    }
+  }
+
+  @include when(light) {
+    background: getCssVar('bg-color', 'overlay');
+    border: 1px solid getCssVar('border-color', 'light');
+
+    > #{$arrow-selector}::before {
+      border: 1px solid getCssVar('border-color', 'light');
+      background: getCssVar('bg-color', 'overlay');
+      right: 0;
+    }
+  }
+
+  @include when(pure) {
+    padding: 0;
+  }
+
+  @include e(arrow) {
+    position: absolute;
+    width: 10px;
+    height: 10px;
+    z-index: -1;
+
+    &::before {
+      position: absolute;
+      width: 10px;
+      height: 10px;
+      z-index: -1;
+      content: ' ';
+      transform: rotate(45deg);
+      background: getCssVar('text-color', 'primary');
+      box-sizing: border-box;
+    }
+  }
+
+  $placements: (
+    'top': 'bottom',
+    'bottom': 'top',
+    'left': 'right',
+    'right': 'left',
+  );
+
+  @each $placement, $opposite in $placements {
+    &[data-popper-placement^='#{$placement}'] > #{$arrow-selector} {
+      #{$opposite}: -5px;
+
+      &::before {
+        @if $placement == top {
+          border-bottom-right-radius: 2px;
+        }
+        @if $placement == bottom {
+          border-top-left-radius: 2px;
+        }
+        @if $placement == left {
+          border-top-right-radius: 2px;
+        }
+        @if $placement == right {
+          border-bottom-left-radius: 2px;
+        }
+      }
+    }
+  }
+
+  @each $placement,
+    $adjacency
+      in ('top': 'left', 'bottom': 'right', 'left': 'bottom', 'right': 'top')
+  {
+    &[data-popper-placement^='#{$placement}'] > {
+      #{$arrow-selector}::before {
+        border-#{$placement}-color: transparent !important;
+        border-#{$adjacency}-color: transparent !important;
+      }
+    }
+  }
+}

--- a/components/popper/src/popper.styles.scss
+++ b/components/popper/src/popper.styles.scss
@@ -1,1 +1,1 @@
-@use 'element-plus/theme-chalk/src/popper.scss' as *;
+@use '@flash-global66/g-utils/popper' as *;

--- a/scripts/scss-parity/baseline/g-utils-popper.css
+++ b/scripts/scss-parity/baseline/g-utils-popper.css
@@ -1,0 +1,98 @@
+/* Element Chalk Variables */
+.gui-popper {
+  --gui-popper-border-radius: var(--gui-popover-border-radius, 4px);
+}
+
+.gui-popper {
+  position: absolute;
+  border-radius: var(--gui-popper-border-radius);
+  padding: 5px 11px;
+  z-index: 2000;
+  font-size: 12px;
+  line-height: 20px;
+  min-width: 10px;
+  overflow-wrap: break-word;
+  visibility: visible;
+}
+.gui-popper.is-dark {
+  color: var(--gui-bg-color);
+  background: var(--gui-text-color-primary);
+  border: 1px solid var(--gui-text-color-primary);
+}
+.gui-popper.is-dark > .gui-popper__arrow::before {
+  border: 1px solid var(--gui-text-color-primary);
+  background: var(--gui-text-color-primary);
+  right: 0;
+}
+
+.gui-popper.is-light {
+  background: var(--gui-bg-color-overlay);
+  border: 1px solid var(--gui-border-color-light);
+}
+.gui-popper.is-light > .gui-popper__arrow::before {
+  border: 1px solid var(--gui-border-color-light);
+  background: var(--gui-bg-color-overlay);
+  right: 0;
+}
+
+.gui-popper.is-pure {
+  padding: 0;
+}
+
+.gui-popper__arrow {
+  position: absolute;
+  width: 10px;
+  height: 10px;
+  z-index: -1;
+}
+.gui-popper__arrow::before {
+  position: absolute;
+  width: 10px;
+  height: 10px;
+  z-index: -1;
+  content: " ";
+  transform: rotate(45deg);
+  background: var(--gui-text-color-primary);
+  box-sizing: border-box;
+}
+
+.gui-popper[data-popper-placement^=top] > .gui-popper__arrow {
+  bottom: -5px;
+}
+.gui-popper[data-popper-placement^=top] > .gui-popper__arrow::before {
+  border-bottom-right-radius: 2px;
+}
+.gui-popper[data-popper-placement^=bottom] > .gui-popper__arrow {
+  top: -5px;
+}
+.gui-popper[data-popper-placement^=bottom] > .gui-popper__arrow::before {
+  border-top-left-radius: 2px;
+}
+.gui-popper[data-popper-placement^=left] > .gui-popper__arrow {
+  right: -5px;
+}
+.gui-popper[data-popper-placement^=left] > .gui-popper__arrow::before {
+  border-top-right-radius: 2px;
+}
+.gui-popper[data-popper-placement^=right] > .gui-popper__arrow {
+  left: -5px;
+}
+.gui-popper[data-popper-placement^=right] > .gui-popper__arrow::before {
+  border-bottom-left-radius: 2px;
+}
+.gui-popper[data-popper-placement^=top] > .gui-popper__arrow::before {
+  border-top-color: transparent !important;
+  border-left-color: transparent !important;
+}
+.gui-popper[data-popper-placement^=bottom] > .gui-popper__arrow::before {
+  border-bottom-color: transparent !important;
+  border-right-color: transparent !important;
+}
+.gui-popper[data-popper-placement^=left] > .gui-popper__arrow::before {
+  border-left-color: transparent !important;
+  border-bottom-color: transparent !important;
+}
+.gui-popper[data-popper-placement^=right] > .gui-popper__arrow::before {
+  border-right-color: transparent !important;
+  border-top-color: transparent !important;
+}

--- a/scripts/scss-parity/baseline/popper.css
+++ b/scripts/scss-parity/baseline/popper.css
@@ -1,0 +1,98 @@
+/* Element Chalk Variables */
+.gui-popper {
+  --gui-popper-border-radius: var(--gui-popover-border-radius, 4px);
+}
+
+.gui-popper {
+  position: absolute;
+  border-radius: var(--gui-popper-border-radius);
+  padding: 5px 11px;
+  z-index: 2000;
+  font-size: 12px;
+  line-height: 20px;
+  min-width: 10px;
+  overflow-wrap: break-word;
+  visibility: visible;
+}
+.gui-popper.is-dark {
+  color: var(--gui-bg-color);
+  background: var(--gui-text-color-primary);
+  border: 1px solid var(--gui-text-color-primary);
+}
+.gui-popper.is-dark > .gui-popper__arrow::before {
+  border: 1px solid var(--gui-text-color-primary);
+  background: var(--gui-text-color-primary);
+  right: 0;
+}
+
+.gui-popper.is-light {
+  background: var(--gui-bg-color-overlay);
+  border: 1px solid var(--gui-border-color-light);
+}
+.gui-popper.is-light > .gui-popper__arrow::before {
+  border: 1px solid var(--gui-border-color-light);
+  background: var(--gui-bg-color-overlay);
+  right: 0;
+}
+
+.gui-popper.is-pure {
+  padding: 0;
+}
+
+.gui-popper__arrow {
+  position: absolute;
+  width: 10px;
+  height: 10px;
+  z-index: -1;
+}
+.gui-popper__arrow::before {
+  position: absolute;
+  width: 10px;
+  height: 10px;
+  z-index: -1;
+  content: " ";
+  transform: rotate(45deg);
+  background: var(--gui-text-color-primary);
+  box-sizing: border-box;
+}
+
+.gui-popper[data-popper-placement^=top] > .gui-popper__arrow {
+  bottom: -5px;
+}
+.gui-popper[data-popper-placement^=top] > .gui-popper__arrow::before {
+  border-bottom-right-radius: 2px;
+}
+.gui-popper[data-popper-placement^=bottom] > .gui-popper__arrow {
+  top: -5px;
+}
+.gui-popper[data-popper-placement^=bottom] > .gui-popper__arrow::before {
+  border-top-left-radius: 2px;
+}
+.gui-popper[data-popper-placement^=left] > .gui-popper__arrow {
+  right: -5px;
+}
+.gui-popper[data-popper-placement^=left] > .gui-popper__arrow::before {
+  border-top-right-radius: 2px;
+}
+.gui-popper[data-popper-placement^=right] > .gui-popper__arrow {
+  left: -5px;
+}
+.gui-popper[data-popper-placement^=right] > .gui-popper__arrow::before {
+  border-bottom-left-radius: 2px;
+}
+.gui-popper[data-popper-placement^=top] > .gui-popper__arrow::before {
+  border-top-color: transparent !important;
+  border-left-color: transparent !important;
+}
+.gui-popper[data-popper-placement^=bottom] > .gui-popper__arrow::before {
+  border-bottom-color: transparent !important;
+  border-right-color: transparent !important;
+}
+.gui-popper[data-popper-placement^=left] > .gui-popper__arrow::before {
+  border-left-color: transparent !important;
+  border-bottom-color: transparent !important;
+}
+.gui-popper[data-popper-placement^=right] > .gui-popper__arrow::before {
+  border-right-color: transparent !important;
+  border-top-color: transparent !important;
+}

--- a/scripts/scss-parity/targets.json
+++ b/scripts/scss-parity/targets.json
@@ -23,5 +23,7 @@
   "scrollbar": "components/scrollbar/src/scrollbar.styles.scss",
   "pagination": "components/pagination/src/pagination.styles.scss",
   "quote": "components/quote/src/quote.styles.scss",
-  "toast": "components/toast/src/toast.styles.scss"
+  "toast": "components/toast/src/toast.styles.scss",
+  "g-utils-popper": "common/g-utils/styles/popper.scss",
+  "popper": "components/popper/src/popper.styles.scss"
 }


### PR DESCRIPTION
## Qué

Primera slice de **WU4** (repunte de *theme completo* de componente, no solo mixins). Porta byte-exacto `element-plus/theme-chalk/src/popper.scss` a g-utils como nuevo export `./popper`, y repunta el componente `popper` para dejar de depender de element-plus.

Bajo la arquitectura **híbrida** acordada: los themes EP **compartidos** viven en g-utils. `popper` es compartido por `dropdown`, `select`, `table`, `tooltip` y `date-picker`, así que esta slice **desbloquea** esas slices posteriores.

## Verificación

- **Byte-exacto**: el port de g-utils y el componente repuntado compilan idénticos a la fuente de element-plus en namespace `gui` (2705 b cada uno).
- Repunte interno del port: `mixins/mixins`→`mixins`, `mixins/var`→`var-mixins`, `common/var`→`tokens`.
- **Parity harness**: 27/27 OK.
- Tests pre-push ✅.
- Validación b2b vía yarn link: pendiente antes del merge.

## Nota de transición

Mientras `dropdown`/`select`/`table`/`tooltip`/`date-picker` publicados sigan importando el `popper.scss` de element-plus, el agregado de b2b emitirá **dos bloques `.gui-popper` byte-idénticos** (módulos distintos → sin dedup). Es benigno (reglas idénticas) y se resuelve cuando esos consumidores migren en slices siguientes.

## Alcance

Sin cambios de API pública. Solo port SCSS + repunte de import. No toca los bridges de EP en config-provider (diferidos a la slice final 4.7).