### PR TITLE
refactor(styles): repoint checkbox/radio/drawer/dropdown/input-tag off element-plus (ep-extraction-scss WU4 S4)

### DIFF
--- a/common/g-utils/package.json
+++ b/common/g-utils/package.json
@@ -22,7 +22,9 @@
     "./tooltip-v2": "./styles/tooltip-v2.scss",
     "./option": "./styles/option.scss",
     "./virtual-list": "./styles/virtual-list.scss",
-    "./overlay": "./styles/overlay.scss"
+    "./overlay": "./styles/overlay.scss",
+    "./button-mixins": "./styles/button-mixins.scss",
+    "./radio-group": "./styles/radio-group.scss"
   },
   "sideEffects": [
     "**/*.scss",

--- a/common/g-utils/styles/button-mixins.scss
+++ b/common/g-utils/styles/button-mixins.scss
@@ -1,0 +1,165 @@
+@use 'var-mixins' as *;
+@use 'function' as *;
+@use 'tokens' as *;
+
+@mixin button-plain($type) {
+  $button-color-types: (
+    '': (
+      'text-color': (
+        'color',
+        $type,
+      ),
+      'bg-color': (
+        'color',
+        $type,
+        'light-9',
+      ),
+      'border-color': (
+        'color',
+        $type,
+        'light-5',
+      ),
+    ),
+    'hover': (
+      'text-color': (
+        'color',
+        'white',
+      ),
+      'bg-color': (
+        'color',
+        $type,
+      ),
+      'border-color': (
+        'color',
+        $type,
+      ),
+    ),
+    'active': (
+      'text-color': (
+        'color',
+        'white',
+      ),
+    ),
+  );
+
+  @each $type, $typeMap in $button-color-types {
+    @each $typeColor, $list in $typeMap {
+      @include css-var-from-global(('button', $type, $typeColor), $list);
+    }
+  }
+
+  &.is-disabled {
+    &,
+    &:hover,
+    &:focus,
+    &:active {
+      color: getCssVar('color', $type, 'light-5');
+      background-color: getCssVar('color', $type, 'light-9');
+      border-color: getCssVar('color', $type, 'light-8');
+    }
+  }
+}
+
+@mixin button-variant($type) {
+  $button-color-types: (
+    '': (
+      'text-color': (
+        'color',
+        'white',
+      ),
+      'bg-color': (
+        'color',
+        $type,
+      ),
+      'border-color': (
+        'color',
+        $type,
+      ),
+      'outline-color': (
+        'color',
+        $type,
+        'light-5',
+      ),
+      'active-color': (
+        'color',
+        $type,
+        'dark-2',
+      ),
+    ),
+    'hover': (
+      'text-color': (
+        'color',
+        'white',
+      ),
+      'link-text-color': (
+        'color',
+        $type,
+        'light-5',
+      ),
+      'bg-color': (
+        'color',
+        $type,
+        'light-3',
+      ),
+      'border-color': (
+        'color',
+        $type,
+        'light-3',
+      ),
+    ),
+    'active': (
+      'bg-color': (
+        'color',
+        $type,
+        'dark-2',
+      ),
+      'border-color': (
+        'color',
+        $type,
+        'dark-2',
+      ),
+    ),
+    'disabled': (
+      'text-color': (
+        'color',
+        'white',
+      ),
+      'bg-color': (
+        'color',
+        $type,
+        'light-5',
+      ),
+      'border-color': (
+        'color',
+        $type,
+        'light-5',
+      ),
+    ),
+  );
+
+  @each $type, $typeMap in $button-color-types {
+    @each $typeColor, $list in $typeMap {
+      @include css-var-from-global(('button', $type, $typeColor), $list);
+    }
+  }
+
+  &.is-plain,
+  &.is-text,
+  &.is-link {
+    @include button-plain($type);
+  }
+}
+
+@mixin button-size(
+  $padding-vertical,
+  $padding-horizontal,
+  $font-size,
+  $border-radius
+) {
+  padding: $padding-vertical $padding-horizontal;
+  font-size: $font-size;
+  border-radius: $border-radius;
+  &.is-round {
+    padding: $padding-vertical $padding-horizontal;
+  }
+}

--- a/common/g-utils/styles/mixins.scss
+++ b/common/g-utils/styles/mixins.scss
@@ -1,11 +1,13 @@
 // BEM mixins — mirrors element-plus/theme-chalk/src/mixins/mixins.scss
 // b/e/m/when produce CSS output IDENTICAL to element-plus theme-chalk.
 @use 'function' as *;
+@use 'tokens' as *;
 // Forward config so consumers can do @forward '@flash-global66/g-utils/config' with ($namespace: 'gui')
 @forward 'config';
 // Forward function so `@use 'mixins' as *;` also exposes getCssVar/getCssVarName/
 // joinVarName/getCssVarWithDefault (mirrors element-plus/theme-chalk/src/mixins/mixins.scss).
 @forward 'function';
+@forward 'var-mixins';
 @use 'config' as *;
 @use 'sass:string';
 @use 'sass:map';
@@ -78,5 +80,157 @@ $E: null !default;
     &.#{$state-prefix + $state} {
       @content;
     }
+  }
+}
+// Break-points
+@mixin res($key, $map: $breakpoints) {
+  // loop breakpoint Map, return if present
+  @if map.has-key($map, $key) {
+    @media only screen and #{string.unquote(map.get($map, $key))} {
+      @content;
+    }
+  } @else {
+    @warn "Undefined points: `#{$map}`";
+  }
+}
+// Scrollbar
+@mixin scroll-bar {
+  $scrollbar-thumb-background: getCssVar('text-color', 'disabled');
+  $scrollbar-track-background: getCssVar('fill-color', 'blank');
+
+  &::-webkit-scrollbar {
+    z-index: 11;
+    width: 6px;
+
+    &:horizontal {
+      height: 6px;
+    }
+
+    &-thumb {
+      border-radius: 5px;
+      width: 6px;
+      background: $scrollbar-thumb-background;
+    }
+
+    &-corner {
+      background: $scrollbar-track-background;
+    }
+
+    &-track {
+      background: $scrollbar-track-background;
+
+      &-piece {
+        background: $scrollbar-track-background;
+        width: 6px;
+      }
+    }
+  }
+}
+@mixin configurable-m($modifier, $E-flag: false) {
+  $selector: &;
+  $interpolation: '';
+
+  @if $E-flag {
+    $interpolation: $element-separator + $E-flag;
+  }
+
+  @at-root {
+    #{$selector} {
+      .#{$B + $interpolation + $modifier-separator + $modifier} {
+        @content;
+      }
+    }
+  }
+}
+@mixin spec-selector(
+  $specSelector: '',
+  $element: $E,
+  $modifier: false,
+  $block: $B
+) {
+  $modifierCombo: '';
+
+  @if $modifier {
+    $modifierCombo: $modifier-separator + $modifier;
+  }
+
+  @at-root {
+    #{&}#{$specSelector}.#{$block
+      + $element-separator
+      + $element
+      + $modifierCombo} {
+      @content;
+    }
+  }
+}
+@mixin meb($modifier: false, $element: $E, $block: $B) {
+  $selector: &;
+  $modifierCombo: '';
+
+  @if $modifier {
+    $modifierCombo: $modifier-separator + $modifier;
+  }
+
+  @at-root {
+    #{$selector} {
+      .#{$block + $element-separator + $element + $modifierCombo} {
+        @content;
+      }
+    }
+  }
+}
+@mixin extend-rule($name) {
+  @extend #{'%shared-' + $name} !optional;
+}
+@mixin share-rule($name) {
+  $rule-name: '%shared-' + $name;
+
+  @at-root #{$rule-name} {
+    @content;
+  }
+}
+@mixin pseudo($pseudo) {
+  @at-root #{&}#{':#{$pseudo}'} {
+    @content;
+  }
+}
+@mixin picker-popper($background, $border, $box-shadow) {
+  &.#{$namespace}-popper {
+    background: $background;
+    border: $border;
+    box-shadow: $box-shadow;
+
+    .#{$namespace}-popper__arrow {
+      &::before {
+        border: $border;
+      }
+    }
+
+    @each $placement,
+      $adjacency
+        in ('top': 'left', 'bottom': 'right', 'left': 'bottom', 'right': 'top')
+    {
+      &[data-popper-placement^='#{$placement}'] {
+        .#{$namespace}-popper__arrow::before {
+          border-#{$placement}-color: transparent;
+          border-#{$adjacency}-color: transparent;
+        }
+      }
+    }
+  }
+}
+// dark
+@mixin dark($block) {
+  html.dark {
+    @include b($block) {
+      @content;
+    }
+  }
+}
+@mixin inset-input-border($color, $important: false) {
+  @if $important == true {
+    box-shadow: 0 0 0 1px $color inset !important;
+  } @else {
+    box-shadow: 0 0 0 1px $color inset;
   }
 }

--- a/common/g-utils/styles/radio-group.scss
+++ b/common/g-utils/styles/radio-group.scss
@@ -1,0 +1,9 @@
+@use 'mixins' as *;
+@use 'tokens' as *;
+
+@include b(radio-group) {
+  display: inline-flex;
+  align-items: center;
+  flex-wrap: wrap;
+  font-size: 0;
+}

--- a/components/checkbox/src/checkbox.styles.scss
+++ b/components/checkbox/src/checkbox.styles.scss
@@ -1,8 +1,8 @@
-@use "element-plus/theme-chalk/src/checkbox.scss" as *;
-@use "element-plus/theme-chalk/src/mixins/mixins" as *;
-@use "element-plus/theme-chalk/src/mixins/utils" as *;
-@use "element-plus/theme-chalk/src/mixins/var" as *;
-@use "element-plus/theme-chalk/src/common/var" as *;
+@use "./styles/checkbox.scss" as *;
+@use "@flash-global66/g-utils/mixins" as *;
+@use "@flash-global66/g-utils/utils" as *;
+@use "@flash-global66/g-utils/var-mixins" as *;
+@use "@flash-global66/g-utils/tokens" as *;
 
 @include b("checkbox") {
   @apply text-3 gap-xxs m-0 h-fit items-center;

--- a/components/checkbox/src/styles/checkbox.scss
+++ b/components/checkbox/src/styles/checkbox.scss
@@ -1,0 +1,298 @@
+@use 'sass:map';
+
+@use '@flash-global66/g-utils/tokens' as *;
+@use '@flash-global66/g-utils/mixins' as *;
+@use '@flash-global66/g-utils/var-mixins' as *;
+@use '@flash-global66/g-utils/button-mixins' as button;
+@use '@flash-global66/g-utils/utils' as *;
+
+$checkbox-height: () !default;
+$checkbox-height: map.merge($common-component-size, $checkbox-height);
+
+$checkbox-bordered-input-height: () !default;
+$checkbox-bordered-input-height: map.merge(
+  (
+    'large': 14px,
+    'default': 12px,
+    'small': 12px,
+  ),
+  $checkbox-bordered-input-height
+);
+
+$checkbox-font-size: () !default;
+$checkbox-font-size: map.merge(
+  (
+    'large': 14px,
+    'small': 12px,
+  ),
+  $checkbox-font-size
+);
+
+$checkbox-bordered-input-width: () !default;
+$checkbox-bordered-input-width: map.merge(
+  $checkbox-bordered-input-height,
+  $checkbox-bordered-input-width
+);
+
+@include b(checkbox) {
+  @include set-component-css-var('checkbox', $checkbox);
+}
+
+@include b(checkbox) {
+  color: getCssVar('checkbox-text-color');
+  font-weight: getCssVar('checkbox-font-weight');
+  font-size: getCssVar('font-size', 'base');
+  position: relative;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  white-space: nowrap;
+  user-select: none;
+  margin-right: 30px;
+  height: getCssVarWithDefault(
+    'checkbox-height',
+    map.get($checkbox-height, 'default')
+  );
+
+  @include when(disabled) {
+    cursor: not-allowed;
+  }
+
+  @include when(bordered) {
+    padding: 0 map.get($checkbox-bordered-padding-right, 'default')-$border-width
+      0 map.get($checkbox-bordered-padding-left, 'default')-$border-width;
+    border-radius: getCssVar('border-radius-base');
+    border: getCssVar('border');
+    box-sizing: border-box;
+
+    &.is-checked {
+      border-color: getCssVar('color-primary');
+    }
+
+    &.is-disabled {
+      border-color: getCssVar('border-color-lighter');
+    }
+
+    @each $size in (large, small) {
+      &.#{$namespace}-checkbox--#{$size} {
+        padding: 0
+          map.get($checkbox-bordered-padding-right, $size)-$border-width
+          0
+          map.get($checkbox-bordered-padding-left, $size)-$border-width;
+
+        border-radius: map.get($button-border-radius, $size);
+
+        .#{$namespace}-checkbox__label {
+          font-size: map.get($button-font-size, $size);
+        }
+
+        .#{$namespace}-checkbox__inner {
+          height: map.get($checkbox-bordered-input-height, $size);
+          width: map.get($checkbox-bordered-input-width, $size);
+        }
+      }
+    }
+
+    &.#{$namespace}-checkbox--small {
+      .#{$namespace}-checkbox__inner {
+        &::after {
+          height: 6px;
+          width: 2px;
+        }
+      }
+    }
+  }
+
+  input:focus-visible {
+    & + .#{$namespace}-checkbox__inner {
+      outline: 2px solid getCssVar('checkbox-input-border-color-hover');
+      outline-offset: 1px;
+      border-radius: getCssVar('checkbox-border-radius');
+    }
+  }
+
+  @include e(input) {
+    white-space: nowrap;
+    cursor: pointer;
+    outline: none;
+    display: inline-flex;
+    position: relative;
+
+    @include when(disabled) {
+      .#{$namespace}-checkbox__inner {
+        background-color: getCssVar('checkbox-disabled-input-fill');
+        border-color: getCssVar('checkbox-disabled-border-color');
+        cursor: not-allowed;
+
+        &::after {
+          cursor: not-allowed;
+          border-color: getCssVar('checkbox-disabled-icon-color');
+        }
+      }
+
+      &.is-checked {
+        .#{$namespace}-checkbox__inner {
+          background-color: getCssVar('checkbox-disabled-checked-input-fill');
+          border-color: getCssVar(
+            'checkbox-disabled-checked-input-border-color'
+          );
+
+          &::after {
+            border-color: getCssVar('checkbox-disabled-checked-icon-color');
+          }
+        }
+      }
+
+      &.is-indeterminate {
+        .#{$namespace}-checkbox__inner {
+          background-color: getCssVar('checkbox-disabled-checked-input-fill');
+          border-color: getCssVar(
+            'checkbox-disabled-checked-input-border-color'
+          );
+
+          &::before {
+            background-color: getCssVar('checkbox-disabled-checked-icon-color');
+            border-color: getCssVar('checkbox-disabled-checked-icon-color');
+          }
+        }
+      }
+
+      & + span.#{$namespace}-checkbox__label {
+        color: getCssVar('disabled-text-color');
+        cursor: not-allowed;
+      }
+    }
+
+    @include when(checked) {
+      .#{$namespace}-checkbox__inner {
+        background-color: getCssVar('checkbox-checked-bg-color');
+        border-color: getCssVar('checkbox-checked-input-border-color');
+
+        &::after {
+          transform: rotate(45deg) scaleY(1);
+          border-color: getCssVar('checkbox-checked-icon-color');
+        }
+      }
+
+      & + .#{$namespace}-checkbox__label {
+        color: getCssVar('checkbox-checked-text-color');
+      }
+    }
+    @include when(focus) {
+      // Visually distinguish when focus
+      &:not(.is-checked) {
+        .#{$namespace}-checkbox__original:not(:focus-visible) {
+          border-color: getCssVar('checkbox-input-border-color-hover');
+        }
+      }
+    }
+    @include when(indeterminate) {
+      .#{$namespace}-checkbox__inner {
+        background-color: getCssVar('checkbox-checked-bg-color');
+        border-color: getCssVar('checkbox-checked-input-border-color');
+
+        &::before {
+          content: '';
+          position: absolute;
+          display: block;
+          background-color: getCssVar('checkbox-checked-icon-color');
+          height: 2px;
+          transform: scale(0.5);
+          left: 0;
+          right: 0;
+          top: 5px;
+        }
+
+        &::after {
+          display: none;
+        }
+      }
+    }
+  }
+  @include e(inner) {
+    display: inline-block;
+    position: relative;
+    border: getCssVar('checkbox-input-border');
+    border-radius: getCssVar('checkbox-border-radius');
+    box-sizing: border-box;
+    width: getCssVar('checkbox-input-width');
+    height: getCssVar('checkbox-input-height');
+    background-color: getCssVar('checkbox-bg-color');
+    z-index: getCssVar('index-normal');
+    transition: border-color 0.25s cubic-bezier(0.71, -0.46, 0.29, 1.46),
+      background-color 0.25s cubic-bezier(0.71, -0.46, 0.29, 1.46),
+      outline 0.25s cubic-bezier(0.71, -0.46, 0.29, 1.46);
+
+    &:hover {
+      border-color: getCssVar('checkbox-input-border-color-hover');
+    }
+
+    &::after {
+      box-sizing: content-box;
+      content: '';
+      border: 1px solid transparent;
+      border-left: 0;
+      border-top: 0;
+      height: 7px;
+      left: 4px;
+      position: absolute;
+      top: 1px;
+      transform: rotate(45deg) scaleY(0);
+      width: 3px;
+      transition: transform 0.15s ease-in 0.05s;
+      transform-origin: center;
+    }
+  }
+
+  @include e(original) {
+    opacity: 0;
+    outline: none;
+    position: absolute;
+    margin: 0;
+    width: 0;
+    height: 0;
+    z-index: -1;
+  }
+
+  @include e(label) {
+    display: inline-block;
+    padding-left: 8px;
+    line-height: 1;
+    font-size: getCssVar('checkbox-font-size');
+  }
+
+  @each $size in (large, small) {
+    &.#{$namespace}-checkbox--#{$size} {
+      height: map.get($checkbox-height, $size);
+      @include e(label) {
+        font-size: map.get($checkbox-font-size, $size);
+      }
+      @include e(inner) {
+        width: map.get($checkbox-font-size, $size);
+        height: map.get($checkbox-font-size, $size);
+      }
+    }
+  }
+
+  &.#{$namespace}-checkbox--small {
+    @include e(input) {
+      @include when(indeterminate) {
+        @include e(inner) {
+          &::before {
+            top: 4px;
+          }
+        }
+      }
+    }
+    @include e(inner) {
+      &::after {
+        width: 2px;
+        height: 6px;
+      }
+    }
+  }
+
+  &:last-of-type {
+    margin-right: 0;
+  }
+}

