### PR TITLE
refactor(styles): port shared element-plus themes into g-utils (ep-extraction-scss WU4 S2)

### DIFF
--- a/common/g-utils/package.json
+++ b/common/g-utils/package.json
@@ -17,7 +17,12 @@
     "./transition": "./styles/transition.scss",
     "./icon": "./styles/icon.scss",
     "./popup": "./styles/popup.scss",
-    "./popper": "./styles/popper.scss"
+    "./popper": "./styles/popper.scss",
+    "./scrollbar": "./styles/scrollbar.scss",
+    "./tooltip-v2": "./styles/tooltip-v2.scss",
+    "./option": "./styles/option.scss",
+    "./virtual-list": "./styles/virtual-list.scss",
+    "./overlay": "./styles/overlay.scss"
   },
   "sideEffects": [
     "**/*.scss",

--- a/common/g-utils/styles/option.scss
+++ b/common/g-utils/styles/option.scss
@@ -1,0 +1,71 @@
+@use 'sass:map';
+
+@use 'mixins' as *;
+@use 'tokens' as *;
+
+$checked-icon: "data:image/svg+xml;utf8,%3Csvg class='icon' width='200' height='200' viewBox='0 0 1024 1024' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath fill='currentColor' d='M406.656 706.944L195.84 496.256a32 32 0 10-45.248 45.248l256 256 512-512a32 32 0 00-45.248-45.248L406.592 706.944z'%3E%3C/path%3E%3C/svg%3E";
+
+@mixin checked-icon {
+  content: '';
+  position: absolute;
+  top: 50%;
+  right: 20px;
+  border-top: none;
+  border-right: none;
+  background-repeat: no-repeat;
+  background-position: center;
+  background-color: map.get($select-option, 'selected-text-color');
+  mask: url('#{$checked-icon}') no-repeat;
+  mask-size: 100% 100%;
+  -webkit-mask: url('#{$checked-icon}') no-repeat;
+  -webkit-mask-size: 100% 100%;
+  transform: translateY(-50%);
+  width: 12px;
+  height: 12px;
+}
+
+@include b(select-dropdown) {
+  @include e(item) {
+    font-size: map.get($select, 'font-size');
+    // 20 as the padding of option item, 12 as the size of ✓ icon size
+    padding: 0 #{20 + 12}px 0 20px;
+    position: relative;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    color: map.get($select-option, 'text-color');
+    height: map.get($select-option, 'height');
+    line-height: map.get($select-option, 'height');
+    box-sizing: border-box;
+    cursor: pointer;
+
+    @include when(hovering) {
+      background-color: map.get($select-option, 'hover-background');
+    }
+
+    @include when(selected) {
+      color: map.get($select-option, 'selected-text-color');
+      font-weight: bold;
+    }
+
+    @include when(disabled) {
+      color: map.get($select-option, 'disabled-color');
+      cursor: not-allowed;
+      background-color: unset;
+    }
+  }
+
+  @include when(multiple) {
+    .#{$namespace}-select-dropdown__item.is-selected {
+      &::after {
+        @include checked-icon;
+      }
+    }
+
+    .#{$namespace}-select-dropdown__item.is-disabled {
+      &::after {
+        background-color: map.get($select-option, 'disabled-color');
+      }
+    }
+  }
+}

--- a/common/g-utils/styles/overlay.scss
+++ b/common/g-utils/styles/overlay.scss
@@ -1,0 +1,17 @@
+@use 'mixins' as *;
+@use 'tokens' as *;
+
+@include b(overlay) {
+  position: fixed;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  z-index: 2000;
+  height: 100%;
+  background-color: getCssVar('overlay-color', 'lighter');
+  overflow: auto;
+  #{& + '-root'} {
+    height: 0;
+  }
+}