--- a/components/drawer/src/drawer.styles.scss
+++ b/components/drawer/src/drawer.styles.scss
@@ -1,9 +1,9 @@
-@use 'element-plus/theme-chalk/src/drawer.scss' as *;
-@use 'element-plus/theme-chalk/src/overlay.scss' as *;
-@use 'element-plus/theme-chalk/src/mixins/mixins' as *;
-@use 'element-plus/theme-chalk/src/mixins/utils' as *;
-@use 'element-plus/theme-chalk/src/mixins/var' as *;
-@use 'element-plus/theme-chalk/src/common/var' as *;
+@use './styles/drawer.scss' as *;
+@use '@flash-global66/g-utils/overlay' as *;
+@use '@flash-global66/g-utils/mixins' as *;
+@use '@flash-global66/g-utils/utils' as *;
+@use '@flash-global66/g-utils/var-mixins' as *;
+@use '@flash-global66/g-utils/tokens' as *;
 
 @include b('drawer') {
   @include e('header') {

--- a/components/drawer/src/styles/drawer.scss
+++ b/components/drawer/src/styles/drawer.scss
@@ -1,0 +1,155 @@
+@use '@flash-global66/g-utils/mixins' as *;
+@use '@flash-global66/g-utils/var-mixins' as *;
+@use '@flash-global66/g-utils/tokens' as *;
+
+$directions: rtl, ltr, ttb, btt;
+
+@include b(drawer) {
+  @include set-component-css-var('drawer', $drawer);
+}
+
+@include b(drawer) {
+  position: absolute;
+  box-sizing: border-box;
+  background-color: getCssVar('drawer', 'bg-color');
+  display: flex;
+  flex-direction: column;
+  box-shadow: getCssVar('box-shadow', 'dark');
+  overflow: hidden;
+
+  transition: all getCssVar('transition-duration');
+
+  @each $direction in $directions {
+    .#{$direction} {
+      transform: translate(0, 0);
+    }
+  }
+
+  &__sr-focus:focus {
+    outline: none !important;
+  }
+
+  &__header {
+    align-items: center;
+    color: rgb(114, 118, 123);
+    display: flex;
+    margin-bottom: 32px;
+    padding: getCssVar('drawer-padding-primary');
+    padding-bottom: 0;
+    & > :first-child {
+      flex: 1;
+    }
+  }
+
+  &__title {
+    margin: 0;
+    flex: 1;
+    line-height: inherit;
+    font-size: 16px;
+  }
+
+  @include e(footer) {
+    padding: getCssVar('drawer-padding-primary');
+    padding-top: 10px;
+    text-align: right;
+  }
+
+  &__close-btn {
+    display: inline-flex;
+    border: none;
+    cursor: pointer;
+    font-size: getCssVar('font-size-extra-large');
+    color: inherit;
+    background-color: transparent;
+    outline: none;
+    &:focus,
+    &:hover {
+      i {
+        color: getCssVar('color-primary');
+      }
+    }
+  }
+
+  &__body {
+    flex: 1;
+    padding: getCssVar('drawer-padding-primary');
+    overflow: auto;
+    & > * {
+      box-sizing: border-box;
+    }
+  }
+
+  &.ltr,
+  &.rtl {
+    height: 100%;
+    top: 0;
+    bottom: 0;
+  }
+
+  &.ttb,
+  &.btt {
+    width: 100%;
+    left: 0;
+    right: 0;
+  }
+
+  &.ltr {
+    left: 0;
+  }
+
+  &.rtl {
+    right: 0;
+  }
+
+  &.ttb {
+    top: 0;
+  }
+
+  &.btt {
+    bottom: 0;
+  }
+}
+
+.#{$namespace}-drawer-fade {
+  &-enter-active,
+  &-leave-active {
+    transition: all getCssVar('transition-duration');
+  }
+
+  &-enter-from,
+  &-enter-active,
+  &-enter-to,
+  &-leave-from,
+  &-leave-active,
+  &-leave-to {
+    overflow: hidden !important;
+  }
+
+  &-enter-from,
+  &-leave-to {
+    background-color: transparent !important;
+  }
+
+  &-enter-from,
+  &-leave-to {
+    @each $direction in $directions {
+      .#{$direction} {
+        @if $direction == ltr {
+          transform: translateX(-100%);
+        }
+
+        @if $direction == rtl {
+          transform: translateX(100%);
+        }
+
+        @if $direction == ttb {
+          transform: translateY(-100%);
+        }
+
+        @if $direction == btt {
+          transform: translateY(100%);
+        }
+      }
+    }
+  }
+}

--- a/components/dropdown/src/dropdown.styles.scss
+++ b/components/dropdown/src/dropdown.styles.scss
@@ -1,10 +1,10 @@
-@use "element-plus/theme-chalk/src/dropdown.scss" as *;
-@use "element-plus/theme-chalk/src/scrollbar.scss" as *;
-@use "element-plus/theme-chalk/src/popper.scss" as *;
-@use 'element-plus/theme-chalk/src/mixins/mixins' as *;
-@use 'element-plus/theme-chalk/src/mixins/utils' as *;
-@use 'element-plus/theme-chalk/src/mixins/var' as *;
-@use 'element-plus/theme-chalk/src/common/var' as *;
+@use "./styles/dropdown.scss" as *;
+@use "@flash-global66/g-utils/scrollbar" as *;
+@use "@flash-global66/g-utils/popper" as *;
+@use '@flash-global66/g-utils/mixins' as *;
+@use '@flash-global66/g-utils/utils' as *;
+@use '@flash-global66/g-utils/var-mixins' as *;
+@use '@flash-global66/g-utils/tokens' as *;
 
 @include b('dropdown') {
   @include e("popper") {

--- a/components/dropdown/src/styles/dropdown.scss
+++ b/components/dropdown/src/styles/dropdown.scss
@@ -1,0 +1,208 @@
+@use 'sass:map';
+
+@use '@flash-global66/g-utils/mixins' as *;
+@use '@flash-global66/g-utils/var-mixins' as *;
+@use '@flash-global66/g-utils/tokens' as *;
+
+$dropdown-item-line-height: () !default;
+$dropdown-item-line-height: map.merge(
+  (
+    'large': 22px,
+    'default': 22px,
+    'small': 20px,
+  ),
+  $dropdown-item-line-height
+);
+
+$dropdown-item-padding: () !default;
+$dropdown-item-padding: map.merge(
+  (
+    'large': 7px 20px,
+    'default': 5px 16px,
+    'small': 2px 12px,
+  ),
+  $dropdown-item-padding
+);
+
+$dropdown-item-divided-margin: () !default;
+$dropdown-item-divided-margin: map.merge(
+  (
+    'large': 8px 0,
+    'default': 6px 0,
+    'small': 4px 0,
+  ),
+  $dropdown-item-divided-margin
+);
+
+$dropdown-caret-width: () !default;
+$dropdown-caret-width: map.merge($common-component-size, $dropdown-caret-width);
+
+$dropdown-divider-width: 1px !default;
+
+@include b(dropdown) {
+  @include set-component-css-var('dropdown', $dropdown);
+
+  display: inline-flex;
+  position: relative;
+  color: getCssVar('text-color', 'regular');
+  font-size: getCssVar('font-size', 'base');
+  line-height: 1;
+  vertical-align: top;
+
+  &.is-disabled {
+    color: getCssVar('text-color', 'placeholder');
+    cursor: not-allowed;
+  }
+
+  @include e(popper) {
+    @include set-component-css-var('dropdown', $dropdown);
+
+    // using attributes selector to override
+
+    @include picker-popper(
+      getCssVar('bg-color', 'overlay'),
+      1px solid getCssVar('border-color-light'),
+      getCssVar('dropdown-menu-box-shadow')
+    );
+
+    .#{$namespace}-dropdown-menu {
+      border: none;
+    }
+
+    #{& + '-selfdefine'} {
+      outline: none;
+    }
+
+    @include b(scrollbar__bar) {
+      z-index: calc(#{getCssVar('dropdown', 'menu-index')} + 1);
+    }
+
+    @include b(dropdown__list) {
+      list-style: none;
+      padding: 0;
+      margin: 0;
+      box-sizing: border-box;
+    }
+  }
+
+  & .#{$namespace}-dropdown__caret-button {
+    padding-left: 0;
+    padding-right: 0;
+    display: inline-flex;
+    justify-content: center;
+    align-items: center;
+    width: map.get($dropdown-caret-width, 'default');
+    border-left: none;
+
+    > span {
+      display: inline-flex;
+    }
+
+    &::before {
+      content: '';
+      position: absolute;
+      display: block;
+      width: 1px;
+      top: -1px;
+      bottom: -1px;
+      left: 0;
+      background: getCssVar('overlay-color', 'lighter');
+    }
+
+    &.#{$namespace}-button::before {
+      background: getCssVar('border-color');
+      opacity: 0.5;
+    }
+
+    & .#{$namespace}-dropdown__icon {
+      font-size: inherit;
+      padding-left: 0;
+    }
+  }
+
+  .#{$namespace}-dropdown-selfdefine {
+    // 自定义
+    outline: none;
+  }
+
+  @each $size in (large, small) {
+    @include m($size) {
+      .#{$namespace}-dropdown__caret-button {
+        width: map.get($dropdown-caret-width, $size);
+      }
+    }
+  }
+}
+
+$dropdown-menu-padding-vertical: () !default;
+$dropdown-menu-padding-vertical: map.merge(
+  (
+    'large': 8px,
+    'default': 6px,
+    'small': 4px,
+  ),
+  $dropdown-menu-padding-vertical
+);
+
+@include b(dropdown-menu) {
+  position: relative;
+  top: 0;
+  left: 0;
+  z-index: getCssVar('dropdown-menu-index');
+  padding: map.get($dropdown-menu-padding-vertical, 'default')-$border-width 0;
+  margin: 0;
+  background-color: getCssVar('bg-color', 'overlay');
+  border: none;
+  border-radius: getCssVar('border-radius-base');
+  box-shadow: none;
+  list-style: none;
+
+  @include e(item) {
+    display: flex;
+    align-items: center;
+    white-space: nowrap;
+    list-style: none;
+    line-height: map.get($dropdown-item-line-height, 'default');
+    padding: map.get($dropdown-item-padding, 'default');
+    margin: 0;
+    font-size: getCssVar('font-size', 'base');
+    color: getCssVar('text-color', 'regular');
+    cursor: pointer;
+    outline: none;
+    &:not(.is-disabled):hover,
+    &:not(.is-disabled):focus {
+      background-color: getCssVar('dropdown-menuItem-hover-fill');
+      color: getCssVar('dropdown-menuItem-hover-color');
+    }
+
+    i {
+      margin-right: 5px;
+    }
+
+    @include m(divided) {
+      margin: map.get($dropdown-item-divided-margin, 'default');
+      border-top: 1px solid getCssVar('border-color-lighter');
+    }
+
+    @include when(disabled) {
+      cursor: not-allowed;
+      color: getCssVar('text-color-disabled');
+    }
+  }
+
+  @each $size in (large, small) {
+    @include m($size) {
+      padding: map.get($dropdown-menu-padding-vertical, $size)-$border-width 0;
+
+      @include e(item) {
+        padding: map.get($dropdown-item-padding, $size);
+        line-height: map.get($dropdown-item-line-height, $size);
+        font-size: map.get($input-font-size, $size);
+
+        @include m(divided) {
+          margin: map.get($dropdown-item-divided-margin, $size);
+        }
+      }
+    }
+  }
+}

--- a/components/input-tag/src/input-tag.styles.scss
+++ b/components/input-tag/src/input-tag.styles.scss
@@ -1,12 +1,12 @@
 @use "sass:map";
 
-@use "element-plus/theme-chalk/src/input-tag.scss" as *;
+@use "./styles/input-tag.scss" as *;
 @use "@flash-global66/g-tag/src/tag.styles.scss" as *;
 @use "@flash-global66/g-tooltip/styles.scss" as *;
-@use "element-plus/theme-chalk/src/mixins/mixins" as *;
-@use "element-plus/theme-chalk/src/mixins/utils" as *;
-@use "element-plus/theme-chalk/src/mixins/var" as *;
-@use "element-plus/theme-chalk/src/common/var" as *;
+@use "@flash-global66/g-utils/mixins" as *;
+@use "@flash-global66/g-utils/utils" as *;
+@use "@flash-global66/g-utils/var-mixins" as *;
+@use "@flash-global66/g-utils/tokens" as *;
 
 @include b("input-tag") {
   @apply relative flex items-center bg-white py-sm px-xs border border-disabled-bd rounded-md min-h-12 gap-xs shadow-none text-primary-txt font-medium text-4 transition-all duration-200 ease-in;

--- a/components/input-tag/src/styles/input-tag.scss
+++ b/components/input-tag/src/styles/input-tag.scss
@@ -1,0 +1,220 @@
+@use 'sass:map';
+
+@use '@flash-global66/g-utils/mixins' as *;
+@use '@flash-global66/g-utils/utils' as *;
+@use '@flash-global66/g-utils/var-mixins' as *;
+@use '@flash-global66/g-utils/tokens' as *;
+
+@mixin mixed-input-border($color) {
+  box-shadow: 0 0 0 1px $color inset;
+}
+
+@include b(input-tag) {
+  @include set-component-css-var('input-tag', $input-tag);
+  @include css-var-from-global('input-tag-mini-height', 'component-size');
+  @include set-css-var-value(
+    ('input-tag', 'gap'),
+    map.get($input-tag-gap, default)
+  );
+  @include set-css-var-value(
+    ('input-tag', 'padding'),
+    map.get($input-tag-padding, default)
+  );
+  @include set-css-var-value(
+    ('input-tag', 'inner-padding'),
+    map.get($input-tag-inner-padding, default)
+  );
+  @include set-css-var-value(
+    ('input-tag', 'line-height'),
+    map.get($tag-height, default)
+  );
+}
+
+@include b(input-tag) {
+  display: flex;
+  align-items: center;
+  box-sizing: border-box;
+  cursor: pointer;
+  font-size: getCssVar('input-tag-font-size');
+  padding: getCssVar('input-tag-padding');
+  width: getCssVar('input-tag-width');
+  min-height: getCssVar('input-tag-mini-height');
+  line-height: getCssVar('input-tag-line-height');
+  border-radius: getCssVar('border-radius-base');
+  background-color: getCssVar('fill-color', 'blank');
+  transition: getCssVar('transition', 'duration');
+  transform: translate3d(0, 0, 0);
+  @include mixed-input-border(#{getCssVar('border-color')});
+
+  @include when(focused) {
+    @include mixed-input-border(#{getCssVar('color-primary')});
+  }
+
+  @include when(hovering) {
+    &:not(.is-focused) {
+      @include mixed-input-border(#{getCssVar('border-color-hover')});
+    }
+  }
+
+  @include when(disabled) {
+    cursor: not-allowed;
+    pointer-events: none;
+    background-color: getCssVar('fill-color', 'light');
+    @include mixed-input-border(#{getCssVar('input-tag-disabled-border')});
+
+    &:hover {
+      @include mixed-input-border(#{getCssVar('input-tag-disabled-border')});
+    }
+
+    &.is-focus {
+      @include mixed-input-border(#{getCssVar('input-focus-border-color')});
+    }
+
+    @include e(inner) {
+      @include e(input) {
+        cursor: not-allowed;
+      }
+      .#{$namespace}-tag {
+        cursor: not-allowed;
+      }
+    }
+  }
+
+  @include e(prefix) {
+    display: flex;
+    align-items: center;
+    flex-shrink: 0;
+    padding: 0 getCssVar('input-tag-inner-padding');
+    color: var(
+      #{getCssVarName('input-icon-color')},
+      map.get($input, 'icon-color')
+    );
+  }
+
+  @include e(suffix) {
+    display: flex;
+    align-items: center;
+    flex-shrink: 0;
+    padding: 0 getCssVar('input-tag-inner-padding');
+    gap: 8px;
+    color: var(
+      #{getCssVarName('input-icon-color')},
+      map.get($input, 'icon-color')
+    );
+  }
+
+  @include e(inner) {
+    position: relative;
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    flex: 1;
+    max-width: 100%;
+    min-width: 0;
+    gap: getCssVar('input-tag-gap');
+
+    @include when(left-space) {
+      margin-left: getCssVar('input-tag-inner-padding');
+    }
+
+    @include when(right-space) {
+      margin-right: getCssVar('input-tag-inner-padding');
+    }
+
+    @include when(draggable) {
+      .#{$namespace}-tag {
+        cursor: move;
+        user-select: none;
+      }
+    }
+
+    @include e(drop-indicator) {
+      position: absolute;
+      top: 0;
+      width: 1px;
+      height: var(--el-input-tag-line-height);
+      background-color: getCssVar('color-primary');
+    }
+
+    .#{$namespace}-tag {
+      max-width: 100%;
+      cursor: pointer;
+      border-color: transparent;
+
+      &.#{$namespace}-tag--plain {
+        border-color: getCssVar('tag', 'border-color');
+      }
+
+      .#{$namespace}-tag__content {
+        min-width: 0;
+        line-height: normal;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
+    }
+  }
+
+  @include e(input-wrapper) {
+    flex: 1;
+  }
+
+  @include e(input) {
+    border: none;
+    outline: none;
+    padding: 0;
+    color: getCssVar('input-tag-text-color');
+    font-size: inherit;
+    font-family: inherit;
+    line-height: inherit;
+    appearance: none;
+    width: 100%;
+    background-color: transparent;
+
+    &::placeholder {
+      color: getCssVar('input-tag-placeholder-color');
+    }
+  }
+
+  @include e(input-calculator) {
+    position: absolute;
+    left: 0;
+    top: 0;
+    max-width: 100%;
+    visibility: hidden;
+    white-space: pre;
+    overflow: hidden;
+  }
+
+  @each $size in (large, small) {
+    @include m($size) {
+      @include set-css-var-value(
+        ('input-tag', 'gap'),
+        map.get($input-tag-gap, $size)
+      );
+      @include set-css-var-value(
+        ('input-tag', 'padding'),
+        map.get($input-tag-padding, $size)
+      );
+      @include set-css-var-value(
+        ('input-tag', 'padding-left'),
+        map.get($input-tag-inner-padding, $size)
+      );
+      @include set-css-var-value(
+        ('input-tag', 'font-size'),
+        map.get($input-font-size, $size)
+      );
+
+      @if $size == small {
+        @include set-css-var-value(
+          ('input-tag', 'line-height'),
+          map.get($tag-height, $size)
+        );
+        @include css-var-from-global(
+          'input-tag-mini-height',
+          ('component-size', $size)
+        );
+      }
+    }
+  }
+}

--- a/components/radio/src/radio.styles.scss
+++ b/components/radio/src/radio.styles.scss
@@ -1,9 +1,9 @@
-@use "element-plus/theme-chalk/src/radio.scss" as *;
-@use "element-plus/theme-chalk/src/radio-group.scss" as *;
-@use "element-plus/theme-chalk/src/mixins/mixins" as *;
-@use "element-plus/theme-chalk/src/mixins/utils" as *;
-@use "element-plus/theme-chalk/src/mixins/var" as *;
-@use "element-plus/theme-chalk/src/common/var" as *;
+@use "./styles/radio.scss" as *;
+@use "@flash-global66/g-utils/radio-group" as *;
+@use "@flash-global66/g-utils/mixins" as *;
+@use "@flash-global66/g-utils/utils" as *;
+@use "@flash-global66/g-utils/var-mixins" as *;
+@use "@flash-global66/g-utils/tokens" as *;
 
 @include b("radio") {
   @apply text-3 gap-xxs m-0 h-fit items-center;

--- a/components/radio/src/styles/radio.scss
+++ b/components/radio/src/styles/radio.scss
@@ -1,0 +1,215 @@
+@use 'sass:map';
+
+@use '@flash-global66/g-utils/mixins' as *;
+@use '@flash-global66/g-utils/utils' as *;
+@use '@flash-global66/g-utils/var-mixins' as *;
+@use '@flash-global66/g-utils/button-mixins' as *;
+@use '@flash-global66/g-utils/tokens' as *;
+
+$radio-font-size: () !default;
+$radio-font-size: map.merge(
+  (
+    'large': 14px,
+    'small': 12px,
+  ),
+  $radio-font-size
+);
+
+@include b(radio) {
+  @include set-component-css-var('radio', $radio);
+}
+
+@include b(radio) {
+  color: getCssVar('radio-text-color');
+  font-weight: getCssVar('radio-font-weight');
+  position: relative;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  white-space: nowrap;
+  outline: none;
+  font-size: getCssVar('font-size', 'base');
+  user-select: none;
+  margin-right: 30px;
+  height: map.get($radio-height, 'default');
+
+  @each $size in (large, small) {
+    &.#{$namespace}-radio--#{$size} {
+      height: map.get($radio-height, $size);
+    }
+  }
+
+  @include when(bordered) {
+    padding: 0 map.get($checkbox-bordered-padding-right, 'default')-$border-width
+      0 map.get($checkbox-bordered-padding-left, 'default')-$border-width;
+
+    border-radius: getCssVar('border-radius-base');
+    border: getCssVar('border');
+    box-sizing: border-box;
+
+    &.is-checked {
+      border-color: getCssVar('color-primary');
+    }
+
+    &.is-disabled {
+      cursor: not-allowed;
+      border-color: getCssVar('border-color-lighter');
+    }
+
+    @each $size in (large, small) {
+      &.#{$namespace}-radio--#{$size} {
+        padding: 0
+          map.get($checkbox-bordered-padding-right, $size)-$border-width
+          0
+          map.get($checkbox-bordered-padding-left, $size)-$border-width;
+        border-radius: getCssVar('border-radius-base');
+
+        .#{$namespace}-radio__label {
+          font-size: map.get($button-font-size, $size);
+        }
+
+        .#{$namespace}-radio__inner {
+          height: map.get($radio-bordered-input-height, $size);
+          width: map.get($radio-bordered-input-width, $size);
+        }
+      }
+    }
+  }
+
+  &:last-child {
+    margin-right: 0;
+  }
+
+  @include e(input) {
+    white-space: nowrap;
+    cursor: pointer;
+    outline: none;
+    display: inline-flex;
+    position: relative;
+    vertical-align: middle;
+
+    @include when(disabled) {
+      .#{$namespace}-radio__inner {
+        background-color: map.get($radio-disabled, 'input-fill');
+        border-color: map.get($radio-disabled, 'input-border-color');
+        cursor: not-allowed;
+
+        &::after {
+          cursor: not-allowed;
+          background-color: map.get($radio-disabled, 'icon-color');
+        }
+
+        & + .#{$namespace}-radio__label {
+          cursor: not-allowed;
+        }
+      }
+      &.is-checked {
+        .#{$namespace}-radio__inner {
+          background-color: map.get($radio-disabled, 'checked-input-fill');
+          border-color: map.get($radio-disabled, 'checked-input-border-color');
+
+          &::after {
+            background-color: map.get($radio-disabled, 'checked-icon-color');
+          }
+        }
+      }
+      & + span.#{$namespace}-radio__label {
+        color: getCssVar('text-color', 'placeholder');
+        cursor: not-allowed;
+      }
+    }
+
+    @include when(checked) {
+      .#{$namespace}-radio__inner {
+        border-color: map.get($radio-checked, 'input-border-color');
+        background: map.get($radio-checked, 'icon-color');
+
+        &::after {
+          transform: translate(-50%, -50%) scale(1);
+        }
+      }
+
+      & + .#{$namespace}-radio__label {
+        color: map.get($radio-checked, 'text-color');
+      }
+    }
+
+    @include when(focus) {
+      .#{$namespace}-radio__inner {
+        border-color: getCssVar('radio-input-border-color-hover');
+      }
+    }
+  }
+  @include e(inner) {
+    border: getCssVar('radio-input-border');
+    border-radius: getCssVar('radio-input-border-radius');
+    width: getCssVar('radio-input-width');
+    height: getCssVar('radio-input-height');
+    background-color: getCssVar('radio-input-bg-color');
+    position: relative;
+    cursor: pointer;
+    display: inline-block;
+    box-sizing: border-box;
+
+    &:hover {
+      border-color: getCssVar('radio-input-border-color-hover');
+    }
+
+    &::after {
+      width: 4px;
+      height: 4px;
+      border-radius: getCssVar('radio-input-border-radius');
+      background-color: getCssVar('color-white');
+      content: '';
+      position: absolute;
+      left: 50%;
+      top: 50%;
+      transform: translate(-50%, -50%) scale(0);
+      transition: transform 0.15s ease-in;
+    }
+  }
+
+  @include e(original) {
+    opacity: 0;
+    outline: none;
+    position: absolute;
+    z-index: -1;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    margin: 0;
+
+    &:focus-visible {
+      & + .#{$namespace}-radio__inner {
+        outline: 2px solid getCssVar('radio-input-border-color-hover');
+        outline-offset: 1px;
+        border-radius: getCssVar('radio-input-border-radius');
+      }
+    }
+  }
+
+  &:focus:not(:focus-visible):not(.is-focus):not(:active):not(.is-disabled) {
+    /*获得焦点时 样式提醒*/
+    .#{$namespace}-radio__inner {
+      box-shadow: 0 0 2px 2px getCssVar('radio-input-border-color-hover');
+    }
+  }
+
+  @include e(label) {
+    font-size: getCssVar('radio-font-size');
+    padding-left: 8px;
+  }
+
+  @each $size in (large, small) {
+    &.#{$namespace}-radio--#{$size} {
+      @include e(label) {
+        font-size: map.get($radio-font-size, $size);
+      }
+      @include e(inner) {
+        width: map.get($radio-font-size, $size);
+        height: map.get($radio-font-size, $size);
+      }
+    }
+  }
+}