--- a/common/g-utils/styles/scrollbar.scss
+++ b/common/g-utils/styles/scrollbar.scss
@@ -1,0 +1,97 @@
+@use 'sass:map';
+
+@use 'mixins' as *;
+@use 'var-mixins' as *;
+@use 'tokens' as *;
+
+@include b(scrollbar) {
+  @include set-component-css-var('scrollbar', $scrollbar);
+}
+
+@include b(scrollbar) {
+  overflow: hidden;
+  position: relative;
+  height: 100%;
+
+  @include e(wrap) {
+    overflow: auto;
+    height: 100%;
+
+    @include m(hidden-default) {
+      scrollbar-width: none;
+      &::-webkit-scrollbar {
+        display: none;
+      }
+    }
+  }
+
+  @include e(thumb) {
+    position: relative;
+    display: block;
+    width: 0;
+    height: 0;
+    cursor: pointer;
+    border-radius: inherit;
+    background-color: var(
+      #{getCssVarName('scrollbar-bg-color')},
+      map.get($scrollbar, 'bg-color')
+    );
+    transition: getCssVar('transition-duration') background-color;
+    opacity: var(
+      #{getCssVarName('scrollbar-opacity')},
+      map.get($scrollbar, 'opacity')
+    );
+
+    &:hover {
+      background-color: var(
+        #{getCssVarName('scrollbar-hover-bg-color')},
+        map.get($scrollbar, 'hover-bg-color')
+      );
+      opacity: var(
+        #{getCssVarName('scrollbar-hover-opacity')},
+        map.get($scrollbar, 'hover-opacity')
+      );
+    }
+  }
+
+  @include e(bar) {
+    position: absolute;
+    right: 2px;
+    bottom: 2px;
+    z-index: 1;
+    border-radius: 4px;
+
+    @include when(vertical) {
+      width: 6px;
+      top: 2px;
+
+      > div {
+        width: 100%;
+      }
+    }
+
+    @include when(horizontal) {
+      height: 6px;
+      left: 2px;
+
+      > div {
+        height: 100%;
+      }
+    }
+  }
+}
+
+.#{$namespace}-scrollbar-fade {
+  &-enter-active {
+    transition: opacity 340ms ease-out;
+  }
+
+  &-leave-active {
+    transition: opacity 120ms ease-out;
+  }
+
+  &-enter-from,
+  &-leave-active {
+    opacity: 0;
+  }
+}

--- a/common/g-utils/styles/tooltip-v2.scss
+++ b/common/g-utils/styles/tooltip-v2.scss
@@ -1,0 +1,95 @@
+@use 'mixins' as *;
+@use 'var-mixins' as *;
+@use 'tokens' as *;
+
+@include b(tooltip-v2) {
+  @include e(content) {
+    --#{$namespace}-tooltip-v2-padding: 5px 10px;
+    --#{$namespace}-tooltip-v2-border-radius: 4px;
+
+    @include css-var-from-global(
+      ('tooltip-v2', 'border-color'),
+      ('border-color')
+    );
+
+    border-radius: getCssVar('tooltip-v2-border-radius');
+    color: getCssVar('color-black');
+    background-color: getCssVar('color-white');
+    padding: getCssVar('tooltip-v2-padding');
+    border: 1px solid getCssVar('border-color');
+
+    $content-selector: &;
+
+    $sides: (
+      'top': 'bottom',
+      'bottom': 'top',
+      'left': 'right',
+      'right': 'left',
+    );
+
+    @include e(arrow) {
+      position: absolute;
+      color: getCssVar('color-white');
+      width: var(--#{$namespace}-tooltip-v2-arrow-width);
+      height: var(--#{$namespace}-tooltip-v2-arrow-height);
+      pointer-events: none;
+      left: var(--#{$namespace}-tooltip-v2-arrow-x);
+      top: var(--#{$namespace}-tooltip-v2-arrow-y);
+
+      &::before {
+        content: '';
+        width: 0;
+        height: 0;
+        border: var(--#{$namespace}-tooltip-v2-arrow-border-width) solid
+          transparent;
+        position: absolute;
+      }
+
+      &::after {
+        content: '';
+        width: 0;
+        height: 0;
+        border: var(--#{$namespace}-tooltip-v2-arrow-border-width) solid
+          transparent;
+        position: absolute;
+      }
+
+      @each $side, $opposite in $sides {
+        #{$content-selector}[data-side^='#{$side}'] & {
+          #{$opposite}: 0;
+        }
+
+        #{$content-selector}[data-side^='#{$side}'] &::before {
+          border-#{$side}-color: var(--#{$namespace}-color-white);
+          border-#{$side}-width: var(
+            --#{$namespace}-tooltip-v2-arrow-border-width
+          );
+          border-#{$opposite}: 0;
+          #{$side}: calc(100% - 1px);
+        }
+
+        #{$content-selector}[data-side^='#{$side}'] &::after {
+          border-#{$side}-color: var(--#{$namespace}-border-color);
+          border-#{$side}-width: var(
+            --#{$namespace}-tooltip-v2-arrow-border-width
+          );
+          border-#{$opposite}: 0;
+          #{$side}: 100%;
+          z-index: -1;
+        }
+      }
+    }
+
+    &.is-dark {
+      --#{$namespace}-tooltip-v2-border-color: transparent;
+      background-color: getCssVar('color-black');
+      color: getCssVar('color-white');
+      border-color: transparent;
+
+      @include e(arrow) {
+        background-color: getCssVar('color-black');
+        border-color: transparent;
+      }
+    }
+  }
+}

--- a/common/g-utils/styles/virtual-list.scss
+++ b/common/g-utils/styles/virtual-list.scss
@@ -1,0 +1,40 @@
+@use 'mixins' as *;
+@use 'tokens' as *;
+
+@mixin showScrollbar {
+  @include b(virtual-scrollbar) {
+    opacity: 1;
+  }
+}
+
+@include b(vl) {
+  @include e(wrapper) {
+    position: relative;
+    &:hover {
+      @include showScrollbar();
+    }
+    &.always-on {
+      @include showScrollbar();
+    }
+  }
+}
+
+.#{$namespace}-vl__window {
+  scrollbar-width: none;
+  &::-webkit-scrollbar {
+    display: none;
+  }
+}
+@include b(virtual-scrollbar) {
+  opacity: 0;
+  transition: opacity 340ms ease-out;
+  &.always-on {
+    opacity: 1;
+  }
+}
+
+@include b(vg) {
+  @include e(wrapper) {
+    position: relative;
+  }
+}

--- a/scripts/scss-parity/baseline/g-utils-option.css
+++ b/scripts/scss-parity/baseline/g-utils-option.css
@@ -1,0 +1,50 @@
+/* Element Chalk Variables */
+.gui-select-dropdown__item {
+  font-size: var(--gui-font-size-base);
+  padding: 0 32px 0 20px;
+  position: relative;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  color: var(--gui-text-color-regular);
+  height: 34px;
+  line-height: 34px;
+  box-sizing: border-box;
+  cursor: pointer;
+}
+.gui-select-dropdown__item.is-hovering {
+  background-color: var(--gui-fill-color-light);
+}
+
+.gui-select-dropdown__item.is-selected {
+  color: var(--gui-color-primary);
+  font-weight: bold;
+}
+
+.gui-select-dropdown__item.is-disabled {
+  color: var(--gui-text-color-placeholder);
+  cursor: not-allowed;
+  background-color: unset;
+}
+
+.gui-select-dropdown.is-multiple .gui-select-dropdown__item.is-selected::after {
+  content: "";
+  position: absolute;
+  top: 50%;
+  right: 20px;
+  border-top: none;
+  border-right: none;
+  background-repeat: no-repeat;
+  background-position: center;
+  background-color: var(--gui-color-primary);
+  mask: url("data:image/svg+xml;utf8,%3Csvg class='icon' width='200' height='200' viewBox='0 0 1024 1024' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath fill='currentColor' d='M406.656 706.944L195.84 496.256a32 32 0 10-45.248 45.248l256 256 512-512a32 32 0 00-45.248-45.248L406.592 706.944z'%3E%3C/path%3E%3C/svg%3E") no-repeat;
+  mask-size: 100% 100%;
+  -webkit-mask: url("data:image/svg+xml;utf8,%3Csvg class='icon' width='200' height='200' viewBox='0 0 1024 1024' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath fill='currentColor' d='M406.656 706.944L195.84 496.256a32 32 0 10-45.248 45.248l256 256 512-512a32 32 0 00-45.248-45.248L406.592 706.944z'%3E%3C/path%3E%3C/svg%3E") no-repeat;
+  -webkit-mask-size: 100% 100%;
+  transform: translateY(-50%);
+  width: 12px;
+  height: 12px;
+}
+.gui-select-dropdown.is-multiple .gui-select-dropdown__item.is-disabled::after {
+  background-color: var(--gui-text-color-placeholder);
+}