--- a/scripts/scss-parity/baseline/checkbox-theme.css
+++ b/scripts/scss-parity/baseline/checkbox-theme.css
@@ -1,0 +1,239 @@
+/* Element Chalk Variables */
+.gui-checkbox {
+  --gui-checkbox-font-size: 14px;
+  --gui-checkbox-font-weight: var(--gui-font-weight-primary);
+  --gui-checkbox-text-color: var(--gui-text-color-regular);
+  --gui-checkbox-input-height: 14px;
+  --gui-checkbox-input-width: 14px;
+  --gui-checkbox-border-radius: var(--gui-border-radius-small);
+  --gui-checkbox-bg-color: var(--gui-fill-color-blank);
+  --gui-checkbox-input-border: var(--gui-border);
+  --gui-checkbox-disabled-border-color: var(--gui-border-color);
+  --gui-checkbox-disabled-input-fill: var(--gui-fill-color-light);
+  --gui-checkbox-disabled-icon-color: var(--gui-text-color-placeholder);
+  --gui-checkbox-disabled-checked-input-fill: var(--gui-border-color-extra-light);
+  --gui-checkbox-disabled-checked-input-border-color: var(--gui-border-color);
+  --gui-checkbox-disabled-checked-icon-color: var(--gui-text-color-placeholder);
+  --gui-checkbox-checked-text-color: var(--gui-color-primary);
+  --gui-checkbox-checked-input-border-color: var(--gui-color-primary);
+  --gui-checkbox-checked-bg-color: var(--gui-color-primary);
+  --gui-checkbox-checked-icon-color: var(--gui-color-white);
+  --gui-checkbox-input-border-color-hover: var(--gui-color-primary);
+}
+
+.gui-checkbox {
+  color: var(--gui-checkbox-text-color);
+  font-weight: var(--gui-checkbox-font-weight);
+  font-size: var(--gui-font-size-base);
+  position: relative;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  white-space: nowrap;
+  user-select: none;
+  margin-right: 30px;
+  height: var(--gui-checkbox-height, 32px);
+}
+.gui-checkbox.is-disabled {
+  cursor: not-allowed;
+}
+
+.gui-checkbox.is-bordered {
+  padding: 0 15px 0 9px;
+  border-radius: var(--gui-border-radius-base);
+  border: var(--gui-border);
+  box-sizing: border-box;
+}
+.gui-checkbox.is-bordered.is-checked {
+  border-color: var(--gui-color-primary);
+}
+.gui-checkbox.is-bordered.is-disabled {
+  border-color: var(--gui-border-color-lighter);
+}
+.gui-checkbox.is-bordered.gui-checkbox--large {
+  padding: 0 19px 0 11px;
+  border-radius: var(--gui-border-radius-base);
+}
+.gui-checkbox.is-bordered.gui-checkbox--large .gui-checkbox__label {
+  font-size: var(--gui-font-size-base);
+}
+.gui-checkbox.is-bordered.gui-checkbox--large .gui-checkbox__inner {
+  height: 14px;
+  width: 14px;
+}
+.gui-checkbox.is-bordered.gui-checkbox--small {
+  padding: 0 11px 0 7px;
+  border-radius: calc(var(--gui-border-radius-base) - 1px);
+}
+.gui-checkbox.is-bordered.gui-checkbox--small .gui-checkbox__label {
+  font-size: 12px;
+}
+.gui-checkbox.is-bordered.gui-checkbox--small .gui-checkbox__inner {
+  height: 12px;
+  width: 12px;
+}
+.gui-checkbox.is-bordered.gui-checkbox--small .gui-checkbox__inner::after {
+  height: 6px;
+  width: 2px;
+}
+
+.gui-checkbox input:focus-visible + .gui-checkbox__inner {
+  outline: 2px solid var(--gui-checkbox-input-border-color-hover);
+  outline-offset: 1px;
+  border-radius: var(--gui-checkbox-border-radius);
+}
+.gui-checkbox__input {
+  white-space: nowrap;
+  cursor: pointer;
+  outline: none;
+  display: inline-flex;
+  position: relative;
+}
+.gui-checkbox__input.is-disabled .gui-checkbox__inner {
+  background-color: var(--gui-checkbox-disabled-input-fill);
+  border-color: var(--gui-checkbox-disabled-border-color);
+  cursor: not-allowed;
+}
+.gui-checkbox__input.is-disabled .gui-checkbox__inner::after {
+  cursor: not-allowed;
+  border-color: var(--gui-checkbox-disabled-icon-color);
+}
+.gui-checkbox__input.is-disabled.is-checked .gui-checkbox__inner {
+  background-color: var(--gui-checkbox-disabled-checked-input-fill);
+  border-color: var(--gui-checkbox-disabled-checked-input-border-color);
+}
+.gui-checkbox__input.is-disabled.is-checked .gui-checkbox__inner::after {
+  border-color: var(--gui-checkbox-disabled-checked-icon-color);
+}
+.gui-checkbox__input.is-disabled.is-indeterminate .gui-checkbox__inner {
+  background-color: var(--gui-checkbox-disabled-checked-input-fill);
+  border-color: var(--gui-checkbox-disabled-checked-input-border-color);
+}
+.gui-checkbox__input.is-disabled.is-indeterminate .gui-checkbox__inner::before {
+  background-color: var(--gui-checkbox-disabled-checked-icon-color);
+  border-color: var(--gui-checkbox-disabled-checked-icon-color);
+}
+.gui-checkbox__input.is-disabled + span.gui-checkbox__label {
+  color: var(--gui-disabled-text-color);
+  cursor: not-allowed;
+}
+
+.gui-checkbox__input.is-checked .gui-checkbox__inner {
+  background-color: var(--gui-checkbox-checked-bg-color);
+  border-color: var(--gui-checkbox-checked-input-border-color);
+}
+.gui-checkbox__input.is-checked .gui-checkbox__inner::after {
+  transform: rotate(45deg) scaleY(1);
+  border-color: var(--gui-checkbox-checked-icon-color);
+}
+.gui-checkbox__input.is-checked + .gui-checkbox__label {
+  color: var(--gui-checkbox-checked-text-color);
+}
+
+.gui-checkbox__input.is-focus:not(.is-checked) .gui-checkbox__original:not(:focus-visible) {
+  border-color: var(--gui-checkbox-input-border-color-hover);
+}
+
+.gui-checkbox__input.is-indeterminate .gui-checkbox__inner {
+  background-color: var(--gui-checkbox-checked-bg-color);
+  border-color: var(--gui-checkbox-checked-input-border-color);
+}
+.gui-checkbox__input.is-indeterminate .gui-checkbox__inner::before {
+  content: "";
+  position: absolute;
+  display: block;
+  background-color: var(--gui-checkbox-checked-icon-color);
+  height: 2px;
+  transform: scale(0.5);
+  left: 0;
+  right: 0;
+  top: 5px;
+}
+.gui-checkbox__input.is-indeterminate .gui-checkbox__inner::after {
+  display: none;
+}
+
+.gui-checkbox__inner {
+  display: inline-block;
+  position: relative;
+  border: var(--gui-checkbox-input-border);
+  border-radius: var(--gui-checkbox-border-radius);
+  box-sizing: border-box;
+  width: var(--gui-checkbox-input-width);
+  height: var(--gui-checkbox-input-height);
+  background-color: var(--gui-checkbox-bg-color);
+  z-index: var(--gui-index-normal);
+  transition: border-color 0.25s cubic-bezier(0.71, -0.46, 0.29, 1.46), background-color 0.25s cubic-bezier(0.71, -0.46, 0.29, 1.46), outline 0.25s cubic-bezier(0.71, -0.46, 0.29, 1.46);
+}
+.gui-checkbox__inner:hover {
+  border-color: var(--gui-checkbox-input-border-color-hover);
+}
+.gui-checkbox__inner::after {
+  box-sizing: content-box;
+  content: "";
+  border: 1px solid transparent;
+  border-left: 0;
+  border-top: 0;
+  height: 7px;
+  left: 4px;
+  position: absolute;
+  top: 1px;
+  transform: rotate(45deg) scaleY(0);
+  width: 3px;
+  transition: transform 0.15s ease-in 0.05s;
+  transform-origin: center;
+}
+
+.gui-checkbox__original {
+  opacity: 0;
+  outline: none;
+  position: absolute;
+  margin: 0;
+  width: 0;
+  height: 0;
+  z-index: -1;
+}
+
+.gui-checkbox__label {
+  display: inline-block;
+  padding-left: 8px;
+  line-height: 1;
+  font-size: var(--gui-checkbox-font-size);
+}
+
+.gui-checkbox.gui-checkbox--large {
+  height: 40px;
+}
+.gui-checkbox.gui-checkbox--large .gui-checkbox__label {
+  font-size: 14px;
+}
+
+.gui-checkbox.gui-checkbox--large .gui-checkbox__inner {
+  width: 14px;
+  height: 14px;
+}
+
+.gui-checkbox.gui-checkbox--small {
+  height: 24px;
+}
+.gui-checkbox.gui-checkbox--small .gui-checkbox__label {
+  font-size: 12px;
+}
+
+.gui-checkbox.gui-checkbox--small .gui-checkbox__inner {
+  width: 12px;
+  height: 12px;
+}
+
+.gui-checkbox.gui-checkbox--small .gui-checkbox__input.is-indeterminate .gui-checkbox__inner::before {
+  top: 4px;
+}
+
+.gui-checkbox.gui-checkbox--small .gui-checkbox__inner::after {
+  width: 2px;
+  height: 6px;
+}
+
+.gui-checkbox:last-of-type {
+  margin-right: 0;
+}