--- a/scripts/scss-parity/baseline/g-utils-overlay-theme.css
+++ b/scripts/scss-parity/baseline/g-utils-overlay-theme.css
@@ -1,0 +1,15 @@
+/* Element Chalk Variables */
+.gui-overlay {
+  position: fixed;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  z-index: 2000;
+  height: 100%;
+  background-color: var(--gui-overlay-color-lighter);
+  overflow: auto;
+}
+.gui-overlay .gui-overlay-root {
+  height: 0;
+}

--- a/scripts/scss-parity/baseline/g-utils-scrollbar-theme.css
+++ b/scripts/scss-parity/baseline/g-utils-scrollbar-theme.css
@@ -1,0 +1,72 @@
+/* Element Chalk Variables */
+.gui-scrollbar {
+  --gui-scrollbar-opacity: 0.3;
+  --gui-scrollbar-bg-color: var(--gui-text-color-secondary);
+  --gui-scrollbar-hover-opacity: 0.5;
+  --gui-scrollbar-hover-bg-color: var(--gui-text-color-secondary);
+}
+
+.gui-scrollbar {
+  overflow: hidden;
+  position: relative;
+  height: 100%;
+}
+.gui-scrollbar__wrap {
+  overflow: auto;
+  height: 100%;
+}
+.gui-scrollbar__wrap--hidden-default {
+  scrollbar-width: none;
+}
+.gui-scrollbar__wrap--hidden-default::-webkit-scrollbar {
+  display: none;
+}
+
+.gui-scrollbar__thumb {
+  position: relative;
+  display: block;
+  width: 0;
+  height: 0;
+  cursor: pointer;
+  border-radius: inherit;
+  background-color: var(--gui-scrollbar-bg-color, var(--gui-text-color-secondary));
+  transition: var(--gui-transition-duration) background-color;
+  opacity: var(--gui-scrollbar-opacity, 0.3);
+}
+.gui-scrollbar__thumb:hover {
+  background-color: var(--gui-scrollbar-hover-bg-color, var(--gui-text-color-secondary));
+  opacity: var(--gui-scrollbar-hover-opacity, 0.5);
+}
+
+.gui-scrollbar__bar {
+  position: absolute;
+  right: 2px;
+  bottom: 2px;
+  z-index: 1;
+  border-radius: 4px;
+}
+.gui-scrollbar__bar.is-vertical {
+  width: 6px;
+  top: 2px;
+}
+.gui-scrollbar__bar.is-vertical > div {
+  width: 100%;
+}
+
+.gui-scrollbar__bar.is-horizontal {
+  height: 6px;
+  left: 2px;
+}
+.gui-scrollbar__bar.is-horizontal > div {
+  height: 100%;
+}
+
+.gui-scrollbar-fade-enter-active {
+  transition: opacity 340ms ease-out;
+}
+.gui-scrollbar-fade-leave-active {
+  transition: opacity 120ms ease-out;
+}
+.gui-scrollbar-fade-enter-from, .gui-scrollbar-fade-leave-active {
+  opacity: 0;
+}