--- a/scripts/scss-parity/baseline/checkbox.css
+++ b/scripts/scss-parity/baseline/checkbox.css
@@ -1,0 +1,333 @@
+/* Element Chalk Variables */
+.gui-checkbox {
+  --gui-checkbox-font-size: 14px;
+  --gui-checkbox-font-weight: var(--gui-font-weight-primary);
+  --gui-checkbox-text-color: var(--gui-text-color-regular);
+  --gui-checkbox-input-height: 14px;
+  --gui-checkbox-input-width: 14px;
+  --gui-checkbox-border-radius: var(--gui-border-radius-small);
+  --gui-checkbox-bg-color: var(--gui-fill-color-blank);
+  --gui-checkbox-input-border: var(--gui-border);
+  --gui-checkbox-disabled-border-color: var(--gui-border-color);
+  --gui-checkbox-disabled-input-fill: var(--gui-fill-color-light);
+  --gui-checkbox-disabled-icon-color: var(--gui-text-color-placeholder);
+  --gui-checkbox-disabled-checked-input-fill: var(--gui-border-color-extra-light);
+  --gui-checkbox-disabled-checked-input-border-color: var(--gui-border-color);
+  --gui-checkbox-disabled-checked-icon-color: var(--gui-text-color-placeholder);
+  --gui-checkbox-checked-text-color: var(--gui-color-primary);
+  --gui-checkbox-checked-input-border-color: var(--gui-color-primary);
+  --gui-checkbox-checked-bg-color: var(--gui-color-primary);
+  --gui-checkbox-checked-icon-color: var(--gui-color-white);
+  --gui-checkbox-input-border-color-hover: var(--gui-color-primary);
+}
+
+.gui-checkbox {
+  color: var(--gui-checkbox-text-color);
+  font-weight: var(--gui-checkbox-font-weight);
+  font-size: var(--gui-font-size-base);
+  position: relative;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  white-space: nowrap;
+  user-select: none;
+  margin-right: 30px;
+  height: var(--gui-checkbox-height, 32px);
+}
+.gui-checkbox.is-disabled {
+  cursor: not-allowed;
+}
+
+.gui-checkbox.is-bordered {
+  padding: 0 15px 0 9px;
+  border-radius: var(--gui-border-radius-base);
+  border: var(--gui-border);
+  box-sizing: border-box;
+}
+.gui-checkbox.is-bordered.is-checked {
+  border-color: var(--gui-color-primary);
+}
+.gui-checkbox.is-bordered.is-disabled {
+  border-color: var(--gui-border-color-lighter);
+}
+.gui-checkbox.is-bordered.gui-checkbox--large {
+  padding: 0 19px 0 11px;
+  border-radius: var(--gui-border-radius-base);
+}
+.gui-checkbox.is-bordered.gui-checkbox--large .gui-checkbox__label {
+  font-size: var(--gui-font-size-base);
+}
+.gui-checkbox.is-bordered.gui-checkbox--large .gui-checkbox__inner {
+  height: 14px;
+  width: 14px;
+}
+.gui-checkbox.is-bordered.gui-checkbox--small {
+  padding: 0 11px 0 7px;
+  border-radius: calc(var(--gui-border-radius-base) - 1px);
+}
+.gui-checkbox.is-bordered.gui-checkbox--small .gui-checkbox__label {
+  font-size: 12px;
+}
+.gui-checkbox.is-bordered.gui-checkbox--small .gui-checkbox__inner {
+  height: 12px;
+  width: 12px;
+}
+.gui-checkbox.is-bordered.gui-checkbox--small .gui-checkbox__inner::after {
+  height: 6px;
+  width: 2px;
+}
+
+.gui-checkbox input:focus-visible + .gui-checkbox__inner {
+  outline: 2px solid var(--gui-checkbox-input-border-color-hover);
+  outline-offset: 1px;
+  border-radius: var(--gui-checkbox-border-radius);
+}
+.gui-checkbox__input {
+  white-space: nowrap;
+  cursor: pointer;
+  outline: none;
+  display: inline-flex;
+  position: relative;
+}
+.gui-checkbox__input.is-disabled .gui-checkbox__inner {
+  background-color: var(--gui-checkbox-disabled-input-fill);
+  border-color: var(--gui-checkbox-disabled-border-color);
+  cursor: not-allowed;
+}
+.gui-checkbox__input.is-disabled .gui-checkbox__inner::after {
+  cursor: not-allowed;
+  border-color: var(--gui-checkbox-disabled-icon-color);
+}
+.gui-checkbox__input.is-disabled.is-checked .gui-checkbox__inner {
+  background-color: var(--gui-checkbox-disabled-checked-input-fill);
+  border-color: var(--gui-checkbox-disabled-checked-input-border-color);
+}
+.gui-checkbox__input.is-disabled.is-checked .gui-checkbox__inner::after {
+  border-color: var(--gui-checkbox-disabled-checked-icon-color);
+}
+.gui-checkbox__input.is-disabled.is-indeterminate .gui-checkbox__inner {
+  background-color: var(--gui-checkbox-disabled-checked-input-fill);
+  border-color: var(--gui-checkbox-disabled-checked-input-border-color);
+}
+.gui-checkbox__input.is-disabled.is-indeterminate .gui-checkbox__inner::before {
+  background-color: var(--gui-checkbox-disabled-checked-icon-color);
+  border-color: var(--gui-checkbox-disabled-checked-icon-color);
+}
+.gui-checkbox__input.is-disabled + span.gui-checkbox__label {
+  color: var(--gui-disabled-text-color);
+  cursor: not-allowed;
+}
+
+.gui-checkbox__input.is-checked .gui-checkbox__inner {
+  background-color: var(--gui-checkbox-checked-bg-color);
+  border-color: var(--gui-checkbox-checked-input-border-color);
+}
+.gui-checkbox__input.is-checked .gui-checkbox__inner::after {
+  transform: rotate(45deg) scaleY(1);
+  border-color: var(--gui-checkbox-checked-icon-color);
+}
+.gui-checkbox__input.is-checked + .gui-checkbox__label {
+  color: var(--gui-checkbox-checked-text-color);
+}
+
+.gui-checkbox__input.is-focus:not(.is-checked) .gui-checkbox__original:not(:focus-visible) {
+  border-color: var(--gui-checkbox-input-border-color-hover);
+}
+
+.gui-checkbox__input.is-indeterminate .gui-checkbox__inner {
+  background-color: var(--gui-checkbox-checked-bg-color);
+  border-color: var(--gui-checkbox-checked-input-border-color);
+}
+.gui-checkbox__input.is-indeterminate .gui-checkbox__inner::before {
+  content: "";
+  position: absolute;
+  display: block;
+  background-color: var(--gui-checkbox-checked-icon-color);
+  height: 2px;
+  transform: scale(0.5);
+  left: 0;
+  right: 0;
+  top: 5px;
+}
+.gui-checkbox__input.is-indeterminate .gui-checkbox__inner::after {
+  display: none;
+}
+
+.gui-checkbox__inner {
+  display: inline-block;
+  position: relative;
+  border: var(--gui-checkbox-input-border);
+  border-radius: var(--gui-checkbox-border-radius);
+  box-sizing: border-box;
+  width: var(--gui-checkbox-input-width);
+  height: var(--gui-checkbox-input-height);
+  background-color: var(--gui-checkbox-bg-color);
+  z-index: var(--gui-index-normal);
+  transition: border-color 0.25s cubic-bezier(0.71, -0.46, 0.29, 1.46), background-color 0.25s cubic-bezier(0.71, -0.46, 0.29, 1.46), outline 0.25s cubic-bezier(0.71, -0.46, 0.29, 1.46);
+}
+.gui-checkbox__inner:hover {
+  border-color: var(--gui-checkbox-input-border-color-hover);
+}
+.gui-checkbox__inner::after {
+  box-sizing: content-box;
+  content: "";
+  border: 1px solid transparent;
+  border-left: 0;
+  border-top: 0;
+  height: 7px;
+  left: 4px;
+  position: absolute;
+  top: 1px;
+  transform: rotate(45deg) scaleY(0);
+  width: 3px;
+  transition: transform 0.15s ease-in 0.05s;
+  transform-origin: center;
+}
+
+.gui-checkbox__original {
+  opacity: 0;
+  outline: none;
+  position: absolute;
+  margin: 0;
+  width: 0;
+  height: 0;
+  z-index: -1;
+}
+
+.gui-checkbox__label {
+  display: inline-block;
+  padding-left: 8px;
+  line-height: 1;
+  font-size: var(--gui-checkbox-font-size);
+}
+
+.gui-checkbox.gui-checkbox--large {
+  height: 40px;
+}
+.gui-checkbox.gui-checkbox--large .gui-checkbox__label {
+  font-size: 14px;
+}
+
+.gui-checkbox.gui-checkbox--large .gui-checkbox__inner {
+  width: 14px;
+  height: 14px;
+}
+
+.gui-checkbox.gui-checkbox--small {
+  height: 24px;
+}
+.gui-checkbox.gui-checkbox--small .gui-checkbox__label {
+  font-size: 12px;
+}
+
+.gui-checkbox.gui-checkbox--small .gui-checkbox__inner {
+  width: 12px;
+  height: 12px;
+}
+
+.gui-checkbox.gui-checkbox--small .gui-checkbox__input.is-indeterminate .gui-checkbox__inner::before {
+  top: 4px;
+}
+
+.gui-checkbox.gui-checkbox--small .gui-checkbox__inner::after {
+  width: 2px;
+  height: 6px;
+}
+
+.gui-checkbox:last-of-type {
+  margin-right: 0;
+}
+
+.gui-checkbox {
+  @apply text-3 gap-xxs m-0 h-fit items-center;
+}
+.gui-checkbox.is-checked:not(.is-disabled) .gui-checkbox__label {
+  @apply text-secondary-txt;
+}
+
+.gui-checkbox.is-checked:not(.is-disabled) .gui-checkbox__inner {
+  @apply border-primary-bd bg-primary-def;
+}
+
+.gui-checkbox.is-checked.is-disabled .gui-checkbox__inner {
+  @apply border-disab-lt-bd bg-disab-lt-bg;
+}
+.gui-checkbox.is-checked.is-disabled .gui-checkbox__inner:after {
+  @apply border-white;
+}
+
+.gui-checkbox.is-disabled {
+  @apply cursor-not-allowed;
+}
+.gui-checkbox.is-disabled .gui-checkbox__label {
+  @apply text-disab-lt-txt !important;
+}
+
+.gui-checkbox.is-border {
+  @apply justify-between p-xs border border-disab-lt-bd rounded-md min-h-12 h-fit;
+}
+
+.gui-checkbox.is-invert {
+  @apply flex flex-row-reverse gap-xxs;
+}
+.gui-checkbox.is-invert .gui-checkbox__inner {
+  @apply ml-xs;
+}
+
+.gui-checkbox__label {
+  @apply p-0 text-secondary-txt text-pretty leading-snug;
+}
+
+.gui-checkbox__input {
+  @apply self-center;
+}
+.gui-checkbox__input.is-indeterminate .gui-checkbox__inner {
+  @apply border-primary-bd;
+}
+
+.gui-checkbox__input.is-indeterminate.is-disabled .gui-checkbox__inner {
+  @apply border-disab-lt-bd bg-disab-lt-bg;
+}
+.gui-checkbox__input.is-indeterminate.is-disabled .gui-checkbox__inner:before {
+  @apply bg-white top-[7px];
+}
+
+.gui-checkbox__input.is-disabled {
+  @apply cursor-not-allowed;
+}
+.gui-checkbox__input.is-disabled .gui-checkbox__inner {
+  @apply bg-transparent border-disab-lt-bd;
+}
+.gui-checkbox__input.is-disabled .gui-checkbox__inner .hover-effect {
+  @apply invisible;
+}
+
+.gui-checkbox__input:not(.is-error):not(.is-disabled) .gui-checkbox__inner::before {
+  @apply top-[7px];
+}
+
+.gui-checkbox__inner {
+  @apply w-[18px] h-[18px] border-disabled-bd border rounded mr-xs bg-transparent;
+}
+.gui-checkbox__inner::after {
+  @apply w-[3px] h-2 top-0.5 left-1.5 absolute;
+}
+.gui-checkbox__inner:active .hover-effect {
+  @apply bg-primary-def-press;
+}
+.gui-checkbox__inner .hover-effect {
+  @apply absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 w-0 h-0 rounded-full bg-primary-def-hover bg-center bg-opacity-20 opacity-20 ease-out;
+  transition: background 0.8s, width 0.4s, height 0.4s;
+}
+.gui-checkbox__inner .hover-effect .ripple {
+  @apply absolute w-full h-full bg-white/80 rounded-full scale-0 opacity-100 pointer-events-none;
+}
+.gui-checkbox__inner .hover-effect .ripple.expand {
+  @apply animate-ripple-expand;
+}
+.gui-checkbox__inner .hover-effect .ripple.contract {
+  @apply animate-ripple-contract;
+}
+.gui-checkbox__inner:hover .hover-effect {
+  @apply w-8 h-8;
+}

--- a/scripts/scss-parity/baseline/drawer-theme.css
+++ b/scripts/scss-parity/baseline/drawer-theme.css
@@ -1,0 +1,118 @@
+/* Element Chalk Variables */
+.gui-drawer {
+  --gui-drawer-bg-color: var(--gui-dialog-bg-color, var(--gui-bg-color));
+  --gui-drawer-padding-primary: var(--gui-dialog-padding-primary, 20px);
+}
+
+.gui-drawer {
+  position: absolute;
+  box-sizing: border-box;
+  background-color: var(--gui-drawer-bg-color);
+  display: flex;
+  flex-direction: column;
+  box-shadow: var(--gui-box-shadow-dark);
+  overflow: hidden;
+  transition: all var(--gui-transition-duration);
+}
+.gui-drawer .rtl {
+  transform: translate(0, 0);
+}
+.gui-drawer .ltr {
+  transform: translate(0, 0);
+}
+.gui-drawer .ttb {
+  transform: translate(0, 0);
+}
+.gui-drawer .btt {
+  transform: translate(0, 0);
+}
+.gui-drawer__sr-focus:focus {
+  outline: none !important;
+}
+.gui-drawer__header {
+  align-items: center;
+  color: rgb(114, 118, 123);
+  display: flex;
+  margin-bottom: 32px;
+  padding: var(--gui-drawer-padding-primary);
+  padding-bottom: 0;
+}
+.gui-drawer__header > :first-child {
+  flex: 1;
+}
+.gui-drawer__title {
+  margin: 0;
+  flex: 1;
+  line-height: inherit;
+  font-size: 16px;
+}
+.gui-drawer__footer {
+  padding: var(--gui-drawer-padding-primary);
+  padding-top: 10px;
+  text-align: right;
+}
+
+.gui-drawer__close-btn {
+  display: inline-flex;
+  border: none;
+  cursor: pointer;
+  font-size: var(--gui-font-size-extra-large);
+  color: inherit;
+  background-color: transparent;
+  outline: none;
+}
+.gui-drawer__close-btn:focus i, .gui-drawer__close-btn:hover i {
+  color: var(--gui-color-primary);
+}
+.gui-drawer__body {
+  flex: 1;
+  padding: var(--gui-drawer-padding-primary);
+  overflow: auto;
+}
+.gui-drawer__body > * {
+  box-sizing: border-box;
+}
+.gui-drawer.ltr, .gui-drawer.rtl {
+  height: 100%;
+  top: 0;
+  bottom: 0;
+}
+.gui-drawer.ttb, .gui-drawer.btt {
+  width: 100%;
+  left: 0;
+  right: 0;
+}
+.gui-drawer.ltr {
+  left: 0;
+}
+.gui-drawer.rtl {
+  right: 0;
+}
+.gui-drawer.ttb {
+  top: 0;
+}
+.gui-drawer.btt {
+  bottom: 0;
+}
+
+.gui-drawer-fade-enter-active, .gui-drawer-fade-leave-active {
+  transition: all var(--gui-transition-duration);
+}
+.gui-drawer-fade-enter-from, .gui-drawer-fade-enter-active, .gui-drawer-fade-enter-to, .gui-drawer-fade-leave-from, .gui-drawer-fade-leave-active, .gui-drawer-fade-leave-to {
+  overflow: hidden !important;
+}
+.gui-drawer-fade-enter-from, .gui-drawer-fade-leave-to {
+  background-color: transparent !important;
+}
+.gui-drawer-fade-enter-from .rtl, .gui-drawer-fade-leave-to .rtl {
+  transform: translateX(100%);
+}
+.gui-drawer-fade-enter-from .ltr, .gui-drawer-fade-leave-to .ltr {
+  transform: translateX(-100%);
+}
+.gui-drawer-fade-enter-from .ttb, .gui-drawer-fade-leave-to .ttb {
+  transform: translateY(-100%);
+}
+.gui-drawer-fade-enter-from .btt, .gui-drawer-fade-leave-to .btt {
+  transform: translateY(100%);
+}

--- a/scripts/scss-parity/baseline/drawer.css
+++ b/scripts/scss-parity/baseline/drawer.css
@@ -1,0 +1,195 @@
+/* Element Chalk Variables */
+.gui-drawer {
+  --gui-drawer-bg-color: var(--gui-dialog-bg-color, var(--gui-bg-color));
+  --gui-drawer-padding-primary: var(--gui-dialog-padding-primary, 20px);
+}
+
+.gui-drawer {
+  position: absolute;
+  box-sizing: border-box;
+  background-color: var(--gui-drawer-bg-color);
+  display: flex;
+  flex-direction: column;
+  box-shadow: var(--gui-box-shadow-dark);
+  overflow: hidden;
+  transition: all var(--gui-transition-duration);
+}
+.gui-drawer .rtl {
+  transform: translate(0, 0);
+}
+.gui-drawer .ltr {
+  transform: translate(0, 0);
+}
+.gui-drawer .ttb {
+  transform: translate(0, 0);
+}
+.gui-drawer .btt {
+  transform: translate(0, 0);
+}
+.gui-drawer__sr-focus:focus {
+  outline: none !important;
+}
+.gui-drawer__header {
+  align-items: center;
+  color: rgb(114, 118, 123);
+  display: flex;
+  margin-bottom: 32px;
+  padding: var(--gui-drawer-padding-primary);
+  padding-bottom: 0;
+}
+.gui-drawer__header > :first-child {
+  flex: 1;
+}
+.gui-drawer__title {
+  margin: 0;
+  flex: 1;
+  line-height: inherit;
+  font-size: 16px;
+}
+.gui-drawer__footer {
+  padding: var(--gui-drawer-padding-primary);
+  padding-top: 10px;
+  text-align: right;
+}
+
+.gui-drawer__close-btn {
+  display: inline-flex;
+  border: none;
+  cursor: pointer;
+  font-size: var(--gui-font-size-extra-large);
+  color: inherit;
+  background-color: transparent;
+  outline: none;
+}
+.gui-drawer__close-btn:focus i, .gui-drawer__close-btn:hover i {
+  color: var(--gui-color-primary);
+}
+.gui-drawer__body {
+  flex: 1;
+  padding: var(--gui-drawer-padding-primary);
+  overflow: auto;
+}
+.gui-drawer__body > * {
+  box-sizing: border-box;
+}
+.gui-drawer.ltr, .gui-drawer.rtl {
+  height: 100%;
+  top: 0;
+  bottom: 0;
+}
+.gui-drawer.ttb, .gui-drawer.btt {
+  width: 100%;
+  left: 0;
+  right: 0;
+}
+.gui-drawer.ltr {
+  left: 0;
+}
+.gui-drawer.rtl {
+  right: 0;
+}
+.gui-drawer.ttb {
+  top: 0;
+}
+.gui-drawer.btt {
+  bottom: 0;
+}
+
+.gui-drawer-fade-enter-active, .gui-drawer-fade-leave-active {
+  transition: all var(--gui-transition-duration);
+}
+.gui-drawer-fade-enter-from, .gui-drawer-fade-enter-active, .gui-drawer-fade-enter-to, .gui-drawer-fade-leave-from, .gui-drawer-fade-leave-active, .gui-drawer-fade-leave-to {
+  overflow: hidden !important;
+}
+.gui-drawer-fade-enter-from, .gui-drawer-fade-leave-to {
+  background-color: transparent !important;
+}
+.gui-drawer-fade-enter-from .rtl, .gui-drawer-fade-leave-to .rtl {
+  transform: translateX(100%);
+}
+.gui-drawer-fade-enter-from .ltr, .gui-drawer-fade-leave-to .ltr {
+  transform: translateX(-100%);
+}
+.gui-drawer-fade-enter-from .ttb, .gui-drawer-fade-leave-to .ttb {
+  transform: translateY(-100%);
+}
+.gui-drawer-fade-enter-from .btt, .gui-drawer-fade-leave-to .btt {
+  transform: translateY(100%);
+}
+
+.gui-overlay {
+  position: fixed;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  z-index: 2000;
+  height: 100%;
+  background-color: var(--gui-overlay-color-lighter);
+  overflow: auto;
+}
+.gui-overlay .gui-overlay-root {
+  height: 0;
+}
+
+.gui-drawer__header {
+  @apply flex flex-col items-start px-lg pt-lg gap-4 mb-4;
+}
+.gui-drawer__header--container-close {
+  @apply self-end;
+}
+
+.gui-drawer__header--container-title {
+  @apply flex flex-col gap-md w-full;
+}
+
+.gui-drawer__header--title-description {
+  @apply flex flex-col gap-xxs;
+}
+
+.gui-drawer__title {
+  @apply text-8 font-bold text-primary-txt line-clamp-3;
+}
+
+.gui-drawer__description {
+  @apply text-3 font-medium text-secondary-txt whitespace-pre-line;
+}
+
+.gui-drawer__body {
+  @apply px-lg py-0;
+}
+
+.gui-drawer__footer {
+  @apply w-full mx-auto p-lg;
+}
+.gui-drawer__footer--buttons {
+  @apply w-full;
+}
+.gui-drawer__footer--buttons.layout-dual-row {
+  @apply grid gap-xs grid-cols-2;
+}
+.gui-drawer__footer--buttons.layout-dual-row > button:nth-child(1) {
+  @apply order-2;
+}
+.gui-drawer__footer--buttons.layout-dual-row > button:nth-child(2) {
+  @apply order-1;
+}
+.gui-drawer__footer--buttons.layout-dual-row > button:nth-child(3) {
+  @apply mt-xs mx-auto col-span-2 col-start-1 order-3;
+  max-width: 50%;
+}
+@media (max-width: theme("screens.sm")) {
+  .gui-drawer__footer--buttons.layout-dual-row {
+    @apply flex flex-col;
+  }
+  .gui-drawer__footer--buttons.layout-dual-row > button:nth-child(1),
+  .gui-drawer__footer--buttons.layout-dual-row > button:nth-child(2) {
+    @apply order-none;
+  }
+  .gui-drawer__footer--buttons.layout-dual-row > button:nth-child(3) {
+    @apply max-w-full mx-0 mt-xxs;
+  }
+}
+.gui-drawer__footer--buttons.layout-single-column {
+  @apply flex flex-row-reverse gap-xs;
+}