--- a/scripts/scss-parity/baseline/g-utils-tooltip-v2.css
+++ b/scripts/scss-parity/baseline/g-utils-tooltip-v2.css
@@ -1,0 +1,109 @@
+/* Element Chalk Variables */
+.gui-tooltip-v2__content {
+  --gui-tooltip-v2-padding: 5px 10px;
+  --gui-tooltip-v2-border-radius: 4px;
+  --gui-tooltip-v2-border-color: var(--gui-border-color);
+  border-radius: var(--gui-tooltip-v2-border-radius);
+  color: var(--gui-color-black);
+  background-color: var(--gui-color-white);
+  padding: var(--gui-tooltip-v2-padding);
+  border: 1px solid var(--gui-border-color);
+}
+.gui-tooltip-v2__arrow {
+  position: absolute;
+  color: var(--gui-color-white);
+  width: var(--gui-tooltip-v2-arrow-width);
+  height: var(--gui-tooltip-v2-arrow-height);
+  pointer-events: none;
+  left: var(--gui-tooltip-v2-arrow-x);
+  top: var(--gui-tooltip-v2-arrow-y);
+}
+.gui-tooltip-v2__arrow::before {
+  content: "";
+  width: 0;
+  height: 0;
+  border: var(--gui-tooltip-v2-arrow-border-width) solid transparent;
+  position: absolute;
+}
+.gui-tooltip-v2__arrow::after {
+  content: "";
+  width: 0;
+  height: 0;
+  border: var(--gui-tooltip-v2-arrow-border-width) solid transparent;
+  position: absolute;
+}
+.gui-tooltip-v2__content[data-side^=top] .gui-tooltip-v2__arrow {
+  bottom: 0;
+}
+.gui-tooltip-v2__content[data-side^=top] .gui-tooltip-v2__arrow::before {
+  border-top-color: var(--gui-color-white);
+  border-top-width: var(--gui-tooltip-v2-arrow-border-width);
+  border-bottom: 0;
+  top: calc(100% - 1px);
+}
+.gui-tooltip-v2__content[data-side^=top] .gui-tooltip-v2__arrow::after {
+  border-top-color: var(--gui-border-color);
+  border-top-width: var(--gui-tooltip-v2-arrow-border-width);
+  border-bottom: 0;
+  top: 100%;
+  z-index: -1;
+}
+.gui-tooltip-v2__content[data-side^=bottom] .gui-tooltip-v2__arrow {
+  top: 0;
+}
+.gui-tooltip-v2__content[data-side^=bottom] .gui-tooltip-v2__arrow::before {
+  border-bottom-color: var(--gui-color-white);
+  border-bottom-width: var(--gui-tooltip-v2-arrow-border-width);
+  border-top: 0;
+  bottom: calc(100% - 1px);
+}
+.gui-tooltip-v2__content[data-side^=bottom] .gui-tooltip-v2__arrow::after {
+  border-bottom-color: var(--gui-border-color);
+  border-bottom-width: var(--gui-tooltip-v2-arrow-border-width);
+  border-top: 0;
+  bottom: 100%;
+  z-index: -1;
+}
+.gui-tooltip-v2__content[data-side^=left] .gui-tooltip-v2__arrow {
+  right: 0;
+}
+.gui-tooltip-v2__content[data-side^=left] .gui-tooltip-v2__arrow::before {
+  border-left-color: var(--gui-color-white);
+  border-left-width: var(--gui-tooltip-v2-arrow-border-width);
+  border-right: 0;
+  left: calc(100% - 1px);
+}
+.gui-tooltip-v2__content[data-side^=left] .gui-tooltip-v2__arrow::after {
+  border-left-color: var(--gui-border-color);
+  border-left-width: var(--gui-tooltip-v2-arrow-border-width);
+  border-right: 0;
+  left: 100%;
+  z-index: -1;
+}
+.gui-tooltip-v2__content[data-side^=right] .gui-tooltip-v2__arrow {
+  left: 0;
+}
+.gui-tooltip-v2__content[data-side^=right] .gui-tooltip-v2__arrow::before {
+  border-right-color: var(--gui-color-white);
+  border-right-width: var(--gui-tooltip-v2-arrow-border-width);
+  border-left: 0;
+  right: calc(100% - 1px);
+}
+.gui-tooltip-v2__content[data-side^=right] .gui-tooltip-v2__arrow::after {
+  border-right-color: var(--gui-border-color);
+  border-right-width: var(--gui-tooltip-v2-arrow-border-width);
+  border-left: 0;
+  right: 100%;
+  z-index: -1;
+}
+
+.gui-tooltip-v2__content.is-dark {
+  --gui-tooltip-v2-border-color: transparent;
+  background-color: var(--gui-color-black);
+  color: var(--gui-color-white);
+  border-color: transparent;
+}
+.gui-tooltip-v2__content.is-dark .gui-tooltip-v2__arrow {
+  background-color: var(--gui-color-black);
+  border-color: transparent;
+}