--- a/scripts/scss-parity/baseline/dropdown-theme.css
+++ b/scripts/scss-parity/baseline/dropdown-theme.css
@@ -1,0 +1,170 @@
+/* Element Chalk Variables */
+.gui-dropdown {
+  --gui-dropdown-menu-box-shadow: var(--gui-box-shadow-light);
+  --gui-dropdown-menuItem-hover-fill: var(--gui-color-primary-light-9);
+  --gui-dropdown-menuItem-hover-color: var(--gui-color-primary);
+  --gui-dropdown-menu-index: 10;
+  display: inline-flex;
+  position: relative;
+  color: var(--gui-text-color-regular);
+  font-size: var(--gui-font-size-base);
+  line-height: 1;
+  vertical-align: top;
+}
+.gui-dropdown.is-disabled {
+  color: var(--gui-text-color-placeholder);
+  cursor: not-allowed;
+}
+.gui-dropdown__popper {
+  --gui-dropdown-menu-box-shadow: var(--gui-box-shadow-light);
+  --gui-dropdown-menuItem-hover-fill: var(--gui-color-primary-light-9);
+  --gui-dropdown-menuItem-hover-color: var(--gui-color-primary);
+  --gui-dropdown-menu-index: 10;
+}
+.gui-dropdown__popper.gui-popper {
+  background: var(--gui-bg-color-overlay);
+  border: 1px solid var(--gui-border-color-light);
+  box-shadow: var(--gui-dropdown-menu-box-shadow);
+}
+.gui-dropdown__popper.gui-popper .gui-popper__arrow::before {
+  border: 1px solid var(--gui-border-color-light);
+}
+.gui-dropdown__popper.gui-popper[data-popper-placement^=top] .gui-popper__arrow::before {
+  border-top-color: transparent;
+  border-left-color: transparent;
+}
+.gui-dropdown__popper.gui-popper[data-popper-placement^=bottom] .gui-popper__arrow::before {
+  border-bottom-color: transparent;
+  border-right-color: transparent;
+}
+.gui-dropdown__popper.gui-popper[data-popper-placement^=left] .gui-popper__arrow::before {
+  border-left-color: transparent;
+  border-bottom-color: transparent;
+}
+.gui-dropdown__popper.gui-popper[data-popper-placement^=right] .gui-popper__arrow::before {
+  border-right-color: transparent;
+  border-top-color: transparent;
+}
+.gui-dropdown__popper .gui-dropdown-menu {
+  border: none;
+}
+.gui-dropdown__popper .gui-dropdown__popper-selfdefine {
+  outline: none;
+}
+.gui-dropdown__popper .gui-scrollbar__bar {
+  z-index: calc(var(--gui-dropdown-menu-index) + 1);
+}
+.gui-dropdown__popper .gui-dropdown__list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  box-sizing: border-box;
+}
+
+.gui-dropdown .gui-dropdown__caret-button {
+  padding-left: 0;
+  padding-right: 0;
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  width: 32px;
+  border-left: none;
+}
+.gui-dropdown .gui-dropdown__caret-button > span {
+  display: inline-flex;
+}
+.gui-dropdown .gui-dropdown__caret-button::before {
+  content: "";
+  position: absolute;
+  display: block;
+  width: 1px;
+  top: -1px;
+  bottom: -1px;
+  left: 0;
+  background: var(--gui-overlay-color-lighter);
+}
+.gui-dropdown .gui-dropdown__caret-button.gui-button::before {
+  background: var(--gui-border-color);
+  opacity: 0.5;
+}
+.gui-dropdown .gui-dropdown__caret-button .gui-dropdown__icon {
+  font-size: inherit;
+  padding-left: 0;
+}
+.gui-dropdown .gui-dropdown-selfdefine {
+  outline: none;
+}
+.gui-dropdown--large .gui-dropdown__caret-button {
+  width: 40px;
+}
+
+.gui-dropdown--small .gui-dropdown__caret-button {
+  width: 24px;
+}
+
+.gui-dropdown-menu {
+  position: relative;
+  top: 0;
+  left: 0;
+  z-index: var(--gui-dropdown-menu-index);
+  padding: 5px 0;
+  margin: 0;
+  background-color: var(--gui-bg-color-overlay);
+  border: none;
+  border-radius: var(--gui-border-radius-base);
+  box-shadow: none;
+  list-style: none;
+}
+.gui-dropdown-menu__item {
+  display: flex;
+  align-items: center;
+  white-space: nowrap;
+  list-style: none;
+  line-height: 22px;
+  padding: 5px 16px;
+  margin: 0;
+  font-size: var(--gui-font-size-base);
+  color: var(--gui-text-color-regular);
+  cursor: pointer;
+  outline: none;
+}
+.gui-dropdown-menu__item:not(.is-disabled):hover, .gui-dropdown-menu__item:not(.is-disabled):focus {
+  background-color: var(--gui-dropdown-menuItem-hover-fill);
+  color: var(--gui-dropdown-menuItem-hover-color);
+}
+.gui-dropdown-menu__item i {
+  margin-right: 5px;
+}
+.gui-dropdown-menu__item--divided {
+  margin: 6px 0;
+  border-top: 1px solid var(--gui-border-color-lighter);
+}
+
+.gui-dropdown-menu__item.is-disabled {
+  cursor: not-allowed;
+  color: var(--gui-text-color-disabled);
+}
+
+.gui-dropdown-menu--large {
+  padding: 7px 0;
+}
+.gui-dropdown-menu--large .gui-dropdown-menu__item {
+  padding: 7px 20px;
+  line-height: 22px;
+  font-size: 14px;
+}
+.gui-dropdown-menu--large .gui-dropdown-menu__item--divided {
+  margin: 8px 0;
+}
+
+.gui-dropdown-menu--small {
+  padding: 3px 0;
+}
+.gui-dropdown-menu--small .gui-dropdown-menu__item {
+  padding: 2px 12px;
+  line-height: 20px;
+  font-size: 12px;
+}
+.gui-dropdown-menu--small .gui-dropdown-menu__item--divided {
+  margin: 4px 0;
+}

--- a/scripts/scss-parity/baseline/dropdown.css
+++ b/scripts/scss-parity/baseline/dropdown.css
@@ -1,0 +1,385 @@
+/* Element Chalk Variables */
+.gui-dropdown {
+  --gui-dropdown-menu-box-shadow: var(--gui-box-shadow-light);
+  --gui-dropdown-menuItem-hover-fill: var(--gui-color-primary-light-9);
+  --gui-dropdown-menuItem-hover-color: var(--gui-color-primary);
+  --gui-dropdown-menu-index: 10;
+  display: inline-flex;
+  position: relative;
+  color: var(--gui-text-color-regular);
+  font-size: var(--gui-font-size-base);
+  line-height: 1;
+  vertical-align: top;
+}
+.gui-dropdown.is-disabled {
+  color: var(--gui-text-color-placeholder);
+  cursor: not-allowed;
+}
+.gui-dropdown__popper {
+  --gui-dropdown-menu-box-shadow: var(--gui-box-shadow-light);
+  --gui-dropdown-menuItem-hover-fill: var(--gui-color-primary-light-9);
+  --gui-dropdown-menuItem-hover-color: var(--gui-color-primary);
+  --gui-dropdown-menu-index: 10;
+}
+.gui-dropdown__popper.gui-popper {
+  background: var(--gui-bg-color-overlay);
+  border: 1px solid var(--gui-border-color-light);
+  box-shadow: var(--gui-dropdown-menu-box-shadow);
+}
+.gui-dropdown__popper.gui-popper .gui-popper__arrow::before {
+  border: 1px solid var(--gui-border-color-light);
+}
+.gui-dropdown__popper.gui-popper[data-popper-placement^=top] .gui-popper__arrow::before {
+  border-top-color: transparent;
+  border-left-color: transparent;
+}
+.gui-dropdown__popper.gui-popper[data-popper-placement^=bottom] .gui-popper__arrow::before {
+  border-bottom-color: transparent;
+  border-right-color: transparent;
+}
+.gui-dropdown__popper.gui-popper[data-popper-placement^=left] .gui-popper__arrow::before {
+  border-left-color: transparent;
+  border-bottom-color: transparent;
+}
+.gui-dropdown__popper.gui-popper[data-popper-placement^=right] .gui-popper__arrow::before {
+  border-right-color: transparent;
+  border-top-color: transparent;
+}
+.gui-dropdown__popper .gui-dropdown-menu {
+  border: none;
+}
+.gui-dropdown__popper .gui-dropdown__popper-selfdefine {
+  outline: none;
+}
+.gui-dropdown__popper .gui-scrollbar__bar {
+  z-index: calc(var(--gui-dropdown-menu-index) + 1);
+}
+.gui-dropdown__popper .gui-dropdown__list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  box-sizing: border-box;
+}
+
+.gui-dropdown .gui-dropdown__caret-button {
+  padding-left: 0;
+  padding-right: 0;
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  width: 32px;
+  border-left: none;
+}
+.gui-dropdown .gui-dropdown__caret-button > span {
+  display: inline-flex;
+}
+.gui-dropdown .gui-dropdown__caret-button::before {
+  content: "";
+  position: absolute;
+  display: block;
+  width: 1px;
+  top: -1px;
+  bottom: -1px;
+  left: 0;
+  background: var(--gui-overlay-color-lighter);
+}
+.gui-dropdown .gui-dropdown__caret-button.gui-button::before {
+  background: var(--gui-border-color);
+  opacity: 0.5;
+}
+.gui-dropdown .gui-dropdown__caret-button .gui-dropdown__icon {
+  font-size: inherit;
+  padding-left: 0;
+}
+.gui-dropdown .gui-dropdown-selfdefine {
+  outline: none;
+}
+.gui-dropdown--large .gui-dropdown__caret-button {
+  width: 40px;
+}
+
+.gui-dropdown--small .gui-dropdown__caret-button {
+  width: 24px;
+}
+
+.gui-dropdown-menu {
+  position: relative;
+  top: 0;
+  left: 0;
+  z-index: var(--gui-dropdown-menu-index);
+  padding: 5px 0;
+  margin: 0;
+  background-color: var(--gui-bg-color-overlay);
+  border: none;
+  border-radius: var(--gui-border-radius-base);
+  box-shadow: none;
+  list-style: none;
+}
+.gui-dropdown-menu__item {
+  display: flex;
+  align-items: center;
+  white-space: nowrap;
+  list-style: none;
+  line-height: 22px;
+  padding: 5px 16px;
+  margin: 0;
+  font-size: var(--gui-font-size-base);
+  color: var(--gui-text-color-regular);
+  cursor: pointer;
+  outline: none;
+}
+.gui-dropdown-menu__item:not(.is-disabled):hover, .gui-dropdown-menu__item:not(.is-disabled):focus {
+  background-color: var(--gui-dropdown-menuItem-hover-fill);
+  color: var(--gui-dropdown-menuItem-hover-color);
+}
+.gui-dropdown-menu__item i {
+  margin-right: 5px;
+}
+.gui-dropdown-menu__item--divided {
+  margin: 6px 0;
+  border-top: 1px solid var(--gui-border-color-lighter);
+}
+
+.gui-dropdown-menu__item.is-disabled {
+  cursor: not-allowed;
+  color: var(--gui-text-color-disabled);
+}
+
+.gui-dropdown-menu--large {
+  padding: 7px 0;
+}
+.gui-dropdown-menu--large .gui-dropdown-menu__item {
+  padding: 7px 20px;
+  line-height: 22px;
+  font-size: 14px;
+}
+.gui-dropdown-menu--large .gui-dropdown-menu__item--divided {
+  margin: 8px 0;
+}
+
+.gui-dropdown-menu--small {
+  padding: 3px 0;
+}
+.gui-dropdown-menu--small .gui-dropdown-menu__item {
+  padding: 2px 12px;
+  line-height: 20px;
+  font-size: 12px;
+}
+.gui-dropdown-menu--small .gui-dropdown-menu__item--divided {
+  margin: 4px 0;
+}
+
+.gui-scrollbar {
+  --gui-scrollbar-opacity: 0.3;
+  --gui-scrollbar-bg-color: var(--gui-text-color-secondary);
+  --gui-scrollbar-hover-opacity: 0.5;
+  --gui-scrollbar-hover-bg-color: var(--gui-text-color-secondary);
+}
+
+.gui-scrollbar {
+  overflow: hidden;
+  position: relative;
+  height: 100%;
+}
+.gui-scrollbar__wrap {
+  overflow: auto;
+  height: 100%;
+}
+.gui-scrollbar__wrap--hidden-default {
+  scrollbar-width: none;
+}
+.gui-scrollbar__wrap--hidden-default::-webkit-scrollbar {
+  display: none;
+}
+
+.gui-scrollbar__thumb {
+  position: relative;
+  display: block;
+  width: 0;
+  height: 0;
+  cursor: pointer;
+  border-radius: inherit;
+  background-color: var(--gui-scrollbar-bg-color, var(--gui-text-color-secondary));
+  transition: var(--gui-transition-duration) background-color;
+  opacity: var(--gui-scrollbar-opacity, 0.3);
+}
+.gui-scrollbar__thumb:hover {
+  background-color: var(--gui-scrollbar-hover-bg-color, var(--gui-text-color-secondary));
+  opacity: var(--gui-scrollbar-hover-opacity, 0.5);
+}
+
+.gui-scrollbar__bar {
+  position: absolute;
+  right: 2px;
+  bottom: 2px;
+  z-index: 1;
+  border-radius: 4px;
+}
+.gui-scrollbar__bar.is-vertical {
+  width: 6px;
+  top: 2px;
+}
+.gui-scrollbar__bar.is-vertical > div {
+  width: 100%;
+}
+
+.gui-scrollbar__bar.is-horizontal {
+  height: 6px;
+  left: 2px;
+}
+.gui-scrollbar__bar.is-horizontal > div {
+  height: 100%;
+}
+
+.gui-scrollbar-fade-enter-active {
+  transition: opacity 340ms ease-out;
+}
+.gui-scrollbar-fade-leave-active {
+  transition: opacity 120ms ease-out;
+}
+.gui-scrollbar-fade-enter-from, .gui-scrollbar-fade-leave-active {
+  opacity: 0;
+}
+
+.gui-popper {
+  --gui-popper-border-radius: var(--gui-popover-border-radius, 4px);
+}
+
+.gui-popper {
+  position: absolute;
+  border-radius: var(--gui-popper-border-radius);
+  padding: 5px 11px;
+  z-index: 2000;
+  font-size: 12px;
+  line-height: 20px;
+  min-width: 10px;
+  overflow-wrap: break-word;
+  visibility: visible;
+}
+.gui-popper.is-dark {
+  color: var(--gui-bg-color);
+  background: var(--gui-text-color-primary);
+  border: 1px solid var(--gui-text-color-primary);
+}
+.gui-popper.is-dark > .gui-popper__arrow::before {
+  border: 1px solid var(--gui-text-color-primary);
+  background: var(--gui-text-color-primary);
+  right: 0;
+}
+
+.gui-popper.is-light {
+  background: var(--gui-bg-color-overlay);
+  border: 1px solid var(--gui-border-color-light);
+}
+.gui-popper.is-light > .gui-popper__arrow::before {
+  border: 1px solid var(--gui-border-color-light);
+  background: var(--gui-bg-color-overlay);
+  right: 0;
+}
+
+.gui-popper.is-pure {
+  padding: 0;
+}
+
+.gui-popper__arrow {
+  position: absolute;
+  width: 10px;
+  height: 10px;
+  z-index: -1;
+}
+.gui-popper__arrow::before {
+  position: absolute;
+  width: 10px;
+  height: 10px;
+  z-index: -1;
+  content: " ";
+  transform: rotate(45deg);
+  background: var(--gui-text-color-primary);
+  box-sizing: border-box;
+}
+
+.gui-popper[data-popper-placement^=top] > .gui-popper__arrow {
+  bottom: -5px;
+}
+.gui-popper[data-popper-placement^=top] > .gui-popper__arrow::before {
+  border-bottom-right-radius: 2px;
+}
+.gui-popper[data-popper-placement^=bottom] > .gui-popper__arrow {
+  top: -5px;
+}
+.gui-popper[data-popper-placement^=bottom] > .gui-popper__arrow::before {
+  border-top-left-radius: 2px;
+}
+.gui-popper[data-popper-placement^=left] > .gui-popper__arrow {
+  right: -5px;
+}
+.gui-popper[data-popper-placement^=left] > .gui-popper__arrow::before {
+  border-top-right-radius: 2px;
+}
+.gui-popper[data-popper-placement^=right] > .gui-popper__arrow {
+  left: -5px;
+}
+.gui-popper[data-popper-placement^=right] > .gui-popper__arrow::before {
+  border-bottom-left-radius: 2px;
+}
+.gui-popper[data-popper-placement^=top] > .gui-popper__arrow::before {
+  border-top-color: transparent !important;
+  border-left-color: transparent !important;
+}
+.gui-popper[data-popper-placement^=bottom] > .gui-popper__arrow::before {
+  border-bottom-color: transparent !important;
+  border-right-color: transparent !important;
+}
+.gui-popper[data-popper-placement^=left] > .gui-popper__arrow::before {
+  border-left-color: transparent !important;
+  border-bottom-color: transparent !important;
+}
+.gui-popper[data-popper-placement^=right] > .gui-popper__arrow::before {
+  border-right-color: transparent !important;
+  border-top-color: transparent !important;
+}
+
+.gui-dropdown__popper {
+  @apply rounded-md shadow-md !important;
+}
+.gui-dropdown__popper .gui-popper__arrow {
+  @apply shadow-none !important;
+}
+.gui-dropdown__popper .gui-popper__arrow::before {
+  @apply bg-white !important;
+}
+.gui-dropdown__popper .gui-scrollbar__wrap {
+  @apply rounded-md !important;
+}
+
+.gui-dropdown-menu {
+  @apply flex flex-col gap-xxs min-w-48 rounded-md;
+}
+.gui-dropdown-menu__item {
+  @apply min-h-12 p-md flex items-center justify-start transition-all duration-200 ease-in !important;
+}
+.gui-dropdown-menu__item--content {
+  @apply flex items-start justify-center flex-col overflow-hidden;
+}
+
+.gui-dropdown-menu__item--icon {
+  @apply text-7 text-secondary-txt mr-md;
+}
+
+.gui-dropdown-menu__item--title {
+  @apply text-4 text-secondary-txt font-medium overflow-hidden text-ellipsis w-full;
+}
+
+.gui-dropdown-menu__item--description {
+  @apply text-2 text-terciary-txt font-medium text-pretty line-clamp-2 overflow-hidden text-ellipsis;
+}
+
+.gui-dropdown-menu__item.is-disabled {
+  @apply cursor-not-allowed;
+}
+.gui-dropdown-menu__item.is-disabled:hover {
+  @apply bg-transparent;
+}
+.gui-dropdown-menu__item.is-disabled .gui-dropdown-menu__item--icon, .gui-dropdown-menu__item.is-disabled .gui-dropdown-menu__item--title, .gui-dropdown-menu__item.is-disabled .gui-dropdown-menu__item--description {
+  @apply text-grey-300;
+}