--- a/scripts/scss-parity/baseline/g-utils-virtual-list.css
+++ b/scripts/scss-parity/baseline/g-utils-virtual-list.css
@@ -1,0 +1,29 @@
+/* Element Chalk Variables */
+.gui-vl__wrapper {
+  position: relative;
+}
+.gui-vl__wrapper:hover .gui-virtual-scrollbar {
+  opacity: 1;
+}
+.gui-vl__wrapper.always-on .gui-virtual-scrollbar {
+  opacity: 1;
+}
+
+.gui-vl__window {
+  scrollbar-width: none;
+}
+.gui-vl__window::-webkit-scrollbar {
+  display: none;
+}
+
+.gui-virtual-scrollbar {
+  opacity: 0;
+  transition: opacity 340ms ease-out;
+}
+.gui-virtual-scrollbar.always-on {
+  opacity: 1;
+}
+
+.gui-vg__wrapper {
+  position: relative;
+}

--- a/scripts/scss-parity/targets.json
+++ b/scripts/scss-parity/targets.json
@@ -25,5 +25,10 @@
   "quote": "components/quote/src/quote.styles.scss",
   "toast": "components/toast/src/toast.styles.scss",
   "g-utils-popper": "common/g-utils/styles/popper.scss",
-  "popper": "components/popper/src/popper.styles.scss"
+  "popper": "components/popper/src/popper.styles.scss",
+  "g-utils-scrollbar-theme": "common/g-utils/styles/scrollbar.scss",
+  "g-utils-tooltip-v2": "common/g-utils/styles/tooltip-v2.scss",
+  "g-utils-option": "common/g-utils/styles/option.scss",
+  "g-utils-virtual-list": "common/g-utils/styles/virtual-list.scss",
+  "g-utils-overlay-theme": "common/g-utils/styles/overlay.scss"
 }


### PR DESCRIPTION
## Qué

Segunda slice de WU4. Porta byte-exacto 5 themes de element-plus **compartidos** entre múltiples componentes a g-utils, bajo la arquitectura híbrida acordada (compartidos → g-utils, específicos → per-componente):

- `scrollbar` → `./scrollbar`
- `tooltip-v2` → `./tooltip-v2`
- `option` → `./option`
- `virtual-list` → `./virtual-list`
- `overlay` → `./overlay`

Repunte interno de cada uno: `mixins/mixins`→`mixins`, `mixins/var`→`var-mixins`, `common/var`→`tokens`.

## Alcance

**Solo adición** — ningún componente consume estos exports todavía. Se usarán en slices siguientes para repuntar `dropdown`, `select`, `table`, `tooltip` y `date-picker`. Sin riesgo de regresión (nada cambia en lo que emite ningún consumidor hoy) → no requiere validación por link en b2b.

## Verificación

- **Byte-exacto**: los 5 ports compilan idénticos a sus fuentes de element-plus en namespace `gui`.
- **Parity harness**: 32/32 OK.
- Tests pre-push ✅.