--- a/scripts/scss-parity/baseline/g-utils-button-mixins.css
+++ b/scripts/scss-parity/baseline/g-utils-button-mixins.css
@@ -1,0 +1,1 @@
+/* Element Chalk Variables */

--- a/scripts/scss-parity/baseline/g-utils-radio-group.css
+++ b/scripts/scss-parity/baseline/g-utils-radio-group.css
@@ -1,0 +1,7 @@
+/* Element Chalk Variables */
+.gui-radio-group {
+  display: inline-flex;
+  align-items: center;
+  flex-wrap: wrap;
+  font-size: 0;
+}

--- a/scripts/scss-parity/baseline/input-number.css
+++ b/scripts/scss-parity/baseline/input-number.css
@@ -1,3 +1,4 @@
+/* Element Chalk Variables */
 .gui-input-number {
   @apply inline-flex relative w-fit border border-grey-100 rounded-md h-10;
   overflow: hidden;

--- a/scripts/scss-parity/baseline/input-tag-theme.css
+++ b/scripts/scss-parity/baseline/input-tag-theme.css
@@ -1,0 +1,171 @@
+/* Element Chalk Variables */
+.gui-input-tag {
+  --gui-input-tag-border-color-hover: var(--gui-border-color-hover);
+  --gui-input-tag-placeholder-color: var(--gui-text-color-placeholder);
+  --gui-input-tag-disabled-color: var(--gui-disabled-text-color);
+  --gui-input-tag-disabled-border: var(--gui-disabled-border-color);
+  --gui-input-tag-font-size: var(--gui-font-size-base);
+  --gui-input-tag-close-hover-color: var(--gui-text-color-secondary);
+  --gui-input-tag-text-color: var(--gui-text-color-regular);
+  --gui-input-tag-input-focus-border-color: var(--gui-color-primary);
+  --gui-input-tag-width: 100%;
+  --gui-input-tag-mini-height: var(--gui-component-size);
+  --gui-input-tag-gap: 6px;
+  --gui-input-tag-padding: 4px;
+  --gui-input-tag-inner-padding: 8px;
+  --gui-input-tag-line-height: 24px;
+}
+
+.gui-input-tag {
+  display: flex;
+  align-items: center;
+  box-sizing: border-box;
+  cursor: pointer;
+  font-size: var(--gui-input-tag-font-size);
+  padding: var(--gui-input-tag-padding);
+  width: var(--gui-input-tag-width);
+  min-height: var(--gui-input-tag-mini-height);
+  line-height: var(--gui-input-tag-line-height);
+  border-radius: var(--gui-border-radius-base);
+  background-color: var(--gui-fill-color-blank);
+  transition: var(--gui-transition-duration);
+  transform: translate3d(0, 0, 0);
+  box-shadow: 0 0 0 1px var(--gui-border-color) inset;
+}
+.gui-input-tag.is-focused {
+  box-shadow: 0 0 0 1px var(--gui-color-primary) inset;
+}
+
+.gui-input-tag.is-hovering:not(.is-focused) {
+  box-shadow: 0 0 0 1px var(--gui-border-color-hover) inset;
+}
+
+.gui-input-tag.is-disabled {
+  cursor: not-allowed;
+  pointer-events: none;
+  background-color: var(--gui-fill-color-light);
+  box-shadow: 0 0 0 1px var(--gui-input-tag-disabled-border) inset;
+}
+.gui-input-tag.is-disabled:hover {
+  box-shadow: 0 0 0 1px var(--gui-input-tag-disabled-border) inset;
+}
+.gui-input-tag.is-disabled.is-focus {
+  box-shadow: 0 0 0 1px var(--gui-input-focus-border-color) inset;
+}
+.gui-input-tag.is-disabled .gui-input-tag__inner .gui-input-tag__input {
+  cursor: not-allowed;
+}
+
+.gui-input-tag.is-disabled .gui-input-tag__inner .gui-tag {
+  cursor: not-allowed;
+}
+
+.gui-input-tag__prefix {
+  display: flex;
+  align-items: center;
+  flex-shrink: 0;
+  padding: 0 var(--gui-input-tag-inner-padding);
+  color: var(--gui-input-icon-color, var(--gui-text-color-placeholder));
+}
+
+.gui-input-tag__suffix {
+  display: flex;
+  align-items: center;
+  flex-shrink: 0;
+  padding: 0 var(--gui-input-tag-inner-padding);
+  gap: 8px;
+  color: var(--gui-input-icon-color, var(--gui-text-color-placeholder));
+}
+
+.gui-input-tag__inner {
+  position: relative;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  flex: 1;
+  max-width: 100%;
+  min-width: 0;
+  gap: var(--gui-input-tag-gap);
+}
+.gui-input-tag__inner.is-left-space {
+  margin-left: var(--gui-input-tag-inner-padding);
+}
+
+.gui-input-tag__inner.is-right-space {
+  margin-right: var(--gui-input-tag-inner-padding);
+}
+
+.gui-input-tag__inner.is-draggable .gui-tag {
+  cursor: move;
+  user-select: none;
+}
+
+.gui-input-tag__drop-indicator {
+  position: absolute;
+  top: 0;
+  width: 1px;
+  height: var(--el-input-tag-line-height);
+  background-color: var(--gui-color-primary);
+}
+
+.gui-input-tag__inner .gui-tag {
+  max-width: 100%;
+  cursor: pointer;
+  border-color: transparent;
+}
+.gui-input-tag__inner .gui-tag.gui-tag--plain {
+  border-color: var(--gui-tag-border-color);
+}
+.gui-input-tag__inner .gui-tag .gui-tag__content {
+  min-width: 0;
+  line-height: normal;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.gui-input-tag__input-wrapper {
+  flex: 1;
+}
+
+.gui-input-tag__input {
+  border: none;
+  outline: none;
+  padding: 0;
+  color: var(--gui-input-tag-text-color);
+  font-size: inherit;
+  font-family: inherit;
+  line-height: inherit;
+  appearance: none;
+  width: 100%;
+  background-color: transparent;
+}
+.gui-input-tag__input::placeholder {
+  color: var(--gui-input-tag-placeholder-color);
+}
+
+.gui-input-tag__input-calculator {
+  position: absolute;
+  left: 0;
+  top: 0;
+  max-width: 100%;
+  visibility: hidden;
+  white-space: pre;
+  overflow: hidden;
+}
+
+.gui-input-tag--large {
+  --gui-input-tag-gap: 6px;
+  --gui-input-tag-padding: 8px;
+  --gui-input-tag-padding-left: 8px;
+  --gui-input-tag-font-size: 14px;
+}
+
+.gui-input-tag--small {
+  --gui-input-tag-gap: 4px;
+  --gui-input-tag-padding: 2px;
+  --gui-input-tag-padding-left: 6px;
+  --gui-input-tag-font-size: 12px;
+  --gui-input-tag-line-height: 20px;
+  --gui-input-tag-mini-height: var(--gui-component-size-small);
+}

--- a/scripts/scss-parity/baseline/input-tag.css
+++ b/scripts/scss-parity/baseline/input-tag.css
@@ -1,0 +1,882 @@
+/* Element Chalk Variables */
+.gui-input-tag {
+  --gui-input-tag-border-color-hover: var(--gui-border-color-hover);
+  --gui-input-tag-placeholder-color: var(--gui-text-color-placeholder);
+  --gui-input-tag-disabled-color: var(--gui-disabled-text-color);
+  --gui-input-tag-disabled-border: var(--gui-disabled-border-color);
+  --gui-input-tag-font-size: var(--gui-font-size-base);
+  --gui-input-tag-close-hover-color: var(--gui-text-color-secondary);
+  --gui-input-tag-text-color: var(--gui-text-color-regular);
+  --gui-input-tag-input-focus-border-color: var(--gui-color-primary);
+  --gui-input-tag-width: 100%;
+  --gui-input-tag-mini-height: var(--gui-component-size);
+  --gui-input-tag-gap: 6px;
+  --gui-input-tag-padding: 4px;
+  --gui-input-tag-inner-padding: 8px;
+  --gui-input-tag-line-height: 24px;
+}
+
+.gui-input-tag {
+  display: flex;
+  align-items: center;
+  box-sizing: border-box;
+  cursor: pointer;
+  font-size: var(--gui-input-tag-font-size);
+  padding: var(--gui-input-tag-padding);
+  width: var(--gui-input-tag-width);
+  min-height: var(--gui-input-tag-mini-height);
+  line-height: var(--gui-input-tag-line-height);
+  border-radius: var(--gui-border-radius-base);
+  background-color: var(--gui-fill-color-blank);
+  transition: var(--gui-transition-duration);
+  transform: translate3d(0, 0, 0);
+  box-shadow: 0 0 0 1px var(--gui-border-color) inset;
+}
+.gui-input-tag.is-focused {
+  box-shadow: 0 0 0 1px var(--gui-color-primary) inset;
+}
+
+.gui-input-tag.is-hovering:not(.is-focused) {
+  box-shadow: 0 0 0 1px var(--gui-border-color-hover) inset;
+}
+
+.gui-input-tag.is-disabled {
+  cursor: not-allowed;
+  pointer-events: none;
+  background-color: var(--gui-fill-color-light);
+  box-shadow: 0 0 0 1px var(--gui-input-tag-disabled-border) inset;
+}
+.gui-input-tag.is-disabled:hover {
+  box-shadow: 0 0 0 1px var(--gui-input-tag-disabled-border) inset;
+}
+.gui-input-tag.is-disabled.is-focus {
+  box-shadow: 0 0 0 1px var(--gui-input-focus-border-color) inset;
+}
+.gui-input-tag.is-disabled .gui-input-tag__inner .gui-input-tag__input {
+  cursor: not-allowed;
+}
+
+.gui-input-tag.is-disabled .gui-input-tag__inner .gui-tag {
+  cursor: not-allowed;
+}
+
+.gui-input-tag__prefix {
+  display: flex;
+  align-items: center;
+  flex-shrink: 0;
+  padding: 0 var(--gui-input-tag-inner-padding);
+  color: var(--gui-input-icon-color, var(--gui-text-color-placeholder));
+}
+
+.gui-input-tag__suffix {
+  display: flex;
+  align-items: center;
+  flex-shrink: 0;
+  padding: 0 var(--gui-input-tag-inner-padding);
+  gap: 8px;
+  color: var(--gui-input-icon-color, var(--gui-text-color-placeholder));
+}
+
+.gui-input-tag__inner {
+  position: relative;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  flex: 1;
+  max-width: 100%;
+  min-width: 0;
+  gap: var(--gui-input-tag-gap);
+}
+.gui-input-tag__inner.is-left-space {
+  margin-left: var(--gui-input-tag-inner-padding);
+}
+
+.gui-input-tag__inner.is-right-space {
+  margin-right: var(--gui-input-tag-inner-padding);
+}
+
+.gui-input-tag__inner.is-draggable .gui-tag {
+  cursor: move;
+  user-select: none;
+}
+
+.gui-input-tag__drop-indicator {
+  position: absolute;
+  top: 0;
+  width: 1px;
+  height: var(--el-input-tag-line-height);
+  background-color: var(--gui-color-primary);
+}
+
+.gui-input-tag__inner .gui-tag {
+  max-width: 100%;
+  cursor: pointer;
+  border-color: transparent;
+}
+.gui-input-tag__inner .gui-tag.gui-tag--plain {
+  border-color: var(--gui-tag-border-color);
+}
+.gui-input-tag__inner .gui-tag .gui-tag__content {
+  min-width: 0;
+  line-height: normal;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.gui-input-tag__input-wrapper {
+  flex: 1;
+}
+
+.gui-input-tag__input {
+  border: none;
+  outline: none;
+  padding: 0;
+  color: var(--gui-input-tag-text-color);
+  font-size: inherit;
+  font-family: inherit;
+  line-height: inherit;
+  appearance: none;
+  width: 100%;
+  background-color: transparent;
+}
+.gui-input-tag__input::placeholder {
+  color: var(--gui-input-tag-placeholder-color);
+}
+
+.gui-input-tag__input-calculator {
+  position: absolute;
+  left: 0;
+  top: 0;
+  max-width: 100%;
+  visibility: hidden;
+  white-space: pre;
+  overflow: hidden;
+}
+
+.gui-input-tag--large {
+  --gui-input-tag-gap: 6px;
+  --gui-input-tag-padding: 8px;
+  --gui-input-tag-padding-left: 8px;
+  --gui-input-tag-font-size: 14px;
+}
+
+.gui-input-tag--small {
+  --gui-input-tag-gap: 4px;
+  --gui-input-tag-padding: 2px;
+  --gui-input-tag-padding-left: 6px;
+  --gui-input-tag-font-size: 12px;
+  --gui-input-tag-line-height: 20px;
+  --gui-input-tag-mini-height: var(--gui-component-size-small);
+}
+
+.gui-tag {
+  --gui-tag-font-size: 12px;
+  --gui-tag-border-radius: 4px;
+  --gui-tag-border-radius-rounded: 9999px;
+}
+
+.gui-tag {
+  background-color: var(--gui-tag-bg-color);
+  border-color: var(--gui-tag-border-color);
+  color: var(--gui-tag-text-color);
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  vertical-align: middle;
+  height: 24px;
+  padding: 0 9px;
+  font-size: var(--gui-tag-font-size);
+  line-height: 1;
+  border-width: 1px;
+  border-style: solid;
+  border-radius: var(--gui-tag-border-radius);
+  box-sizing: border-box;
+  white-space: nowrap;
+  --gui-icon-size: 14px;
+  --gui-tag-bg-color: var(--gui-color-primary-light-9);
+  --gui-tag-border-color: var(--gui-color-primary-light-8);
+  --gui-tag-hover-color: var(--gui-color-primary);
+}
+.gui-tag.gui-tag--primary {
+  --gui-tag-bg-color: var(--gui-color-primary-light-9);
+  --gui-tag-border-color: var(--gui-color-primary-light-8);
+  --gui-tag-hover-color: var(--gui-color-primary);
+}
+.gui-tag.gui-tag--success {
+  --gui-tag-bg-color: var(--gui-color-success-light-9);
+  --gui-tag-border-color: var(--gui-color-success-light-8);
+  --gui-tag-hover-color: var(--gui-color-success);
+}
+.gui-tag.gui-tag--warning {
+  --gui-tag-bg-color: var(--gui-color-warning-light-9);
+  --gui-tag-border-color: var(--gui-color-warning-light-8);
+  --gui-tag-hover-color: var(--gui-color-warning);
+}
+.gui-tag.gui-tag--danger {
+  --gui-tag-bg-color: var(--gui-color-danger-light-9);
+  --gui-tag-border-color: var(--gui-color-danger-light-8);
+  --gui-tag-hover-color: var(--gui-color-danger);
+}
+.gui-tag.gui-tag--error {
+  --gui-tag-bg-color: var(--gui-color-error-light-9);
+  --gui-tag-border-color: var(--gui-color-error-light-8);
+  --gui-tag-hover-color: var(--gui-color-error);
+}
+.gui-tag.gui-tag--info {
+  --gui-tag-bg-color: var(--gui-color-info-light-9);
+  --gui-tag-border-color: var(--gui-color-info-light-8);
+  --gui-tag-hover-color: var(--gui-color-info);
+}
+.gui-tag.is-hit {
+  border-color: var(--gui-color-primary);
+}
+
+.gui-tag.is-round {
+  border-radius: var(--gui-tag-border-radius-rounded);
+}
+
+.gui-tag .gui-tag__close {
+  flex-shrink: 0;
+  color: var(--gui-tag-text-color);
+}
+.gui-tag .gui-tag__close:hover {
+  color: var(--gui-color-white);
+  background-color: var(--gui-tag-hover-color);
+}
+.gui-tag.gui-tag--primary {
+  --gui-tag-text-color: var(--gui-color-primary);
+}
+.gui-tag.gui-tag--success {
+  --gui-tag-text-color: var(--gui-color-success);
+}
+.gui-tag.gui-tag--warning {
+  --gui-tag-text-color: var(--gui-color-warning);
+}
+.gui-tag.gui-tag--danger {
+  --gui-tag-text-color: var(--gui-color-danger);
+}
+.gui-tag.gui-tag--error {
+  --gui-tag-text-color: var(--gui-color-error);
+}
+.gui-tag.gui-tag--info {
+  --gui-tag-text-color: var(--gui-color-info);
+}
+.gui-tag .gui-icon {
+  border-radius: 50%;
+  cursor: pointer;
+  font-size: calc(var(--gui-icon-size) - 2px);
+  height: var(--gui-icon-size);
+  width: var(--gui-icon-size);
+}
+.gui-tag .gui-tag__close {
+  margin-left: 6px;
+}
+.gui-tag--dark {
+  --gui-tag-text-color: var(--gui-color-white);
+  --gui-tag-bg-color: var(--gui-color-primary);
+  --gui-tag-border-color: var(--gui-color-primary);
+  --gui-tag-hover-color: var(--gui-color-primary-light-3);
+}
+.gui-tag--dark.gui-tag--primary {
+  --gui-tag-bg-color: var(--gui-color-primary);
+  --gui-tag-border-color: var(--gui-color-primary);
+  --gui-tag-hover-color: var(--gui-color-primary-light-3);
+}
+.gui-tag--dark.gui-tag--success {
+  --gui-tag-bg-color: var(--gui-color-success);
+  --gui-tag-border-color: var(--gui-color-success);
+  --gui-tag-hover-color: var(--gui-color-success-light-3);
+}
+.gui-tag--dark.gui-tag--warning {
+  --gui-tag-bg-color: var(--gui-color-warning);
+  --gui-tag-border-color: var(--gui-color-warning);
+  --gui-tag-hover-color: var(--gui-color-warning-light-3);
+}
+.gui-tag--dark.gui-tag--danger {
+  --gui-tag-bg-color: var(--gui-color-danger);
+  --gui-tag-border-color: var(--gui-color-danger);
+  --gui-tag-hover-color: var(--gui-color-danger-light-3);
+}
+.gui-tag--dark.gui-tag--error {
+  --gui-tag-bg-color: var(--gui-color-error);
+  --gui-tag-border-color: var(--gui-color-error);
+  --gui-tag-hover-color: var(--gui-color-error-light-3);
+}
+.gui-tag--dark.gui-tag--info {
+  --gui-tag-bg-color: var(--gui-color-info);
+  --gui-tag-border-color: var(--gui-color-info);
+  --gui-tag-hover-color: var(--gui-color-info-light-3);
+}
+.gui-tag--dark.gui-tag--primary {
+  --gui-tag-text-color: var(--gui-color-white);
+}
+.gui-tag--dark.gui-tag--success {
+  --gui-tag-text-color: var(--gui-color-white);
+}
+.gui-tag--dark.gui-tag--warning {
+  --gui-tag-text-color: var(--gui-color-white);
+}
+.gui-tag--dark.gui-tag--danger {
+  --gui-tag-text-color: var(--gui-color-white);
+}
+.gui-tag--dark.gui-tag--error {
+  --gui-tag-text-color: var(--gui-color-white);
+}
+.gui-tag--dark.gui-tag--info {
+  --gui-tag-text-color: var(--gui-color-white);
+}
+
+.gui-tag--plain {
+  --gui-tag-bg-color: var(--gui-fill-color-blank);
+  --gui-tag-bg-color: var(--gui-fill-color-blank);
+  --gui-tag-border-color: var(--gui-color-primary-light-5);
+  --gui-tag-hover-color: var(--gui-color-primary);
+}
+.gui-tag--plain.gui-tag--primary {
+  --gui-tag-bg-color: var(--gui-fill-color-blank);
+  --gui-tag-border-color: var(--gui-color-primary-light-5);
+  --gui-tag-hover-color: var(--gui-color-primary);
+}
+.gui-tag--plain.gui-tag--success {
+  --gui-tag-bg-color: var(--gui-fill-color-blank);
+  --gui-tag-border-color: var(--gui-color-success-light-5);
+  --gui-tag-hover-color: var(--gui-color-success);
+}
+.gui-tag--plain.gui-tag--warning {
+  --gui-tag-bg-color: var(--gui-fill-color-blank);
+  --gui-tag-border-color: var(--gui-color-warning-light-5);
+  --gui-tag-hover-color: var(--gui-color-warning);
+}
+.gui-tag--plain.gui-tag--danger {
+  --gui-tag-bg-color: var(--gui-fill-color-blank);
+  --gui-tag-border-color: var(--gui-color-danger-light-5);
+  --gui-tag-hover-color: var(--gui-color-danger);
+}
+.gui-tag--plain.gui-tag--error {
+  --gui-tag-bg-color: var(--gui-fill-color-blank);
+  --gui-tag-border-color: var(--gui-color-error-light-5);
+  --gui-tag-hover-color: var(--gui-color-error);
+}
+.gui-tag--plain.gui-tag--info {
+  --gui-tag-bg-color: var(--gui-fill-color-blank);
+  --gui-tag-border-color: var(--gui-color-info-light-5);
+  --gui-tag-hover-color: var(--gui-color-info);
+}
+
+.gui-tag.is-closable {
+  padding-right: 5px;
+}
+.gui-tag--large {
+  padding: 0 11px;
+  height: 32px;
+  --gui-icon-size: 16px;
+}
+.gui-tag--large .gui-tag__close {
+  margin-left: 8px;
+}
+.gui-tag--large.is-closable {
+  padding-right: 7px;
+}
+
+.gui-tag--small {
+  padding: 0 7px;
+  height: 20px;
+  --gui-icon-size: 12px;
+}
+.gui-tag--small .gui-tag__close {
+  margin-left: 4px;
+}
+.gui-tag--small.is-closable {
+  padding-right: 3px;
+}
+
+.gui-tag--small .gui-icon-close {
+  transform: scale(0.8);
+}
+
+.gui-tag.gui-tag--primary.is-hit {
+  border-color: var(--gui-color-primary);
+}
+
+.gui-tag.gui-tag--success.is-hit {
+  border-color: var(--gui-color-success);
+}
+
+.gui-tag.gui-tag--warning.is-hit {
+  border-color: var(--gui-color-warning);
+}
+
+.gui-tag.gui-tag--danger.is-hit {
+  border-color: var(--gui-color-danger);
+}
+
+.gui-tag.gui-tag--error.is-hit {
+  border-color: var(--gui-color-error);
+}
+
+.gui-tag.gui-tag--info.is-hit {
+  border-color: var(--gui-color-info);
+}
+
+.gui-tag {
+  @apply rounded-full flex items-center justify-center text-primary-txt w-min;
+}
+.gui-tag__xs {
+  @apply h-4 p-xxs text-1 font-medium gap-xxs;
+}
+.gui-tag__xs--prefix-icon {
+  @apply w-[10px] h-[10px] flex justify-center items-center;
+}
+.gui-tag__xs--prefix-icon svg {
+  @apply text-1 align-super;
+}
+
+.gui-tag__xs--suffix-icon {
+  @apply w-[10px] h-[10px] flex justify-center items-center;
+}
+.gui-tag__xs--suffix-icon svg {
+  @apply text-1 align-super;
+}
+
+.gui-tag__sm {
+  @apply h-[22px] py-xxs px-xs text-2 font-medium gap-xxs;
+}
+.gui-tag__sm--prefix-icon {
+  @apply w-3 h-3 flex justify-center items-center;
+}
+.gui-tag__sm--prefix-icon svg {
+  @apply text-1 align-super;
+}
+
+.gui-tag__sm--suffix-icon {
+  @apply w-3 h-3 flex justify-center items-center;
+}
+.gui-tag__sm--suffix-icon svg {
+  @apply text-1 align-super;
+}
+
+.gui-tag__md {
+  @apply h-[30px] py-xxs px-xs text-2 font-medium gap-xxs;
+}
+.gui-tag__md--prefix-icon {
+  @apply w-[14px] h-[14px] flex justify-center items-center;
+}
+.gui-tag__md--prefix-icon svg {
+  @apply text-2 align-super;
+}
+
+.gui-tag__md--suffix-icon {
+  @apply w-[14px] h-[14px] flex justify-center items-center;
+}
+.gui-tag__md--suffix-icon svg {
+  @apply text-2 align-super;
+}
+
+.gui-tag__light--success {
+  @apply border-success-bd bg-success-bg;
+}
+
+.gui-tag__light--info {
+  @apply border-info-bd bg-info-bg;
+}
+
+.gui-tag__light--warning {
+  @apply border-warning-bd bg-warning-bg;
+}
+
+.gui-tag__light--error {
+  @apply border-error-bd bg-error-bg;
+}
+
+.gui-tag__light--grey {
+  @apply border-disabled-bd bg-grey-50;
+}
+
+.gui-tag__dark--success {
+  @apply border-success-bd bg-success-def text-inverse-txt;
+}
+
+.gui-tag__dark--info {
+  @apply border-info-bd bg-info-def text-inverse-txt;
+}
+
+.gui-tag__dark--warning {
+  @apply border-warning-bd bg-warning-def text-inverse-txt;
+}
+
+.gui-tag__dark--error {
+  @apply border-error-bd bg-error-def text-inverse-txt;
+}
+
+.gui-tag__dark--grey {
+  @apply border-grey-500 bg-grey-500 text-inverse-txt;
+}
+
+.gui-tag__close {
+  @apply m-0 ml-0 cursor-pointer !important;
+}
+.gui-tag__close:hover {
+  @apply bg-inherit text-inherit !important;
+}
+
+/* Element Chalk Variables */
+.el-tooltip-v2__content {
+  --el-tooltip-v2-padding: 5px 10px;
+  --el-tooltip-v2-border-radius: 4px;
+  --el-tooltip-v2-border-color: var(--el-border-color);
+  border-radius: var(--el-tooltip-v2-border-radius);
+  color: var(--el-color-black);
+  background-color: var(--el-color-white);
+  padding: var(--el-tooltip-v2-padding);
+  border: 1px solid var(--el-border-color);
+}
+.el-tooltip-v2__arrow {
+  position: absolute;
+  color: var(--el-color-white);
+  width: var(--el-tooltip-v2-arrow-width);
+  height: var(--el-tooltip-v2-arrow-height);
+  pointer-events: none;
+  left: var(--el-tooltip-v2-arrow-x);
+  top: var(--el-tooltip-v2-arrow-y);
+}
+.el-tooltip-v2__arrow::before {
+  content: "";
+  width: 0;
+  height: 0;
+  border: var(--el-tooltip-v2-arrow-border-width) solid transparent;
+  position: absolute;
+}
+.el-tooltip-v2__arrow::after {
+  content: "";
+  width: 0;
+  height: 0;
+  border: var(--el-tooltip-v2-arrow-border-width) solid transparent;
+  position: absolute;
+}
+.el-tooltip-v2__content[data-side^=top] .el-tooltip-v2__arrow {
+  bottom: 0;
+}
+.el-tooltip-v2__content[data-side^=top] .el-tooltip-v2__arrow::before {
+  border-top-color: var(--el-color-white);
+  border-top-width: var(--el-tooltip-v2-arrow-border-width);
+  border-bottom: 0;
+  top: calc(100% - 1px);
+}
+.el-tooltip-v2__content[data-side^=top] .el-tooltip-v2__arrow::after {
+  border-top-color: var(--el-border-color);
+  border-top-width: var(--el-tooltip-v2-arrow-border-width);
+  border-bottom: 0;
+  top: 100%;
+  z-index: -1;
+}
+.el-tooltip-v2__content[data-side^=bottom] .el-tooltip-v2__arrow {
+  top: 0;
+}
+.el-tooltip-v2__content[data-side^=bottom] .el-tooltip-v2__arrow::before {
+  border-bottom-color: var(--el-color-white);
+  border-bottom-width: var(--el-tooltip-v2-arrow-border-width);
+  border-top: 0;
+  bottom: calc(100% - 1px);
+}
+.el-tooltip-v2__content[data-side^=bottom] .el-tooltip-v2__arrow::after {
+  border-bottom-color: var(--el-border-color);
+  border-bottom-width: var(--el-tooltip-v2-arrow-border-width);
+  border-top: 0;
+  bottom: 100%;
+  z-index: -1;
+}
+.el-tooltip-v2__content[data-side^=left] .el-tooltip-v2__arrow {
+  right: 0;
+}
+.el-tooltip-v2__content[data-side^=left] .el-tooltip-v2__arrow::before {
+  border-left-color: var(--el-color-white);
+  border-left-width: var(--el-tooltip-v2-arrow-border-width);
+  border-right: 0;
+  left: calc(100% - 1px);
+}
+.el-tooltip-v2__content[data-side^=left] .el-tooltip-v2__arrow::after {
+  border-left-color: var(--el-border-color);
+  border-left-width: var(--el-tooltip-v2-arrow-border-width);
+  border-right: 0;
+  left: 100%;
+  z-index: -1;
+}
+.el-tooltip-v2__content[data-side^=right] .el-tooltip-v2__arrow {
+  left: 0;
+}
+.el-tooltip-v2__content[data-side^=right] .el-tooltip-v2__arrow::before {
+  border-right-color: var(--el-color-white);
+  border-right-width: var(--el-tooltip-v2-arrow-border-width);
+  border-left: 0;
+  right: calc(100% - 1px);
+}
+.el-tooltip-v2__content[data-side^=right] .el-tooltip-v2__arrow::after {
+  border-right-color: var(--el-border-color);
+  border-right-width: var(--el-tooltip-v2-arrow-border-width);
+  border-left: 0;
+  right: 100%;
+  z-index: -1;
+}
+
+.el-tooltip-v2__content.is-dark {
+  --el-tooltip-v2-border-color: transparent;
+  background-color: var(--el-color-black);
+  color: var(--el-color-white);
+  border-color: transparent;
+}
+.el-tooltip-v2__content.is-dark .el-tooltip-v2__arrow {
+  background-color: var(--el-color-black);
+  border-color: transparent;
+}
+
+.el-popper {
+  --el-popper-border-radius: var(--el-popover-border-radius, 4px);
+}
+
+.el-popper {
+  position: absolute;
+  border-radius: var(--el-popper-border-radius);
+  padding: 5px 11px;
+  z-index: 2000;
+  font-size: 12px;
+  line-height: 20px;
+  min-width: 10px;
+  overflow-wrap: break-word;
+  visibility: visible;
+}
+.el-popper.is-dark {
+  color: var(--el-bg-color);
+  background: var(--el-text-color-primary);
+  border: 1px solid var(--el-text-color-primary);
+}
+.el-popper.is-dark > .el-popper__arrow::before {
+  border: 1px solid var(--el-text-color-primary);
+  background: var(--el-text-color-primary);
+  right: 0;
+}
+
+.el-popper.is-light {
+  background: var(--el-bg-color-overlay);
+  border: 1px solid var(--el-border-color-light);
+}
+.el-popper.is-light > .el-popper__arrow::before {
+  border: 1px solid var(--el-border-color-light);
+  background: var(--el-bg-color-overlay);
+  right: 0;
+}
+
+.el-popper.is-pure {
+  padding: 0;
+}
+
+.el-popper__arrow {
+  position: absolute;
+  width: 10px;
+  height: 10px;
+  z-index: -1;
+}
+.el-popper__arrow::before {
+  position: absolute;
+  width: 10px;
+  height: 10px;
+  z-index: -1;
+  content: " ";
+  transform: rotate(45deg);
+  background: var(--el-text-color-primary);
+  box-sizing: border-box;
+}
+
+.el-popper[data-popper-placement^=top] > .el-popper__arrow {
+  bottom: -5px;
+}
+.el-popper[data-popper-placement^=top] > .el-popper__arrow::before {
+  border-bottom-right-radius: 2px;
+}
+.el-popper[data-popper-placement^=bottom] > .el-popper__arrow {
+  top: -5px;
+}
+.el-popper[data-popper-placement^=bottom] > .el-popper__arrow::before {
+  border-top-left-radius: 2px;
+}
+.el-popper[data-popper-placement^=left] > .el-popper__arrow {
+  right: -5px;
+}
+.el-popper[data-popper-placement^=left] > .el-popper__arrow::before {
+  border-top-right-radius: 2px;
+}
+.el-popper[data-popper-placement^=right] > .el-popper__arrow {
+  left: -5px;
+}
+.el-popper[data-popper-placement^=right] > .el-popper__arrow::before {
+  border-bottom-left-radius: 2px;
+}
+.el-popper[data-popper-placement^=top] > .el-popper__arrow::before {
+  border-top-color: transparent !important;
+  border-left-color: transparent !important;
+}
+.el-popper[data-popper-placement^=bottom] > .el-popper__arrow::before {
+  border-bottom-color: transparent !important;
+  border-right-color: transparent !important;
+}
+.el-popper[data-popper-placement^=left] > .el-popper__arrow::before {
+  border-left-color: transparent !important;
+  border-bottom-color: transparent !important;
+}
+.el-popper[data-popper-placement^=right] > .el-popper__arrow::before {
+  border-right-color: transparent !important;
+  border-top-color: transparent !important;
+}
+
+.el-popper.gui-popper__tooltip {
+  @apply p-md bg-everBlue-50 border-none rounded-md max-w-56 pt-sm shadow-md !important;
+}
+.el-popper__container {
+  @apply flex flex-col gap-xxs;
+}
+
+.el-popper__header {
+  @apply flex items-center justify-between;
+}
+.el-popper__header h6 {
+  @apply text-2 font-semibold text-primary-txt line-clamp-2;
+}
+
+.el-popper__description {
+  @apply text-2 font-medium text-secondary-txt text-pretty;
+}
+
+.el-popper__content {
+  @apply text-2 font-medium text-secondary-txt text-pretty;
+}
+
+.el-popper__arrow::before {
+  @apply bg-everBlue-50 border-none !important;
+}
+
+.gui-input-tag {
+  @apply relative flex items-center bg-white py-sm px-xs border border-disabled-bd rounded-md min-h-12 gap-xs shadow-none text-primary-txt font-medium text-4 transition-all duration-200 ease-in;
+  box-shadow: none !important;
+  border-width: 1px;
+}
+.gui-input-tag__container {
+  @apply flex flex-col gap-xxs;
+}
+
+.gui-input-tag.is-focused {
+  @apply border-everBlue-500;
+  box-shadow: none !important;
+}
+
+.gui-input-tag.is-complete {
+  @apply border-secondary-bd;
+  box-shadow: none !important;
+}
+
+.gui-input-tag.is-disabled {
+  @apply bg-primary-def-disabled border-grey-400 text-disabled-txt cursor-not-allowed shadow-none;
+  box-shadow: none !important;
+  pointer-events: none;
+}
+.gui-input-tag.is-disabled .gui-tag {
+  @apply cursor-not-allowed;
+}
+
+.gui-input-tag.is-error {
+  @apply border-error-bd;
+}
+
+.gui-input-tag__help {
+  @apply flex gap-xxs justify-between text-2 font-medium text-disabled-txt px-xs;
+  min-height: 18px;
+}
+
+.gui-input-tag__help-text {
+  @apply line-clamp-2;
+}
+
+.gui-input-tag__help-error {
+  @apply text-error-txt;
+}
+
+.gui-input-tag__wrapper {
+  @apply w-full;
+}
+
+.gui-input-tag__inner {
+  @apply flex flex-wrap items-center gap-xs w-full;
+  min-height: 1.5rem;
+}
+.gui-input-tag__inner.is-left-space {
+  @apply pl-xxs;
+}
+
+.gui-input-tag__inner.is-right-space {
+  @apply pr-xxs;
+}
+
+.gui-input-tag__inner.is-draggable .gui-input-tag__tag-wrapper {
+  @apply cursor-move;
+}
+
+.gui-input-tag__tag-wrapper {
+  @apply inline-flex max-w-full;
+}
+
+.gui-input-tag__input-wrapper {
+  @apply flex-1 min-w-[80px];
+}
+
+.gui-input-tag__input {
+  @apply w-full bg-transparent border-0 outline-none text-primary-txt text-4 font-medium p-0 caret-everBlue-500;
+  appearance: none;
+}
+.gui-input-tag__input::placeholder {
+  @apply text-terciary-txt transition-all duration-200 ease-in;
+}
+
+.gui-input-tag__input-calculator {
+  @apply absolute left-0 top-0 max-w-full invisible whitespace-pre overflow-hidden;
+}
+
+.gui-input-tag__prefix {
+  @apply inline-flex items-center flex-shrink-0 pr-2 text-terciary-txt;
+}
+
+.gui-input-tag__suffix {
+  @apply inline-flex items-center flex-shrink-0 pl-2 gap-xxs text-terciary-txt;
+}
+
+.gui-input-tag__icon {
+  @apply text-6 text-grey-500 cursor-pointer select-none w-5 transition-colors duration-200;
+}
+
+.gui-input-tag__clear:hover {
+  @apply text-secondary-txt;
+}
+
+.gui-input-tag__drop-indicator {
+  @apply absolute w-px bg-everBlue-500;
+  top: 0;
+  height: 1.25rem;
+}
+
+.gui-input-tag__collapse-tag {
+  @apply inline-flex max-w-full;
+}
+
+.gui-input-tag__input-tag-list {
+  @apply flex flex-col gap-xs;
+  max-width: 16rem;
+}
+
+.gui-input-tag--small {
+  @apply min-h-10 text-3 px-xs py-xs;
+}
+.gui-input-tag--small .gui-input-tag__input {
+  @apply text-3;
+}
+
+.gui-input-tag--large {
+  @apply min-h-12 text-4 px-xs py-sm;
+}

--- a/scripts/scss-parity/baseline/quote.css
+++ b/scripts/scss-parity/baseline/quote.css
@@ -1,3 +1,4 @@
+/* Element Chalk Variables */
 .gui-quote {
   @apply flex flex-col gap-xs;
 }

--- a/scripts/scss-parity/baseline/radio-theme.css
+++ b/scripts/scss-parity/baseline/radio-theme.css
@@ -1,0 +1,193 @@
+@charset "UTF-8";
+/* Element Chalk Variables */
+.gui-radio {
+  --gui-radio-font-size: var(--gui-font-size-base);
+  --gui-radio-text-color: var(--gui-text-color-regular);
+  --gui-radio-font-weight: var(--gui-font-weight-primary);
+  --gui-radio-input-height: 14px;
+  --gui-radio-input-width: 14px;
+  --gui-radio-input-border-radius: var(--gui-border-radius-circle);
+  --gui-radio-input-bg-color: var(--gui-fill-color-blank);
+  --gui-radio-input-border: var(--gui-border);
+  --gui-radio-input-border-color: var(--gui-border-color);
+  --gui-radio-input-border-color-hover: var(--gui-color-primary);
+}
+
+.gui-radio {
+  color: var(--gui-radio-text-color);
+  font-weight: var(--gui-radio-font-weight);
+  position: relative;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  white-space: nowrap;
+  outline: none;
+  font-size: var(--gui-font-size-base);
+  user-select: none;
+  margin-right: 30px;
+  height: 32px;
+}
+.gui-radio.gui-radio--large {
+  height: 40px;
+}
+.gui-radio.gui-radio--small {
+  height: 24px;
+}
+.gui-radio.is-bordered {
+  padding: 0 15px 0 9px;
+  border-radius: var(--gui-border-radius-base);
+  border: var(--gui-border);
+  box-sizing: border-box;
+}
+.gui-radio.is-bordered.is-checked {
+  border-color: var(--gui-color-primary);
+}
+.gui-radio.is-bordered.is-disabled {
+  cursor: not-allowed;
+  border-color: var(--gui-border-color-lighter);
+}
+.gui-radio.is-bordered.gui-radio--large {
+  padding: 0 19px 0 11px;
+  border-radius: var(--gui-border-radius-base);
+}
+.gui-radio.is-bordered.gui-radio--large .gui-radio__label {
+  font-size: var(--gui-font-size-base);
+}
+.gui-radio.is-bordered.gui-radio--large .gui-radio__inner {
+  height: 14px;
+  width: 14px;
+}
+.gui-radio.is-bordered.gui-radio--small {
+  padding: 0 11px 0 7px;
+  border-radius: var(--gui-border-radius-base);
+}
+.gui-radio.is-bordered.gui-radio--small .gui-radio__label {
+  font-size: 12px;
+}
+.gui-radio.is-bordered.gui-radio--small .gui-radio__inner {
+  height: 12px;
+  width: 12px;
+}
+
+.gui-radio:last-child {
+  margin-right: 0;
+}
+.gui-radio__input {
+  white-space: nowrap;
+  cursor: pointer;
+  outline: none;
+  display: inline-flex;
+  position: relative;
+  vertical-align: middle;
+}
+.gui-radio__input.is-disabled .gui-radio__inner {
+  background-color: var(--gui-disabled-bg-color);
+  border-color: var(--gui-disabled-border-color);
+  cursor: not-allowed;
+}
+.gui-radio__input.is-disabled .gui-radio__inner::after {
+  cursor: not-allowed;
+  background-color: var(--gui-disabled-bg-color);
+}
+.gui-radio__input.is-disabled .gui-radio__inner + .gui-radio__label {
+  cursor: not-allowed;
+}
+.gui-radio__input.is-disabled.is-checked .gui-radio__inner {
+  background-color: var(--gui-disabled-bg-color);
+  border-color: var(--gui-disabled-border-color);
+}
+.gui-radio__input.is-disabled.is-checked .gui-radio__inner::after {
+  background-color: var(--gui-text-color-placeholder);
+}
+.gui-radio__input.is-disabled + span.gui-radio__label {
+  color: var(--gui-text-color-placeholder);
+  cursor: not-allowed;
+}
+
+.gui-radio__input.is-checked .gui-radio__inner {
+  border-color: var(--gui-color-primary);
+  background: var(--gui-color-primary);
+}
+.gui-radio__input.is-checked .gui-radio__inner::after {
+  transform: translate(-50%, -50%) scale(1);
+}
+.gui-radio__input.is-checked + .gui-radio__label {
+  color: var(--gui-color-primary);
+}
+
+.gui-radio__input.is-focus .gui-radio__inner {
+  border-color: var(--gui-radio-input-border-color-hover);
+}
+
+.gui-radio__inner {
+  border: var(--gui-radio-input-border);
+  border-radius: var(--gui-radio-input-border-radius);
+  width: var(--gui-radio-input-width);
+  height: var(--gui-radio-input-height);
+  background-color: var(--gui-radio-input-bg-color);
+  position: relative;
+  cursor: pointer;
+  display: inline-block;
+  box-sizing: border-box;
+}
+.gui-radio__inner:hover {
+  border-color: var(--gui-radio-input-border-color-hover);
+}
+.gui-radio__inner::after {
+  width: 4px;
+  height: 4px;
+  border-radius: var(--gui-radio-input-border-radius);
+  background-color: var(--gui-color-white);
+  content: "";
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  transform: translate(-50%, -50%) scale(0);
+  transition: transform 0.15s ease-in;
+}
+
+.gui-radio__original {
+  opacity: 0;
+  outline: none;
+  position: absolute;
+  z-index: -1;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  margin: 0;
+}
+.gui-radio__original:focus-visible + .gui-radio__inner {
+  outline: 2px solid var(--gui-radio-input-border-color-hover);
+  outline-offset: 1px;
+  border-radius: var(--gui-radio-input-border-radius);
+}
+
+.gui-radio:focus:not(:focus-visible):not(.is-focus):not(:active):not(.is-disabled) {
+  /*获得焦点时 样式提醒*/
+}
+.gui-radio:focus:not(:focus-visible):not(.is-focus):not(:active):not(.is-disabled) .gui-radio__inner {
+  box-shadow: 0 0 2px 2px var(--gui-radio-input-border-color-hover);
+}
+.gui-radio__label {
+  font-size: var(--gui-radio-font-size);
+  padding-left: 8px;
+}
+
+.gui-radio.gui-radio--large .gui-radio__label {
+  font-size: 14px;
+}
+
+.gui-radio.gui-radio--large .gui-radio__inner {
+  width: 14px;
+  height: 14px;
+}
+
+.gui-radio.gui-radio--small .gui-radio__label {
+  font-size: 12px;
+}
+
+.gui-radio.gui-radio--small .gui-radio__inner {
+  width: 12px;
+  height: 12px;
+}

--- a/scripts/scss-parity/baseline/radio.css
+++ b/scripts/scss-parity/baseline/radio.css
@@ -1,0 +1,270 @@
+@charset "UTF-8";
+/* Element Chalk Variables */
+.gui-radio {
+  --gui-radio-font-size: var(--gui-font-size-base);
+  --gui-radio-text-color: var(--gui-text-color-regular);
+  --gui-radio-font-weight: var(--gui-font-weight-primary);
+  --gui-radio-input-height: 14px;
+  --gui-radio-input-width: 14px;
+  --gui-radio-input-border-radius: var(--gui-border-radius-circle);
+  --gui-radio-input-bg-color: var(--gui-fill-color-blank);
+  --gui-radio-input-border: var(--gui-border);
+  --gui-radio-input-border-color: var(--gui-border-color);
+  --gui-radio-input-border-color-hover: var(--gui-color-primary);
+}
+
+.gui-radio {
+  color: var(--gui-radio-text-color);
+  font-weight: var(--gui-radio-font-weight);
+  position: relative;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  white-space: nowrap;
+  outline: none;
+  font-size: var(--gui-font-size-base);
+  user-select: none;
+  margin-right: 30px;
+  height: 32px;
+}
+.gui-radio.gui-radio--large {
+  height: 40px;
+}
+.gui-radio.gui-radio--small {
+  height: 24px;
+}
+.gui-radio.is-bordered {
+  padding: 0 15px 0 9px;
+  border-radius: var(--gui-border-radius-base);
+  border: var(--gui-border);
+  box-sizing: border-box;
+}
+.gui-radio.is-bordered.is-checked {
+  border-color: var(--gui-color-primary);
+}
+.gui-radio.is-bordered.is-disabled {
+  cursor: not-allowed;
+  border-color: var(--gui-border-color-lighter);
+}
+.gui-radio.is-bordered.gui-radio--large {
+  padding: 0 19px 0 11px;
+  border-radius: var(--gui-border-radius-base);
+}
+.gui-radio.is-bordered.gui-radio--large .gui-radio__label {
+  font-size: var(--gui-font-size-base);
+}
+.gui-radio.is-bordered.gui-radio--large .gui-radio__inner {
+  height: 14px;
+  width: 14px;
+}
+.gui-radio.is-bordered.gui-radio--small {
+  padding: 0 11px 0 7px;
+  border-radius: var(--gui-border-radius-base);
+}
+.gui-radio.is-bordered.gui-radio--small .gui-radio__label {
+  font-size: 12px;
+}
+.gui-radio.is-bordered.gui-radio--small .gui-radio__inner {
+  height: 12px;
+  width: 12px;
+}
+
+.gui-radio:last-child {
+  margin-right: 0;
+}
+.gui-radio__input {
+  white-space: nowrap;
+  cursor: pointer;
+  outline: none;
+  display: inline-flex;
+  position: relative;
+  vertical-align: middle;
+}
+.gui-radio__input.is-disabled .gui-radio__inner {
+  background-color: var(--gui-disabled-bg-color);
+  border-color: var(--gui-disabled-border-color);
+  cursor: not-allowed;
+}
+.gui-radio__input.is-disabled .gui-radio__inner::after {
+  cursor: not-allowed;
+  background-color: var(--gui-disabled-bg-color);
+}
+.gui-radio__input.is-disabled .gui-radio__inner + .gui-radio__label {
+  cursor: not-allowed;
+}
+.gui-radio__input.is-disabled.is-checked .gui-radio__inner {
+  background-color: var(--gui-disabled-bg-color);
+  border-color: var(--gui-disabled-border-color);
+}
+.gui-radio__input.is-disabled.is-checked .gui-radio__inner::after {
+  background-color: var(--gui-text-color-placeholder);
+}
+.gui-radio__input.is-disabled + span.gui-radio__label {
+  color: var(--gui-text-color-placeholder);
+  cursor: not-allowed;
+}
+
+.gui-radio__input.is-checked .gui-radio__inner {
+  border-color: var(--gui-color-primary);
+  background: var(--gui-color-primary);
+}
+.gui-radio__input.is-checked .gui-radio__inner::after {
+  transform: translate(-50%, -50%) scale(1);
+}
+.gui-radio__input.is-checked + .gui-radio__label {
+  color: var(--gui-color-primary);
+}
+
+.gui-radio__input.is-focus .gui-radio__inner {
+  border-color: var(--gui-radio-input-border-color-hover);
+}
+
+.gui-radio__inner {
+  border: var(--gui-radio-input-border);
+  border-radius: var(--gui-radio-input-border-radius);
+  width: var(--gui-radio-input-width);
+  height: var(--gui-radio-input-height);
+  background-color: var(--gui-radio-input-bg-color);
+  position: relative;
+  cursor: pointer;
+  display: inline-block;
+  box-sizing: border-box;
+}
+.gui-radio__inner:hover {
+  border-color: var(--gui-radio-input-border-color-hover);
+}
+.gui-radio__inner::after {
+  width: 4px;
+  height: 4px;
+  border-radius: var(--gui-radio-input-border-radius);
+  background-color: var(--gui-color-white);
+  content: "";
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  transform: translate(-50%, -50%) scale(0);
+  transition: transform 0.15s ease-in;
+}
+
+.gui-radio__original {
+  opacity: 0;
+  outline: none;
+  position: absolute;
+  z-index: -1;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  margin: 0;
+}
+.gui-radio__original:focus-visible + .gui-radio__inner {
+  outline: 2px solid var(--gui-radio-input-border-color-hover);
+  outline-offset: 1px;
+  border-radius: var(--gui-radio-input-border-radius);
+}
+
+.gui-radio:focus:not(:focus-visible):not(.is-focus):not(:active):not(.is-disabled) {
+  /*获得焦点时 样式提醒*/
+}
+.gui-radio:focus:not(:focus-visible):not(.is-focus):not(:active):not(.is-disabled) .gui-radio__inner {
+  box-shadow: 0 0 2px 2px var(--gui-radio-input-border-color-hover);
+}
+.gui-radio__label {
+  font-size: var(--gui-radio-font-size);
+  padding-left: 8px;
+}
+
+.gui-radio.gui-radio--large .gui-radio__label {
+  font-size: 14px;
+}
+
+.gui-radio.gui-radio--large .gui-radio__inner {
+  width: 14px;
+  height: 14px;
+}
+
+.gui-radio.gui-radio--small .gui-radio__label {
+  font-size: 12px;
+}
+
+.gui-radio.gui-radio--small .gui-radio__inner {
+  width: 12px;
+  height: 12px;
+}
+
+.gui-radio-group {
+  display: inline-flex;
+  align-items: center;
+  flex-wrap: wrap;
+  font-size: 0;
+}
+
+.gui-radio {
+  @apply text-3 gap-xxs m-0 h-fit items-center;
+}
+.gui-radio__label {
+  @apply p-0 text-secondary-txt text-pretty relative -top-0.5;
+}
+
+.gui-radio.is-checked:not(.is-disabled) .gui-radio__label {
+  @apply text-secondary-txt;
+}
+
+.gui-radio.is-checked:not(.is-disabled) .gui-radio__inner {
+  @apply border-primary-bd;
+}
+
+.gui-radio.is-checked.is-disabled .gui-radio__inner {
+  @apply bg-transparent border-disab-lt-bd;
+}
+.gui-radio.is-checked.is-disabled .gui-radio__inner:after {
+  @apply bg-disab-lt-bg;
+}
+
+.gui-radio.is-disabled {
+  @apply cursor-not-allowed;
+}
+.gui-radio.is-disabled .gui-radio__label {
+  @apply text-disab-lt-txt !important;
+}
+
+.gui-radio__input {
+  @apply self-start;
+}
+.gui-radio__input.is-checked .gui-radio__inner {
+  @apply bg-transparent;
+}
+.gui-radio__input.is-checked .gui-radio__inner:after {
+  @apply w-3 h-3 bg-primary-def;
+}
+
+.gui-radio__input.is-disabled {
+  @apply cursor-not-allowed;
+}
+.gui-radio__input.is-disabled .gui-radio__inner {
+  @apply bg-transparent border-disab-lt-bd;
+}
+.gui-radio__input.is-disabled .gui-radio__inner .hover-effect {
+  @apply invisible;
+}
+
+.gui-radio__inner {
+  @apply w-[18px] h-[18px] border-disabled-bd border mr-[7px] bg-transparent;
+  transition: border-color 0.4s;
+}
+.gui-radio__inner:active .hover-effect {
+  @apply bg-primary-def-press;
+}
+.gui-radio__inner:hover .hover-effect {
+  @apply w-8 h-8;
+}
+.gui-radio__inner .hover-effect {
+  @apply absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 w-0 h-0 rounded-full bg-primary-def-hover bg-center bg-opacity-20 opacity-20 ease-out;
+  transition: background 0.8s, width 0.4s, height 0.4s;
+}
+.gui-radio__inner .hover-effect .ripple {
+  @apply absolute w-full h-full bg-white/80 rounded-full scale-0 opacity-100 pointer-events-none;
+}
+.gui-radio__inner .hover-effect .ripple.expand {
+  @apply animate-ripple-expand;
+}

--- a/scripts/scss-parity/targets.json
+++ b/scripts/scss-parity/targets.json
@@ -38,5 +38,17 @@
   "collapse-theme": "components/collapse/src/styles/collapse.scss",
   "collapse": "components/collapse/src/collapse.styles.scss",
   "segmented-theme": "components/segmented/src/styles/segmented.scss",
-  "segmented": "components/segmented/src/segmented.styles.scss"
+  "segmented": "components/segmented/src/segmented.styles.scss",
+  "checkbox-theme": "components/checkbox/src/styles/checkbox.scss",
+  "checkbox": "components/checkbox/src/checkbox.styles.scss",
+  "radio-theme": "components/radio/src/styles/radio.scss",
+  "radio": "components/radio/src/radio.styles.scss",
+  "drawer-theme": "components/drawer/src/styles/drawer.scss",
+  "drawer": "components/drawer/src/drawer.styles.scss",
+  "dropdown-theme": "components/dropdown/src/styles/dropdown.scss",
+  "dropdown": "components/dropdown/src/dropdown.styles.scss",
+  "input-tag-theme": "components/input-tag/src/styles/input-tag.scss",
+  "input-tag": "components/input-tag/src/input-tag.styles.scss",
+  "g-utils-button-mixins": "common/g-utils/styles/button-mixins.scss",
+  "g-utils-radio-group": "common/g-utils/styles/radio-group.scss"
 }


### PR DESCRIPTION
## Qué

Cuarta slice de WU4. Porta byte-exacto el theme de `checkbox`, `radio`, `drawer`, `dropdown` e `input-tag` a un archivo local `src/styles/<nombre>.scss` de cada componente, repuntando la hoja de entrada. `drawer` y `dropdown` además repuntan a los exports de g-utils ya portados en S1/S2 (`overlay`, `scrollbar`, `popper`) en vez de duplicar esos ports.

## Hallazgos durante esta slice

**g-utils `mixins.scss` estaba incompleto.** El puerto de WU1 solo tenía 4 de los 15 mixins de element-plus (`b/e/m/when`). `dropdown` necesita `picker-popper`, que no existía → error real de compilación ("Undefined mixin"). Se completó el puerto con los 11 mixins faltantes (`res`, `scroll-bar`, `configurable-m`, `spec-selector`, `meb`, `extend-rule`, `share-rule`, `pseudo`, `picker-popper`, `dark`, `inset-input-border`), cada uno verificado byte-exacto contra element-plus vía invocación forzada.

Esto reveló un efecto secundario **benigno**: al completar `mixins.scss` (que ahora depende de `tokens` para `$breakpoints`, igual que en EP), dos baselines ya migradas (`input-number`, `quote`) ganan un bloque `:root` de tokens que antes no era alcanzable en su compilación aislada. Verificado con diff de multiset de bloques: **pura adición, 0 removido, +1 bloque** — sin regresión real (en el agregado real, config-provider ya bootstrapea tokens primero). Baselines actualizadas con esa justificación.

Dos exports nuevos en g-utils, descubiertos al portar checkbox/radio:
- `./button-mixins`: puerto byte-exacto de `mixins/_button.scss` de EP (actualmente sin uso real en ninguno de los dos consumidores, portado igual por fidelidad).
- `./radio-group`: puerto byte-exacto del theme `radio-group.scss` de EP, consumido por `radio` (la isla JS `radio-group` queda intacta per task 4.3 hasta su propia migración).

## Verificación

- Byte-exacto: los 5 componentes completos + los 2 exports compartidos nuevos + las 15 invocaciones de mixins.
- **Parity harness**: 52/52 OK.
- Tests pre-push ✅.
- Validación en b2b vía yarn link: pendiente antes del merge.

## Alcance

Sin cambios de API pública. El componente/isla `radio-group` (JS) no se toca — sigue importando element-plus directamente hasta su propia slice de migración JS.