### PR TITLE
refactor(styles): repoint select/table off element-plus (ep-extraction-scss WU4 S5)

### DIFF
--- a/components/select/src/select.styles.scss
+++ b/components/select/src/select.styles.scss
@@ -1,15 +1,15 @@
 @use "sass:map";
 
-@use "element-plus/theme-chalk/src/select-v2.scss" as *;
-@use "element-plus/theme-chalk/src/scrollbar.scss" as *;
-@use "element-plus/theme-chalk/src/virtual-list.scss" as *;
-@use "element-plus/theme-chalk/src/option.scss" as *;
-@use "element-plus/theme-chalk/src/tooltip-v2.scss" as *;
-@use "element-plus/theme-chalk/src/popper.scss" as *;
-@use "element-plus/theme-chalk/src/mixins/mixins" as *;
-@use "element-plus/theme-chalk/src/mixins/utils" as *;
-@use "element-plus/theme-chalk/src/mixins/var" as *;
-@use "element-plus/theme-chalk/src/common/var" as *;
+@use "./styles/select-v2.scss" as *;
+@use "@flash-global66/g-utils/scrollbar" as *;
+@use "@flash-global66/g-utils/virtual-list" as *;
+@use "@flash-global66/g-utils/option" as *;
+@use "@flash-global66/g-utils/tooltip-v2" as *;
+@use "@flash-global66/g-utils/popper" as *;
+@use "@flash-global66/g-utils/mixins" as *;
+@use "@flash-global66/g-utils/utils" as *;
+@use "@flash-global66/g-utils/var-mixins" as *;
+@use "@flash-global66/g-utils/tokens" as *;
 
 .selectContainer {
   @apply flex flex-col gap-xxs;

--- a/components/select/src/styles/option-group.scss
+++ b/components/select/src/styles/option-group.scss
@@ -1,0 +1,33 @@
+@use 'sass:map';
+
+@use '@flash-global66/g-utils/mixins' as *;
+@use '@flash-global66/g-utils/tokens' as *;
+
+@include b(select-group) {
+  $gap: 20px;
+
+  margin: 0;
+  padding: 0;
+
+  @include e(wrap) {
+    position: relative;
+    list-style: none;
+    margin: 0;
+    padding: 0;
+  }
+
+  @include e(title) {
+    box-sizing: border-box;
+    padding: 0 $gap;
+    font-size: map.get($select-group, 'font-size');
+    color: map.get($select-group, 'text-color');
+    line-height: map.get($select-group, 'height');
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  & .#{$namespace}-select-dropdown__item {
+    padding-left: $gap;
+  }
+}

--- a/components/select/src/styles/select-dropdown-v2.scss
+++ b/components/select/src/styles/select-dropdown-v2.scss
@@ -1,0 +1,1 @@
+@use './select-dropdown.scss';

--- a/components/select/src/styles/select-dropdown.scss
+++ b/components/select/src/styles/select-dropdown.scss
@@ -1,0 +1,57 @@
+@use 'sass:map';
+
+@use '@flash-global66/g-utils/mixins' as *;
+@use '@flash-global66/g-utils/tokens' as *;
+
+@include b(select-dropdown) {
+  z-index: calc(#{getCssVar('index-top')} + 1);
+  border-radius: getCssVar('border-radius-base');
+  box-sizing: border-box;
+
+  .#{$namespace}-scrollbar.is-empty .#{$namespace}-select-dropdown__list {
+    padding: 0;
+  }
+}
+
+@include b(select-dropdown__loading) {
+  padding: map.get($select-dropdown, 'empty-padding');
+  margin: 0;
+  text-align: center;
+  color: map.get($select-dropdown, 'empty-color');
+  font-size: getCssVar('select-font-size');
+}
+
+@include b(select-dropdown__empty) {
+  padding: map.get($select-dropdown, 'empty-padding');
+  margin: 0;
+  text-align: center;
+  color: map.get($select-dropdown, 'empty-color');
+  font-size: getCssVar('select-font-size');
+}
+
+@include b(select-dropdown__wrap) {
+  max-height: map.get($select-dropdown, 'max-height');
+}
+
+@include b(select-dropdown__list) {
+  list-style: none;
+  padding: map.get($select-dropdown, 'padding');
+  margin: 0;
+  box-sizing: border-box;
+
+  &.#{$namespace}-vl__window {
+    // for select-v2
+    margin: map.get($select-dropdown, 'padding');
+    padding: 0;
+  }
+}
+
+@include b(select-dropdown__header) {
+  padding: map.get($select-dropdown, 'header-padding');
+  border-bottom: map.get($select-dropdown, 'border');
+}
+
+@include b(select-dropdown__footer) {
+  padding: map.get($select-dropdown, 'footer-padding');
+  border-top: map.get($select-dropdown, 'border');
+}

--- a/components/select/src/styles/select-v2.scss
+++ b/components/select/src/styles/select-v2.scss
@@ -1,0 +1,4 @@
+@use './select.scss';
+@use './select-dropdown-v2.scss';
+@use '@flash-global66/g-utils/option';
+@use './option-group.scss';

--- a/components/select/src/styles/select.scss
+++ b/components/select/src/styles/select.scss
@@ -1,0 +1,264 @@
+@use 'sass:map';
+
+@use '@flash-global66/g-utils/mixins' as *;
+@use '@flash-global66/g-utils/utils' as *;
+@use '@flash-global66/g-utils/var-mixins' as *;
+@use '@flash-global66/g-utils/tokens' as *;
+@use './select-dropdown.scss';
+@use '@flash-global66/g-utils/option';
+@use './option-group.scss';
+
+@mixin mixed-input-border($color) {
+  box-shadow: 0 0 0 1px $color inset;
+}
+
+@include b(select) {
+  @include set-component-css-var('select', $select);
+}
+
+@include b(select) {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  width: getCssVar('select-width');
+
+  @include e(wrapper) {
+    display: flex;
+    align-items: center;
+    position: relative;
+    box-sizing: border-box;
+    cursor: pointer;
+    text-align: left;
+    font-size: map.get($input-font-size, 'default');
+    padding: map.get($select-wrapper-padding, 'default');
+    gap: map.get($select-item-gap, 'default');
+    min-height: map.get($input-height, 'default');
+    line-height: map.get($select-item-height, 'default');
+    border-radius: getCssVar('border-radius-base');
+    background-color: getCssVar('fill-color', 'blank');
+    transition: getCssVar('transition', 'duration');
+    transform: translate3d(0, 0, 0);
+    @include mixed-input-border(#{getCssVar('border-color')});
+
+    @include when(filterable) {
+      cursor: text;
+    }
+
+    @include when(focused) {
+      @include mixed-input-border(#{getCssVar('color-primary')});
+    }
+
+    @include when(hovering) {
+      &:not(.is-focused) {
+        @include mixed-input-border(#{getCssVar('border-color-hover')});
+      }
+    }
+
+    @include when(disabled) {
+      cursor: not-allowed;
+      pointer-events: none;
+
+      background-color: getCssVar('fill-color', 'light');
+      color: getCssVar('text-color', 'placeholder');
+      @include mixed-input-border(#{getCssVar('select-disabled-border')});
+
+      &:hover {
+        @include mixed-input-border(#{getCssVar('select-disabled-border')});
+      }
+
+      &.is-focus {
+        @include mixed-input-border(#{getCssVar('input-focus-border-color')});
+      }
+
+      @include e(selected-item) {
+        color: getCssVar('select-disabled-color');
+      }
+
+      @include e(caret) {
+        cursor: not-allowed;
+      }
+
+      .#{$namespace}-tag {
+        cursor: not-allowed;
+      }
+    }
+  }
+
+  @include e(prefix) {
+    display: flex;
+    align-items: center;
+    flex-shrink: 0;
+    gap: map.get($select-item-gap, 'default');
+    color: var(
+      #{getCssVarName('input-icon-color')},
+      map.get($input, 'icon-color')
+    );
+  }
+
+  @include e(suffix) {
+    display: flex;
+    align-items: center;
+    flex-shrink: 0;
+    gap: map.get($select-item-gap, 'default');
+    color: var(
+      #{getCssVarName('input-icon-color')},
+      map.get($input, 'icon-color')
+    );
+  }
+
+  @include e(caret) {
+    color: getCssVar('select-input-color');
+    font-size: getCssVar('select-input-font-size');
+    transition: getCssVar('transition', 'duration');
+    transform: rotateZ(0deg);
+    cursor: pointer;
+
+    @include when(reverse) {
+      transform: rotateZ(180deg);
+    }
+  }
+
+  @include e(clear) {
+    cursor: pointer;
+
+    &:hover {
+      color: getCssVar('select-close-hover-color');
+    }
+  }
+
+  @include e(selection) {
+    position: relative;
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    flex: 1;
+    min-width: 0;
+    gap: map.get($select-item-gap, 'default');
+
+    @include when(near) {
+      margin-left: map.get($select-near-margin-left, 'default');
+    }
+
+    .#{$namespace}-tag {
+      cursor: pointer;
+      border-color: transparent;
+
+      &.#{$namespace}-tag--plain {
+        border-color: getCssVar('tag', 'border-color');
+      }
+
+      .#{$namespace}-tag__content {
+        min-width: 0;
+      }
+    }
+  }
+
+  @include e(selected-item) {
+    display: flex;
+    flex-wrap: wrap;
+    user-select: none;
+  }
+
+  @include e(tags-text) {
+    display: block;
+    line-height: normal;
+    @include utils-ellipsis;
+  }
+
+  @include e(placeholder) {
+    position: absolute;
+    z-index: -1;
+    display: block;
+    top: 50%;
+    transform: translateY(-50%);
+    width: 100%;
+    @include utils-ellipsis;
+    color: var(
+      #{getCssVarName('input-text-color')},
+      map.get($input, 'text-color')
+    );
+
+    @include when(transparent) {
+      user-select: none;
+      color: getCssVar('text-color', 'placeholder');
+    }
+  }
+
+  @include e(popper) {
+    @include picker-popper(
+      map.get($select-dropdown, 'bg-color'),
+      map.get($select-dropdown, 'border'),
+      map.get($select-dropdown, 'shadow')
+    );
+  }
+
+  @include e(input-wrapper) {
+    flex: 1;
+
+    @include when(hidden) {
+      // Out of the document flow
+      position: absolute;
+      opacity: 0;
+      z-index: -1;
+    }
+  }
+
+  @include e(input) {
+    border: none;
+    outline: none;
+    padding: 0;
+    color: getCssVar('select-multiple-input-color');
+    font-size: inherit;
+    font-family: inherit;
+    appearance: none;
+    height: map.get($select-item-height, 'default');
+    width: 100%;
+    background-color: transparent;
+
+    @include when(disabled) {
+      cursor: not-allowed;
+    }
+  }
+
+  @include e(input-calculator) {
+    position: absolute;
+    left: 0;
+    top: 0;
+    max-width: 100%;
+    visibility: hidden;
+    white-space: pre;
+    overflow: hidden;
+  }
+
+  @each $size in (large, small) {
+    @include m($size) {
+      @include e(wrapper) {
+        gap: map.get($select-item-gap, $size);
+        padding: map.get($select-wrapper-padding, $size);
+        min-height: map.get($input-height, $size);
+        line-height: map.get($select-item-height, $size);
+        font-size: map.get($input-font-size, $size);
+      }
+
+      @include e(selection) {
+        gap: map.get($select-item-gap, $size);
+
+        @include when(near) {
+          margin-left: map.get($select-near-margin-left, $size);
+        }
+      }
+
+      @include e(prefix) {
+        gap: map.get($select-item-gap, $size);
+      }
+
+      @include e(suffix) {
+        gap: map.get($select-item-gap, $size);
+      }
+
+      @include e(input) {
+        height: map.get($select-item-height, $size);
+      }
+    }
+  }
+}

--- a/components/table/src/styles/table-column.scss
+++ b/components/table/src/styles/table-column.scss
@@ -1,0 +1,98 @@
+@use 'sass:map';
+
+@use '@flash-global66/g-utils/mixins' as *;
+@use '@flash-global66/g-utils/tokens' as *;
+
+@include b(table-column) {
+  @include m(selection) {
+    .cell {
+      padding-left: 14px;
+      padding-right: 14px;
+    }
+  }
+}
+
+@include b(table-filter) {
+  border: solid 1px getCssVar('border-color-lighter');
+  border-radius: 2px;
+  background-color: $color-white;
+  box-shadow: map.get($dropdown, 'menu-box-shadow');
+  box-sizing: border-box;
+
+  /** used for dropdown mode */
+  @include e(list) {
+    padding: 5px 0;
+    margin: 0;
+    list-style: none;
+    min-width: 100px;
+  }
+
+  @include e(list-item) {
+    line-height: 36px;
+    padding: 0 10px;
+    cursor: pointer;
+    font-size: getCssVar('font-size', 'base');
+
+    &:hover {
+      background-color: map.get($dropdown, 'menuItem-hover-fill');
+      color: map.get($dropdown, 'menuItem-hover-color');
+    }
+
+    @include when(active) {
+      background-color: getCssVar('color-primary');
+      color: $color-white;
+    }
+  }
+
+  @include e(content) {
+    min-width: 100px;
+  }
+
+  @include e(bottom) {
+    border-top: 1px solid getCssVar('border-color-lighter');
+    padding: 8px;
+
+    button {
+      background: transparent;
+      border: none;
+      color: getCssVar('text-color', 'regular');
+      cursor: pointer;
+      font-size: getCssVar('font-size-small');
+      padding: 0 3px;
+
+      &:hover {
+        color: getCssVar('color-primary');
+      }
+
+      &:focus {
+        outline: none;
+      }
+
+      &.is-disabled {
+        color: getCssVar('disabled-text-color');
+        cursor: not-allowed;
+      }
+    }
+  }
+
+  @include e(wrap) {
+    max-height: 280px;
+  }
+
+  @include e(checkbox-group) {
+    padding: 10px;
+
+    label.#{$namespace}-checkbox {
+      display: flex;
+      align-items: center;
+      margin-right: 5px;
+      margin-bottom: 12px;
+      margin-left: 5px;
+      height: unset;
+    }
+
+    .#{$namespace}-checkbox:last-child {
+      margin-bottom: 0;
+    }
+  }
+}

--- a/components/table/src/styles/table.scss
+++ b/components/table/src/styles/table.scss
@@ -1,0 +1,694 @@
+@use 'sass:map';
+
+@use '@flash-global66/g-utils/mixins' as *;
+@use '@flash-global66/g-utils/var-mixins' as *;
+@use '@flash-global66/g-utils/tokens' as *;
+
+@include b(table) {
+  @include set-component-css-var('table', $table);
+}
+
+@include b(table) {
+  position: relative;
+  overflow: hidden;
+  box-sizing: border-box;
+  height: fit-content;
+  width: 100%;
+  max-width: 100%;
+  background-color: getCssVar('table-bg-color');
+  font-size: getCssVar('font-size', 'base');
+  color: getCssVar('table-text-color');
+
+  @include e(inner-wrapper) {
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+
+    // 表格底部伪 border，总是有的
+    &::before {
+      @include extend-rule(border-pseudo);
+      left: 0;
+      bottom: 0;
+      height: 1px;
+    }
+  }
+
+  tbody {
+    &:focus-visible {
+      outline: none;
+    }
+  }
+
+  &.has-footer {
+    &.#{$namespace}-table--scrollable-y,
+    &.#{$namespace}-table--fluid-height {
+      tr:last-child td.#{$namespace}-table__cell {
+        border-bottom-color: transparent;
+      }
+    }
+  }
+
+  // when data is empty
+  @include e(empty-block) {
+    position: sticky;
+    left: 0;
+    min-height: 60px;
+    text-align: center;
+    width: 100%;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+  }
+
+  @include e(empty-text) {
+    // min-height doesn't work in IE10 and IE11 https://github.com/philipwalton/flexbugs#3-min-height-on-a-flex-container-wont-apply-to-its-flex-items
+    // set empty text line height up to contrainer min-height as workaround.
+    line-height: 60px;
+    width: 50%;
+    color: getCssVar('text-color', 'secondary');
+  }
+
+  // expand the row
+  @include e(expand-column) {
+    .cell {
+      padding: 0;
+      text-align: center;
+      user-select: none;
+    }
+  }
+
+  @include e(expand-icon) {
+    position: relative;
+    cursor: pointer;
+    color: getCssVar('text-color', 'regular');
+    font-size: 12px;
+    transition: transform getCssVar('transition-duration-fast') ease-in-out;
+    height: 20px;
+
+    @include m(expanded) {
+      transform: rotate(90deg);
+    }
+
+    > .#{$namespace}-icon {
+      font-size: 12px;
+    }
+  }
+
+  @include e(expanded-cell) {
+    background-color: getCssVar('table-expanded-cell-bg-color');
+
+    // increase the weight purely
+    &[class*='cell'] {
+      padding: 20px 50px;
+    }
+
+    &:hover {
+      background-color: transparent !important;
+    }
+  }
+
+  @include e(placeholder) {
+    display: inline-block;
+    width: 20px;
+  }
+
+  @include e(append-wrapper) {
+    // avoid overlapping margin https://developer.mozilla.org/zh-CN/docs/Web/CSS/CSS_Box_Model/Mastering_margin_collapsing
+    overflow: hidden;
+  }
+
+  @include m(fit) {
+    border-right: 0;
+    border-bottom: 0;
+
+    .#{$namespace}-table__cell.gutter {
+      border-right-width: 1px;
+    }
+
+    @include e(inner-wrapper) {
+      &::before {
+        width: 100%;
+      }
+    }
+  }
+
+  thead {
+    color: getCssVar('table-header-text-color');
+
+    th {
+      font-weight: 600;
+    }
+
+    &.is-group {
+      th.#{$namespace}-table__cell {
+        background: getCssVar('fill-color', 'light');
+      }
+    }
+  }
+
+  .#{$namespace}-table__cell {
+    padding: map.get($table-padding, 'default');
+    min-width: 0;
+    box-sizing: border-box;
+    text-overflow: ellipsis;
+    vertical-align: middle;
+    position: relative;
+    text-align: left;
+    z-index: getCssVar('table-index');
+
+    @include when(center) {
+      text-align: center;
+    }
+
+    @include when(right) {
+      text-align: right;
+    }
+
+    &.gutter {
+      width: 15px;
+      border-right-width: 0;
+      border-bottom-width: 0;
+      padding: 0;
+    }
+
+    &.is-hidden {
+      > * {
+        visibility: hidden;
+      }
+    }
+  }
+
+  .cell {
+    box-sizing: border-box;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: normal;
+    overflow-wrap: break-word;
+    line-height: 23px;
+    padding: 0 12px;
+
+    &.#{$namespace}-tooltip {
+      white-space: nowrap;
+      min-width: 50px;
+    }
+  }
+
+  @each $size in (large, default, small) {
+    @include m($size) {
+      font-size: map.get($table-font-size, $size);
+
+      .#{$namespace}-table__cell {
+        padding: map.get($table-padding, $size);
+      }
+
+      .cell {
+        padding: map.get($table-cell-padding, $size);
+      }
+    }
+  }
+
+  tr {
+    background-color: getCssVar('table-tr-bg-color');
+
+    input[type='checkbox'] {
+      margin: 0;
+    }
+  }
+
+  th.#{$namespace}-table__cell.is-leaf,
+  td.#{$namespace}-table__cell {
+    border-bottom: getCssVar('table-border');
+  }
+
+  th.#{$namespace}-table__cell.is-sortable {
+    cursor: pointer;
+  }
+
+  th.#{$namespace}-table__cell {
+    background-color: getCssVar('table-header-bg-color');
+
+    > .cell.highlight {
+      color: getCssVar('color-primary');
+    }
+
+    &.required > div::before {
+      display: inline-block;
+      content: '';
+      width: 8px;
+      height: 8px;
+      border-radius: 50%;
+      background: #ff4d51;
+      margin-right: 5px;
+      vertical-align: middle;
+    }
+  }
+
+  td.#{$namespace}-table__cell {
+    div {
+      box-sizing: border-box;
+    }
+
+    &.gutter {
+      width: 0;
+    }
+  }
+
+  // 拥有多级表头
+  @include m((group, border)) {
+    @include share-rule(border-pseudo) {
+      content: '';
+      position: absolute;
+      background-color: getCssVar('table-border-color');
+      z-index: calc(getCssVar('table-index') + 2);
+    }
+  }
+
+  // table--border
+  @include m(border) {
+    @include e(inner-wrapper) {
+      &::after {
+        @include extend-rule(border-pseudo);
+        left: 0;
+        top: 0;
+        width: 100%;
+        height: 1px;
+        z-index: calc(getCssVar('table-index') + 2);
+      }
+    }
+
+    &::before {
+      @include extend-rule(border-pseudo);
+      top: -1px;
+      left: 0;
+      width: 1px;
+      height: 100%;
+    }
+
+    &::after {
+      @include extend-rule(border-pseudo);
+      top: -1px;
+      right: 0;
+      width: 1px;
+      height: 100%;
+    }
+
+    @include e(inner-wrapper) {
+      border-right: none;
+      border-bottom: none;
+    }
+
+    @include e(footer-wrapper) {
+      position: relative;
+      flex-shrink: 0;
+    }
+
+    .#{$namespace}-table__cell {
+      border-right: getCssVar('table-border');
+    }
+
+    th.#{$namespace}-table__cell.gutter:last-of-type {
+      border-bottom: getCssVar('table-border');
+      border-bottom-width: 1px;
+    }
+
+    & th.#{$namespace}-table__cell {
+      border-bottom: getCssVar('table-border');
+    }
+  }
+
+  @include m(hidden) {
+    visibility: hidden;
+  }
+
+  @include e((header-wrapper, body-wrapper, footer-wrapper)) {
+    width: 100%;
+
+    tr {
+      td,
+      th {
+        &.#{$namespace}-table-fixed-column--left,
+        &.#{$namespace}-table-fixed-column--right {
+          position: sticky !important;
+          background: inherit;
+          z-index: calc(getCssVar('table-index') + 1);
+
+          &.is-last-column,
+          &.is-first-column {
+            &::before {
+              content: '';
+              position: absolute;
+              top: 0px;
+              width: 10px;
+              bottom: -1px;
+              overflow-x: hidden;
+              overflow-y: hidden;
+              box-shadow: none;
+              touch-action: none;
+              pointer-events: none;
+            }
+          }
+
+          &.is-first-column {
+            &::before {
+              left: -10px;
+            }
+          }
+
+          &.is-last-column {
+            &::before {
+              right: -10px;
+              box-shadow: none;
+            }
+          }
+        }
+
+        &.#{$namespace}-table__fixed-right-patch {
+          position: sticky !important;
+          z-index: calc(getCssVar('table-index') + 1);
+          background: #fff;
+          right: 0;
+        }
+      }
+    }
+  }
+
+  @include e(header-wrapper) {
+    flex-shrink: 0;
+
+    tr {
+      th {
+        &.#{$namespace}-table-fixed-column--left,
+        &.#{$namespace}-table-fixed-column--right {
+          background-color: getCssVar('table-header-bg-color');
+        }
+      }
+    }
+  }
+
+  @include e((header, body, footer)) {
+    table-layout: fixed;
+    border-collapse: separate;
+  }
+
+  @include e((header-wrapper)) {
+    overflow: hidden;
+
+    & tbody td.#{$namespace}-table__cell {
+      background-color: getCssVar('table-row-hover-bg-color');
+      color: getCssVar('table-text-color');
+    }
+  }
+
+  @include e((footer-wrapper)) {
+    overflow: hidden;
+    flex-shrink: 0;
+
+    tfoot td.#{$namespace}-table__cell {
+      background-color: getCssVar('table-row-hover-bg-color');
+      color: getCssVar('table-text-color');
+    }
+  }
+
+  @include e((header-wrapper, body-wrapper)) {
+    .#{$namespace}-table-column--selection {
+      > .cell {
+        display: inline-flex;
+        align-items: center;
+        height: 23px;
+      }
+
+      .#{$namespace}-checkbox {
+        height: unset;
+      }
+    }
+  }
+
+  @include when(scrolling-left) {
+    .#{$namespace}-table-fixed-column--right.is-first-column {
+      &::before {
+        box-shadow: getCssVar('table-fixed-right-column');
+      }
+    }
+
+    &.#{$namespace}-table--border {
+      .#{$namespace}-table-fixed-column--left {
+        &.is-last-column {
+          &.#{$namespace}-table__cell {
+            border-right: getCssVar('table-border');
+          }
+        }
+      }
+    }
+
+    th.#{$namespace}-table-fixed-column--left {
+      background-color: getCssVar('table-header-bg-color');
+    }
+  }
+
+  @include when(scrolling-right) {
+    .#{$namespace}-table-fixed-column--left.is-last-column {
+      &::before {
+        box-shadow: getCssVar('table-fixed-left-column');
+      }
+    }
+
+    .#{$namespace}-table-fixed-column--left.is-last-column.#{$namespace}-table__cell {
+      border-right: none;
+    }
+
+    th.#{$namespace}-table-fixed-column--right {
+      background-color: getCssVar('table-header-bg-color');
+    }
+  }
+
+  @include when(scrolling-middle) {
+    .#{$namespace}-table-fixed-column--left.is-last-column.#{$namespace}-table__cell {
+      border-right: none;
+    }
+
+    .#{$namespace}-table-fixed-column--right.is-first-column {
+      &::before {
+        box-shadow: getCssVar('table-fixed-right-column');
+      }
+    }
+
+    .#{$namespace}-table-fixed-column--left.is-last-column {
+      &::before {
+        box-shadow: getCssVar('table-fixed-left-column');
+      }
+    }
+  }
+
+  @include when(scrolling-none) {
+    .#{$namespace}-table-fixed-column--left,
+    .#{$namespace}-table-fixed-column--right {
+      &.is-first-column,
+      &.is-last-column {
+        &::before {
+          box-shadow: none;
+        }
+      }
+    }
+
+    th.#{$namespace}-table-fixed-column--left,
+    th.#{$namespace}-table-fixed-column--right {
+      background-color: getCssVar('table-header-bg-color');
+    }
+  }
+
+  @include e(body-wrapper) {
+    overflow: hidden;
+    position: relative;
+    flex: 1;
+
+    .#{$namespace}-scrollbar__bar {
+      z-index: calc(getCssVar('table-index') + 2);
+    }
+  }
+
+  .caret-wrapper {
+    display: inline-flex;
+    flex-direction: column;
+    align-items: center;
+    height: 14px;
+    width: 24px;
+    vertical-align: middle;
+    cursor: pointer;
+    overflow: initial;
+    position: relative;
+  }
+
+  .sort-caret {
+    width: 0;
+    height: 0;
+    border: solid 5px transparent;
+    position: absolute;
+    left: 7px;
+
+    &.ascending {
+      border-bottom-color: getCssVar('text-color', 'placeholder');
+      top: -5px;
+    }
+
+    &.descending {
+      border-top-color: getCssVar('text-color', 'placeholder');
+      bottom: -3px;
+    }
+  }
+
+  .ascending .sort-caret.ascending {
+    border-bottom-color: getCssVar('color-primary');
+  }
+
+  .descending .sort-caret.descending {
+    border-top-color: getCssVar('color-primary');
+  }
+
+  .hidden-columns {
+    visibility: hidden;
+    position: absolute;
+    z-index: -1;
+  }
+
+  @include m(striped) {
+    & .#{$namespace}-table__body {
+      & tr.#{$namespace}-table__row--striped {
+        td.#{$namespace}-table__cell {
+          background: getCssVar('fill-color', 'lighter');
+        }
+
+        &.current-row td.#{$namespace}-table__cell {
+          background-color: getCssVar('table-current-row-bg-color');
+        }
+      }
+    }
+  }
+
+  @include e(body) {
+    tr.hover-row {
+      &,
+      &.#{$namespace}-table__row--striped {
+        &,
+        &.current-row {
+          > td.#{$namespace}-table__cell {
+            background-color: getCssVar('table-row-hover-bg-color');
+          }
+        }
+      }
+    }
+
+    tr > td.hover-cell {
+      background-color: getCssVar('table-row-hover-bg-color');
+    }
+
+    tr.current-row > td.#{$namespace}-table__cell {
+      background-color: getCssVar('table-current-row-bg-color');
+    }
+  }
+
+  &.#{$namespace}-table--scrollable-y {
+    @include e(body-header) {
+      position: sticky;
+      top: 0;
+      z-index: calc(getCssVar('table-index') + 2);
+    }
+
+    @include e(body-footer) {
+      position: sticky;
+      bottom: 0;
+      z-index: calc(getCssVar('table-index') + 2);
+    }
+  }
+
+  @include e(column-resize-proxy) {
+    position: absolute;
+    left: 200px;
+    top: 0;
+    bottom: 0;
+    width: 0;
+    border-left: getCssVar('table-border');
+    z-index: calc(getCssVar('table-index') + 9);
+  }
+
+  @include e(column-filter-trigger) {
+    display: inline-block;
+    cursor: pointer;
+
+    & i {
+      color: getCssVar('color-info');
+      font-size: 14px;
+      vertical-align: middle;
+    }
+  }
+
+  @include e(border-left-patch) {
+    top: 0;
+    left: 0;
+    width: 1px;
+    height: 100%;
+    z-index: calc(getCssVar('table-index') + 2);
+    position: absolute;
+    background-color: getCssVar('table-border-color');
+  }
+
+  @include e(border-bottom-patch) {
+    left: 0;
+    height: 1px;
+    z-index: calc(getCssVar('table-index') + 2);
+    position: absolute;
+    background-color: getCssVar('table-border-color');
+  }
+
+  @include e(border-right-patch) {
+    top: 0;
+    height: 100%;
+    width: 1px;
+    z-index: calc(getCssVar('table-index') + 2);
+    position: absolute;
+    background-color: getCssVar('table-border-color');
+  }
+
+  @include m(enable-row-transition) {
+    .#{$namespace}-table__body td.#{$namespace}-table__cell {
+      transition: background-color 0.25s ease;
+    }
+  }
+
+  @include m(enable-row-hover) {
+    .#{$namespace}-table__body tr:hover > td.#{$namespace}-table__cell {
+      background-color: getCssVar('table-row-hover-bg-color');
+    }
+  }
+
+  [class*='#{$namespace}-table__row--level'] {
+    .#{$namespace}-table__expand-icon {
+      display: inline-block;
+      width: 12px;
+      line-height: 12px;
+      height: 12px;
+      text-align: center;
+      margin-right: 8px;
+    }
+  }
+
+  @include b(table) {
+    &.#{$namespace}-table--border {
+      .#{$namespace}-table__cell {
+        border-right: getCssVar('table-border');
+      }
+    }
+  }
+
+  &:not(.#{$namespace}-table--border) {
+    .#{$namespace}-table__cell {
+      border-right: none;
+    }
+
+    > .#{$namespace}-table__inner-wrapper {
+      &::after {
+        content: none;
+      }
+    }
+  }
+}

--- a/components/table/src/table.styles.scss
+++ b/components/table/src/table.styles.scss
@@ -1,14 +1,14 @@
 @use 'sass:map';
 
-@use 'element-plus/theme-chalk/src/table.scss' as *;
-@use 'element-plus/theme-chalk/src/table-column.scss' as *;
-@use 'element-plus/theme-chalk/src/tooltip-v2.scss' as *;
-@use 'element-plus/theme-chalk/src/popper.scss' as *;
-@use 'element-plus/theme-chalk/src/checkbox.scss' as *;
-@use 'element-plus/theme-chalk/src/mixins/mixins' as *;
-@use 'element-plus/theme-chalk/src/mixins/utils' as *;
-@use 'element-plus/theme-chalk/src/mixins/var' as *;
-@use 'element-plus/theme-chalk/src/common/var' as *;
+@use './styles/table.scss' as *;
+@use './styles/table-column.scss' as *;
+@use '@flash-global66/g-utils/tooltip-v2' as *;
+@use '@flash-global66/g-utils/popper' as *;
+@use '@flash-global66/g-checkbox/src/styles/checkbox.scss' as *;
+@use '@flash-global66/g-utils/mixins' as *;
+@use '@flash-global66/g-utils/utils' as *;
+@use '@flash-global66/g-utils/var-mixins' as *;
+@use '@flash-global66/g-utils/tokens' as *;
 
 @include b('table') {
   tbody {

--- a/scripts/scss-parity/baseline/select-v2-theme.css
+++ b/scripts/scss-parity/baseline/select-v2-theme.css
@@ -1,0 +1,403 @@
+/* Element Chalk Variables */
+.gui-select-dropdown {
+  z-index: calc(var(--gui-index-top) + 1);
+  border-radius: var(--gui-border-radius-base);
+  box-sizing: border-box;
+}
+.gui-select-dropdown .gui-scrollbar.is-empty .gui-select-dropdown__list {
+  padding: 0;
+}
+
+.gui-select-dropdown__loading {
+  padding: 10px 0;
+  margin: 0;
+  text-align: center;
+  color: var(--gui-text-color-secondary);
+  font-size: var(--gui-select-font-size);
+}
+
+.gui-select-dropdown__empty {
+  padding: 10px 0;
+  margin: 0;
+  text-align: center;
+  color: var(--gui-text-color-secondary);
+  font-size: var(--gui-select-font-size);
+}
+
+.gui-select-dropdown__wrap {
+  max-height: 274px;
+}
+
+.gui-select-dropdown__list {
+  list-style: none;
+  padding: 6px 0;
+  margin: 0;
+  box-sizing: border-box;
+}
+.gui-select-dropdown__list.gui-vl__window {
+  margin: 6px 0;
+  padding: 0;
+}
+
+.gui-select-dropdown__header {
+  padding: 10px;
+  border-bottom: 1px solid var(--gui-border-color-light);
+}
+
+.gui-select-dropdown__footer {
+  padding: 10px;
+  border-top: 1px solid var(--gui-border-color-light);
+}
+
+.gui-select-dropdown__item {
+  font-size: var(--gui-font-size-base);
+  padding: 0 32px 0 20px;
+  position: relative;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  color: var(--gui-text-color-regular);
+  height: 34px;
+  line-height: 34px;
+  box-sizing: border-box;
+  cursor: pointer;
+}
+.gui-select-dropdown__item.is-hovering {
+  background-color: var(--gui-fill-color-light);
+}
+
+.gui-select-dropdown__item.is-selected {
+  color: var(--gui-color-primary);
+  font-weight: bold;
+}
+
+.gui-select-dropdown__item.is-disabled {
+  color: var(--gui-text-color-placeholder);
+  cursor: not-allowed;
+  background-color: unset;
+}
+
+.gui-select-dropdown.is-multiple .gui-select-dropdown__item.is-selected::after {
+  content: "";
+  position: absolute;
+  top: 50%;
+  right: 20px;
+  border-top: none;
+  border-right: none;
+  background-repeat: no-repeat;
+  background-position: center;
+  background-color: var(--gui-color-primary);
+  mask: url("data:image/svg+xml;utf8,%3Csvg class='icon' width='200' height='200' viewBox='0 0 1024 1024' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath fill='currentColor' d='M406.656 706.944L195.84 496.256a32 32 0 10-45.248 45.248l256 256 512-512a32 32 0 00-45.248-45.248L406.592 706.944z'%3E%3C/path%3E%3C/svg%3E") no-repeat;
+  mask-size: 100% 100%;
+  -webkit-mask: url("data:image/svg+xml;utf8,%3Csvg class='icon' width='200' height='200' viewBox='0 0 1024 1024' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath fill='currentColor' d='M406.656 706.944L195.84 496.256a32 32 0 10-45.248 45.248l256 256 512-512a32 32 0 00-45.248-45.248L406.592 706.944z'%3E%3C/path%3E%3C/svg%3E") no-repeat;
+  -webkit-mask-size: 100% 100%;
+  transform: translateY(-50%);
+  width: 12px;
+  height: 12px;
+}
+.gui-select-dropdown.is-multiple .gui-select-dropdown__item.is-disabled::after {
+  background-color: var(--gui-text-color-placeholder);
+}
+
+.gui-select-group {
+  margin: 0;
+  padding: 0;
+}
+.gui-select-group__wrap {
+  position: relative;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.gui-select-group__title {
+  box-sizing: border-box;
+  padding: 0 20px;
+  font-size: 12px;
+  color: var(--gui-color-info);
+  line-height: 34px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.gui-select-group .gui-select-dropdown__item {
+  padding-left: 20px;
+}
+
+.gui-select {
+  --gui-select-border-color-hover: var(--gui-border-color-hover);
+  --gui-select-disabled-color: var(--gui-disabled-text-color);
+  --gui-select-disabled-border: var(--gui-disabled-border-color);
+  --gui-select-font-size: var(--gui-font-size-base);
+  --gui-select-close-hover-color: var(--gui-text-color-secondary);
+  --gui-select-input-color: var(--gui-text-color-placeholder);
+  --gui-select-multiple-input-color: var(--gui-text-color-regular);
+  --gui-select-input-focus-border-color: var(--gui-color-primary);
+  --gui-select-input-font-size: 14px;
+  --gui-select-width: 100%;
+}
+
+.gui-select {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  width: var(--gui-select-width);
+}
+.gui-select__wrapper {
+  display: flex;
+  align-items: center;
+  position: relative;
+  box-sizing: border-box;
+  cursor: pointer;
+  text-align: left;
+  font-size: 14px;
+  padding: 4px 12px;
+  gap: 6px;
+  min-height: 32px;
+  line-height: 24px;
+  border-radius: var(--gui-border-radius-base);
+  background-color: var(--gui-fill-color-blank);
+  transition: var(--gui-transition-duration);
+  transform: translate3d(0, 0, 0);
+  box-shadow: 0 0 0 1px var(--gui-border-color) inset;
+}
+.gui-select__wrapper.is-filterable {
+  cursor: text;
+}
+
+.gui-select__wrapper.is-focused {
+  box-shadow: 0 0 0 1px var(--gui-color-primary) inset;
+}
+
+.gui-select__wrapper.is-hovering:not(.is-focused) {
+  box-shadow: 0 0 0 1px var(--gui-border-color-hover) inset;
+}
+
+.gui-select__wrapper.is-disabled {
+  cursor: not-allowed;
+  pointer-events: none;
+  background-color: var(--gui-fill-color-light);
+  color: var(--gui-text-color-placeholder);
+  box-shadow: 0 0 0 1px var(--gui-select-disabled-border) inset;
+}
+.gui-select__wrapper.is-disabled:hover {
+  box-shadow: 0 0 0 1px var(--gui-select-disabled-border) inset;
+}
+.gui-select__wrapper.is-disabled.is-focus {
+  box-shadow: 0 0 0 1px var(--gui-input-focus-border-color) inset;
+}
+.gui-select__wrapper.is-disabled .gui-select__selected-item {
+  color: var(--gui-select-disabled-color);
+}
+
+.gui-select__wrapper.is-disabled .gui-select__caret {
+  cursor: not-allowed;
+}
+
+.gui-select__wrapper.is-disabled .gui-tag {
+  cursor: not-allowed;
+}
+
+.gui-select__prefix {
+  display: flex;
+  align-items: center;
+  flex-shrink: 0;
+  gap: 6px;
+  color: var(--gui-input-icon-color, var(--gui-text-color-placeholder));
+}
+
+.gui-select__suffix {
+  display: flex;
+  align-items: center;
+  flex-shrink: 0;
+  gap: 6px;
+  color: var(--gui-input-icon-color, var(--gui-text-color-placeholder));
+}
+
+.gui-select__caret {
+  color: var(--gui-select-input-color);
+  font-size: var(--gui-select-input-font-size);
+  transition: var(--gui-transition-duration);
+  transform: rotateZ(0deg);
+  cursor: pointer;
+}
+.gui-select__caret.is-reverse {
+  transform: rotateZ(180deg);
+}
+
+.gui-select__clear {
+  cursor: pointer;
+}
+.gui-select__clear:hover {
+  color: var(--gui-select-close-hover-color);
+}
+
+.gui-select__selection {
+  position: relative;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  flex: 1;
+  min-width: 0;
+  gap: 6px;
+}
+.gui-select__selection.is-near {
+  margin-left: -8px;
+}
+
+.gui-select__selection .gui-tag {
+  cursor: pointer;
+  border-color: transparent;
+}
+.gui-select__selection .gui-tag.gui-tag--plain {
+  border-color: var(--gui-tag-border-color);
+}
+.gui-select__selection .gui-tag .gui-tag__content {
+  min-width: 0;
+}
+
+.gui-select__selected-item {
+  display: flex;
+  flex-wrap: wrap;
+  user-select: none;
+}
+
+.gui-select__tags-text {
+  display: block;
+  line-height: normal;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.gui-select__placeholder {
+  position: absolute;
+  z-index: -1;
+  display: block;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--gui-input-text-color, var(--gui-text-color-regular));
+}
+.gui-select__placeholder.is-transparent {
+  user-select: none;
+  color: var(--gui-text-color-placeholder);
+}
+
+.gui-select__popper.gui-popper {
+  background: var(--gui-bg-color-overlay);
+  border: 1px solid var(--gui-border-color-light);
+  box-shadow: var(--gui-box-shadow-light);
+}
+.gui-select__popper.gui-popper .gui-popper__arrow::before {
+  border: 1px solid var(--gui-border-color-light);
+}
+.gui-select__popper.gui-popper[data-popper-placement^=top] .gui-popper__arrow::before {
+  border-top-color: transparent;
+  border-left-color: transparent;
+}
+.gui-select__popper.gui-popper[data-popper-placement^=bottom] .gui-popper__arrow::before {
+  border-bottom-color: transparent;
+  border-right-color: transparent;
+}
+.gui-select__popper.gui-popper[data-popper-placement^=left] .gui-popper__arrow::before {
+  border-left-color: transparent;
+  border-bottom-color: transparent;
+}
+.gui-select__popper.gui-popper[data-popper-placement^=right] .gui-popper__arrow::before {
+  border-right-color: transparent;
+  border-top-color: transparent;
+}
+
+.gui-select__input-wrapper {
+  flex: 1;
+}
+.gui-select__input-wrapper.is-hidden {
+  position: absolute;
+  opacity: 0;
+  z-index: -1;
+}
+
+.gui-select__input {
+  border: none;
+  outline: none;
+  padding: 0;
+  color: var(--gui-select-multiple-input-color);
+  font-size: inherit;
+  font-family: inherit;
+  appearance: none;
+  height: 24px;
+  width: 100%;
+  background-color: transparent;
+}
+.gui-select__input.is-disabled {
+  cursor: not-allowed;
+}
+
+.gui-select__input-calculator {
+  position: absolute;
+  left: 0;
+  top: 0;
+  max-width: 100%;
+  visibility: hidden;
+  white-space: pre;
+  overflow: hidden;
+}
+
+.gui-select--large .gui-select__wrapper {
+  gap: 6px;
+  padding: 8px 16px;
+  min-height: 40px;
+  line-height: 24px;
+  font-size: 14px;
+}
+
+.gui-select--large .gui-select__selection {
+  gap: 6px;
+}
+.gui-select--large .gui-select__selection.is-near {
+  margin-left: -8px;
+}
+
+.gui-select--large .gui-select__prefix {
+  gap: 6px;
+}
+
+.gui-select--large .gui-select__suffix {
+  gap: 6px;
+}
+
+.gui-select--large .gui-select__input {
+  height: 24px;
+}
+
+.gui-select--small .gui-select__wrapper {
+  gap: 4px;
+  padding: 2px 8px;
+  min-height: 24px;
+  line-height: 20px;
+  font-size: 12px;
+}
+
+.gui-select--small .gui-select__selection {
+  gap: 4px;
+}
+.gui-select--small .gui-select__selection.is-near {
+  margin-left: -6px;
+}
+
+.gui-select--small .gui-select__prefix {
+  gap: 4px;
+}
+
+.gui-select--small .gui-select__suffix {
+  gap: 4px;
+}
+
+.gui-select--small .gui-select__input {
+  height: 20px;
+}

--- a/scripts/scss-parity/baseline/select.css
+++ b/scripts/scss-parity/baseline/select.css
@@ -1,0 +1,983 @@
+/* Element Chalk Variables */
+.gui-select-dropdown {
+  z-index: calc(var(--gui-index-top) + 1);
+  border-radius: var(--gui-border-radius-base);
+  box-sizing: border-box;
+}
+.gui-select-dropdown .gui-scrollbar.is-empty .gui-select-dropdown__list {
+  padding: 0;
+}
+
+.gui-select-dropdown__loading {
+  padding: 10px 0;
+  margin: 0;
+  text-align: center;
+  color: var(--gui-text-color-secondary);
+  font-size: var(--gui-select-font-size);
+}
+
+.gui-select-dropdown__empty {
+  padding: 10px 0;
+  margin: 0;
+  text-align: center;
+  color: var(--gui-text-color-secondary);
+  font-size: var(--gui-select-font-size);
+}
+
+.gui-select-dropdown__wrap {
+  max-height: 274px;
+}
+
+.gui-select-dropdown__list {
+  list-style: none;
+  padding: 6px 0;
+  margin: 0;
+  box-sizing: border-box;
+}
+.gui-select-dropdown__list.gui-vl__window {
+  margin: 6px 0;
+  padding: 0;
+}
+
+.gui-select-dropdown__header {
+  padding: 10px;
+  border-bottom: 1px solid var(--gui-border-color-light);
+}
+
+.gui-select-dropdown__footer {
+  padding: 10px;
+  border-top: 1px solid var(--gui-border-color-light);
+}
+
+.gui-select-dropdown__item {
+  font-size: var(--gui-font-size-base);
+  padding: 0 32px 0 20px;
+  position: relative;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  color: var(--gui-text-color-regular);
+  height: 34px;
+  line-height: 34px;
+  box-sizing: border-box;
+  cursor: pointer;
+}
+.gui-select-dropdown__item.is-hovering {
+  background-color: var(--gui-fill-color-light);
+}
+
+.gui-select-dropdown__item.is-selected {
+  color: var(--gui-color-primary);
+  font-weight: bold;
+}
+
+.gui-select-dropdown__item.is-disabled {
+  color: var(--gui-text-color-placeholder);
+  cursor: not-allowed;
+  background-color: unset;
+}
+
+.gui-select-dropdown.is-multiple .gui-select-dropdown__item.is-selected::after {
+  content: "";
+  position: absolute;
+  top: 50%;
+  right: 20px;
+  border-top: none;
+  border-right: none;
+  background-repeat: no-repeat;
+  background-position: center;
+  background-color: var(--gui-color-primary);
+  mask: url("data:image/svg+xml;utf8,%3Csvg class='icon' width='200' height='200' viewBox='0 0 1024 1024' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath fill='currentColor' d='M406.656 706.944L195.84 496.256a32 32 0 10-45.248 45.248l256 256 512-512a32 32 0 00-45.248-45.248L406.592 706.944z'%3E%3C/path%3E%3C/svg%3E") no-repeat;
+  mask-size: 100% 100%;
+  -webkit-mask: url("data:image/svg+xml;utf8,%3Csvg class='icon' width='200' height='200' viewBox='0 0 1024 1024' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath fill='currentColor' d='M406.656 706.944L195.84 496.256a32 32 0 10-45.248 45.248l256 256 512-512a32 32 0 00-45.248-45.248L406.592 706.944z'%3E%3C/path%3E%3C/svg%3E") no-repeat;
+  -webkit-mask-size: 100% 100%;
+  transform: translateY(-50%);
+  width: 12px;
+  height: 12px;
+}
+.gui-select-dropdown.is-multiple .gui-select-dropdown__item.is-disabled::after {
+  background-color: var(--gui-text-color-placeholder);
+}
+
+.gui-select-group {
+  margin: 0;
+  padding: 0;
+}
+.gui-select-group__wrap {
+  position: relative;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.gui-select-group__title {
+  box-sizing: border-box;
+  padding: 0 20px;
+  font-size: 12px;
+  color: var(--gui-color-info);
+  line-height: 34px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.gui-select-group .gui-select-dropdown__item {
+  padding-left: 20px;
+}
+
+.gui-select {
+  --gui-select-border-color-hover: var(--gui-border-color-hover);
+  --gui-select-disabled-color: var(--gui-disabled-text-color);
+  --gui-select-disabled-border: var(--gui-disabled-border-color);
+  --gui-select-font-size: var(--gui-font-size-base);
+  --gui-select-close-hover-color: var(--gui-text-color-secondary);
+  --gui-select-input-color: var(--gui-text-color-placeholder);
+  --gui-select-multiple-input-color: var(--gui-text-color-regular);
+  --gui-select-input-focus-border-color: var(--gui-color-primary);
+  --gui-select-input-font-size: 14px;
+  --gui-select-width: 100%;
+}
+
+.gui-select {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  width: var(--gui-select-width);
+}
+.gui-select__wrapper {
+  display: flex;
+  align-items: center;
+  position: relative;
+  box-sizing: border-box;
+  cursor: pointer;
+  text-align: left;
+  font-size: 14px;
+  padding: 4px 12px;
+  gap: 6px;
+  min-height: 32px;
+  line-height: 24px;
+  border-radius: var(--gui-border-radius-base);
+  background-color: var(--gui-fill-color-blank);
+  transition: var(--gui-transition-duration);
+  transform: translate3d(0, 0, 0);
+  box-shadow: 0 0 0 1px var(--gui-border-color) inset;
+}
+.gui-select__wrapper.is-filterable {
+  cursor: text;
+}
+
+.gui-select__wrapper.is-focused {
+  box-shadow: 0 0 0 1px var(--gui-color-primary) inset;
+}
+
+.gui-select__wrapper.is-hovering:not(.is-focused) {
+  box-shadow: 0 0 0 1px var(--gui-border-color-hover) inset;
+}
+
+.gui-select__wrapper.is-disabled {
+  cursor: not-allowed;
+  pointer-events: none;
+  background-color: var(--gui-fill-color-light);
+  color: var(--gui-text-color-placeholder);
+  box-shadow: 0 0 0 1px var(--gui-select-disabled-border) inset;
+}
+.gui-select__wrapper.is-disabled:hover {
+  box-shadow: 0 0 0 1px var(--gui-select-disabled-border) inset;
+}
+.gui-select__wrapper.is-disabled.is-focus {
+  box-shadow: 0 0 0 1px var(--gui-input-focus-border-color) inset;
+}
+.gui-select__wrapper.is-disabled .gui-select__selected-item {
+  color: var(--gui-select-disabled-color);
+}
+
+.gui-select__wrapper.is-disabled .gui-select__caret {
+  cursor: not-allowed;
+}
+
+.gui-select__wrapper.is-disabled .gui-tag {
+  cursor: not-allowed;
+}
+
+.gui-select__prefix {
+  display: flex;
+  align-items: center;
+  flex-shrink: 0;
+  gap: 6px;
+  color: var(--gui-input-icon-color, var(--gui-text-color-placeholder));
+}
+
+.gui-select__suffix {
+  display: flex;
+  align-items: center;
+  flex-shrink: 0;
+  gap: 6px;
+  color: var(--gui-input-icon-color, var(--gui-text-color-placeholder));
+}
+
+.gui-select__caret {
+  color: var(--gui-select-input-color);
+  font-size: var(--gui-select-input-font-size);
+  transition: var(--gui-transition-duration);
+  transform: rotateZ(0deg);
+  cursor: pointer;
+}
+.gui-select__caret.is-reverse {
+  transform: rotateZ(180deg);
+}
+
+.gui-select__clear {
+  cursor: pointer;
+}
+.gui-select__clear:hover {
+  color: var(--gui-select-close-hover-color);
+}
+
+.gui-select__selection {
+  position: relative;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  flex: 1;
+  min-width: 0;
+  gap: 6px;
+}
+.gui-select__selection.is-near {
+  margin-left: -8px;
+}
+
+.gui-select__selection .gui-tag {
+  cursor: pointer;
+  border-color: transparent;
+}
+.gui-select__selection .gui-tag.gui-tag--plain {
+  border-color: var(--gui-tag-border-color);
+}
+.gui-select__selection .gui-tag .gui-tag__content {
+  min-width: 0;
+}
+
+.gui-select__selected-item {
+  display: flex;
+  flex-wrap: wrap;
+  user-select: none;
+}
+
+.gui-select__tags-text {
+  display: block;
+  line-height: normal;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.gui-select__placeholder {
+  position: absolute;
+  z-index: -1;
+  display: block;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--gui-input-text-color, var(--gui-text-color-regular));
+}
+.gui-select__placeholder.is-transparent {
+  user-select: none;
+  color: var(--gui-text-color-placeholder);
+}
+
+.gui-select__popper.gui-popper {
+  background: var(--gui-bg-color-overlay);
+  border: 1px solid var(--gui-border-color-light);
+  box-shadow: var(--gui-box-shadow-light);
+}
+.gui-select__popper.gui-popper .gui-popper__arrow::before {
+  border: 1px solid var(--gui-border-color-light);
+}
+.gui-select__popper.gui-popper[data-popper-placement^=top] .gui-popper__arrow::before {
+  border-top-color: transparent;
+  border-left-color: transparent;
+}
+.gui-select__popper.gui-popper[data-popper-placement^=bottom] .gui-popper__arrow::before {
+  border-bottom-color: transparent;
+  border-right-color: transparent;
+}
+.gui-select__popper.gui-popper[data-popper-placement^=left] .gui-popper__arrow::before {
+  border-left-color: transparent;
+  border-bottom-color: transparent;
+}
+.gui-select__popper.gui-popper[data-popper-placement^=right] .gui-popper__arrow::before {
+  border-right-color: transparent;
+  border-top-color: transparent;
+}
+
+.gui-select__input-wrapper {
+  flex: 1;
+}
+.gui-select__input-wrapper.is-hidden {
+  position: absolute;
+  opacity: 0;
+  z-index: -1;
+}
+
+.gui-select__input {
+  border: none;
+  outline: none;
+  padding: 0;
+  color: var(--gui-select-multiple-input-color);
+  font-size: inherit;
+  font-family: inherit;
+  appearance: none;
+  height: 24px;
+  width: 100%;
+  background-color: transparent;
+}
+.gui-select__input.is-disabled {
+  cursor: not-allowed;
+}
+
+.gui-select__input-calculator {
+  position: absolute;
+  left: 0;
+  top: 0;
+  max-width: 100%;
+  visibility: hidden;
+  white-space: pre;
+  overflow: hidden;
+}
+
+.gui-select--large .gui-select__wrapper {
+  gap: 6px;
+  padding: 8px 16px;
+  min-height: 40px;
+  line-height: 24px;
+  font-size: 14px;
+}
+
+.gui-select--large .gui-select__selection {
+  gap: 6px;
+}
+.gui-select--large .gui-select__selection.is-near {
+  margin-left: -8px;
+}
+
+.gui-select--large .gui-select__prefix {
+  gap: 6px;
+}
+
+.gui-select--large .gui-select__suffix {
+  gap: 6px;
+}
+
+.gui-select--large .gui-select__input {
+  height: 24px;
+}
+
+.gui-select--small .gui-select__wrapper {
+  gap: 4px;
+  padding: 2px 8px;
+  min-height: 24px;
+  line-height: 20px;
+  font-size: 12px;
+}
+
+.gui-select--small .gui-select__selection {
+  gap: 4px;
+}
+.gui-select--small .gui-select__selection.is-near {
+  margin-left: -6px;
+}
+
+.gui-select--small .gui-select__prefix {
+  gap: 4px;
+}
+
+.gui-select--small .gui-select__suffix {
+  gap: 4px;
+}
+
+.gui-select--small .gui-select__input {
+  height: 20px;
+}
+
+.gui-scrollbar {
+  --gui-scrollbar-opacity: 0.3;
+  --gui-scrollbar-bg-color: var(--gui-text-color-secondary);
+  --gui-scrollbar-hover-opacity: 0.5;
+  --gui-scrollbar-hover-bg-color: var(--gui-text-color-secondary);
+}
+
+.gui-scrollbar {
+  overflow: hidden;
+  position: relative;
+  height: 100%;
+}
+.gui-scrollbar__wrap {
+  overflow: auto;
+  height: 100%;
+}
+.gui-scrollbar__wrap--hidden-default {
+  scrollbar-width: none;
+}
+.gui-scrollbar__wrap--hidden-default::-webkit-scrollbar {
+  display: none;
+}
+
+.gui-scrollbar__thumb {
+  position: relative;
+  display: block;
+  width: 0;
+  height: 0;
+  cursor: pointer;
+  border-radius: inherit;
+  background-color: var(--gui-scrollbar-bg-color, var(--gui-text-color-secondary));
+  transition: var(--gui-transition-duration) background-color;
+  opacity: var(--gui-scrollbar-opacity, 0.3);
+}
+.gui-scrollbar__thumb:hover {
+  background-color: var(--gui-scrollbar-hover-bg-color, var(--gui-text-color-secondary));
+  opacity: var(--gui-scrollbar-hover-opacity, 0.5);
+}
+
+.gui-scrollbar__bar {
+  position: absolute;
+  right: 2px;
+  bottom: 2px;
+  z-index: 1;
+  border-radius: 4px;
+}
+.gui-scrollbar__bar.is-vertical {
+  width: 6px;
+  top: 2px;
+}
+.gui-scrollbar__bar.is-vertical > div {
+  width: 100%;
+}
+
+.gui-scrollbar__bar.is-horizontal {
+  height: 6px;
+  left: 2px;
+}
+.gui-scrollbar__bar.is-horizontal > div {
+  height: 100%;
+}
+
+.gui-scrollbar-fade-enter-active {
+  transition: opacity 340ms ease-out;
+}
+.gui-scrollbar-fade-leave-active {
+  transition: opacity 120ms ease-out;
+}
+.gui-scrollbar-fade-enter-from, .gui-scrollbar-fade-leave-active {
+  opacity: 0;
+}
+
+.gui-vl__wrapper {
+  position: relative;
+}
+.gui-vl__wrapper:hover .gui-virtual-scrollbar {
+  opacity: 1;
+}
+.gui-vl__wrapper.always-on .gui-virtual-scrollbar {
+  opacity: 1;
+}
+
+.gui-vl__window {
+  scrollbar-width: none;
+}
+.gui-vl__window::-webkit-scrollbar {
+  display: none;
+}
+
+.gui-virtual-scrollbar {
+  opacity: 0;
+  transition: opacity 340ms ease-out;
+}
+.gui-virtual-scrollbar.always-on {
+  opacity: 1;
+}
+
+.gui-vg__wrapper {
+  position: relative;
+}
+
+.gui-tooltip-v2__content {
+  --gui-tooltip-v2-padding: 5px 10px;
+  --gui-tooltip-v2-border-radius: 4px;
+  --gui-tooltip-v2-border-color: var(--gui-border-color);
+  border-radius: var(--gui-tooltip-v2-border-radius);
+  color: var(--gui-color-black);
+  background-color: var(--gui-color-white);
+  padding: var(--gui-tooltip-v2-padding);
+  border: 1px solid var(--gui-border-color);
+}
+.gui-tooltip-v2__arrow {
+  position: absolute;
+  color: var(--gui-color-white);
+  width: var(--gui-tooltip-v2-arrow-width);
+  height: var(--gui-tooltip-v2-arrow-height);
+  pointer-events: none;
+  left: var(--gui-tooltip-v2-arrow-x);
+  top: var(--gui-tooltip-v2-arrow-y);
+}
+.gui-tooltip-v2__arrow::before {
+  content: "";
+  width: 0;
+  height: 0;
+  border: var(--gui-tooltip-v2-arrow-border-width) solid transparent;
+  position: absolute;
+}
+.gui-tooltip-v2__arrow::after {
+  content: "";
+  width: 0;
+  height: 0;
+  border: var(--gui-tooltip-v2-arrow-border-width) solid transparent;
+  position: absolute;
+}
+.gui-tooltip-v2__content[data-side^=top] .gui-tooltip-v2__arrow {
+  bottom: 0;
+}
+.gui-tooltip-v2__content[data-side^=top] .gui-tooltip-v2__arrow::before {
+  border-top-color: var(--gui-color-white);
+  border-top-width: var(--gui-tooltip-v2-arrow-border-width);
+  border-bottom: 0;
+  top: calc(100% - 1px);
+}
+.gui-tooltip-v2__content[data-side^=top] .gui-tooltip-v2__arrow::after {
+  border-top-color: var(--gui-border-color);
+  border-top-width: var(--gui-tooltip-v2-arrow-border-width);
+  border-bottom: 0;
+  top: 100%;
+  z-index: -1;
+}
+.gui-tooltip-v2__content[data-side^=bottom] .gui-tooltip-v2__arrow {
+  top: 0;
+}
+.gui-tooltip-v2__content[data-side^=bottom] .gui-tooltip-v2__arrow::before {
+  border-bottom-color: var(--gui-color-white);
+  border-bottom-width: var(--gui-tooltip-v2-arrow-border-width);
+  border-top: 0;
+  bottom: calc(100% - 1px);
+}
+.gui-tooltip-v2__content[data-side^=bottom] .gui-tooltip-v2__arrow::after {
+  border-bottom-color: var(--gui-border-color);
+  border-bottom-width: var(--gui-tooltip-v2-arrow-border-width);
+  border-top: 0;
+  bottom: 100%;
+  z-index: -1;
+}
+.gui-tooltip-v2__content[data-side^=left] .gui-tooltip-v2__arrow {
+  right: 0;
+}
+.gui-tooltip-v2__content[data-side^=left] .gui-tooltip-v2__arrow::before {
+  border-left-color: var(--gui-color-white);
+  border-left-width: var(--gui-tooltip-v2-arrow-border-width);
+  border-right: 0;
+  left: calc(100% - 1px);
+}
+.gui-tooltip-v2__content[data-side^=left] .gui-tooltip-v2__arrow::after {
+  border-left-color: var(--gui-border-color);
+  border-left-width: var(--gui-tooltip-v2-arrow-border-width);
+  border-right: 0;
+  left: 100%;
+  z-index: -1;
+}
+.gui-tooltip-v2__content[data-side^=right] .gui-tooltip-v2__arrow {
+  left: 0;
+}
+.gui-tooltip-v2__content[data-side^=right] .gui-tooltip-v2__arrow::before {
+  border-right-color: var(--gui-color-white);
+  border-right-width: var(--gui-tooltip-v2-arrow-border-width);
+  border-left: 0;
+  right: calc(100% - 1px);
+}
+.gui-tooltip-v2__content[data-side^=right] .gui-tooltip-v2__arrow::after {
+  border-right-color: var(--gui-border-color);
+  border-right-width: var(--gui-tooltip-v2-arrow-border-width);
+  border-left: 0;
+  right: 100%;
+  z-index: -1;
+}
+
+.gui-tooltip-v2__content.is-dark {
+  --gui-tooltip-v2-border-color: transparent;
+  background-color: var(--gui-color-black);
+  color: var(--gui-color-white);
+  border-color: transparent;
+}
+.gui-tooltip-v2__content.is-dark .gui-tooltip-v2__arrow {
+  background-color: var(--gui-color-black);
+  border-color: transparent;
+}
+
+.gui-popper {
+  --gui-popper-border-radius: var(--gui-popover-border-radius, 4px);
+}
+
+.gui-popper {
+  position: absolute;
+  border-radius: var(--gui-popper-border-radius);
+  padding: 5px 11px;
+  z-index: 2000;
+  font-size: 12px;
+  line-height: 20px;
+  min-width: 10px;
+  overflow-wrap: break-word;
+  visibility: visible;
+}
+.gui-popper.is-dark {
+  color: var(--gui-bg-color);
+  background: var(--gui-text-color-primary);
+  border: 1px solid var(--gui-text-color-primary);
+}
+.gui-popper.is-dark > .gui-popper__arrow::before {
+  border: 1px solid var(--gui-text-color-primary);
+  background: var(--gui-text-color-primary);
+  right: 0;
+}
+
+.gui-popper.is-light {
+  background: var(--gui-bg-color-overlay);
+  border: 1px solid var(--gui-border-color-light);
+}
+.gui-popper.is-light > .gui-popper__arrow::before {
+  border: 1px solid var(--gui-border-color-light);
+  background: var(--gui-bg-color-overlay);
+  right: 0;
+}
+
+.gui-popper.is-pure {
+  padding: 0;
+}
+
+.gui-popper__arrow {
+  position: absolute;
+  width: 10px;
+  height: 10px;
+  z-index: -1;
+}
+.gui-popper__arrow::before {
+  position: absolute;
+  width: 10px;
+  height: 10px;
+  z-index: -1;
+  content: " ";
+  transform: rotate(45deg);
+  background: var(--gui-text-color-primary);
+  box-sizing: border-box;
+}
+
+.gui-popper[data-popper-placement^=top] > .gui-popper__arrow {
+  bottom: -5px;
+}
+.gui-popper[data-popper-placement^=top] > .gui-popper__arrow::before {
+  border-bottom-right-radius: 2px;
+}
+.gui-popper[data-popper-placement^=bottom] > .gui-popper__arrow {
+  top: -5px;
+}
+.gui-popper[data-popper-placement^=bottom] > .gui-popper__arrow::before {
+  border-top-left-radius: 2px;
+}
+.gui-popper[data-popper-placement^=left] > .gui-popper__arrow {
+  right: -5px;
+}
+.gui-popper[data-popper-placement^=left] > .gui-popper__arrow::before {
+  border-top-right-radius: 2px;
+}
+.gui-popper[data-popper-placement^=right] > .gui-popper__arrow {
+  left: -5px;
+}
+.gui-popper[data-popper-placement^=right] > .gui-popper__arrow::before {
+  border-bottom-left-radius: 2px;
+}
+.gui-popper[data-popper-placement^=top] > .gui-popper__arrow::before {
+  border-top-color: transparent !important;
+  border-left-color: transparent !important;
+}
+.gui-popper[data-popper-placement^=bottom] > .gui-popper__arrow::before {
+  border-bottom-color: transparent !important;
+  border-right-color: transparent !important;
+}
+.gui-popper[data-popper-placement^=left] > .gui-popper__arrow::before {
+  border-left-color: transparent !important;
+  border-bottom-color: transparent !important;
+}
+.gui-popper[data-popper-placement^=right] > .gui-popper__arrow::before {
+  border-right-color: transparent !important;
+  border-top-color: transparent !important;
+}
+
+.selectContainer {
+  @apply flex flex-col gap-xxs;
+}
+
+.gui-select__wrapper {
+  @apply h-fit py-sm px-xs rounded-md gap-xs border-disabled-bd border relative shadow-none;
+}
+.gui-select__label {
+  @apply absolute text-terciary-txt text-4 transition-all duration-200 ease-in font-medium;
+  top: 50%;
+  transform: translateY(-50%);
+}
+
+.gui-select__input {
+  @apply text-secondary-txt text-4 font-medium caret-everBlue-500;
+}
+
+.gui-select__wrapper.is-hovering:not(.is-focused) {
+  @apply shadow-none;
+}
+
+.gui-select__wrapper.is-complete {
+  @apply border-secondary-bd;
+}
+
+.gui-select__wrapper.is-focused {
+  @apply shadow-none border-everBlue-500;
+}
+.gui-select__wrapper.is-focused .gui-select__label {
+  @apply text-everBlue-500 !important;
+}
+
+.gui-select__wrapper.is-focused .gui-select__label {
+  @apply text-2 font-medium text-secondary-txt;
+  background: linear-gradient(180deg, transparent 40%, white 0);
+  top: 0;
+  transform: translateY(-50%);
+  padding: 0 2px;
+  left: 5px;
+}
+
+.gui-select__wrapper.is-focused .gui-select__selected-item.is-transparent {
+  @apply opacity-100;
+}
+
+.gui-select__wrapper.is-complete .gui-select__label {
+  @apply text-2 font-medium text-secondary-txt;
+  background: linear-gradient(180deg, transparent 40%, white 0);
+  top: 0;
+  transform: translateY(-50%);
+  padding: 0 2px;
+  left: 5px;
+}
+
+.gui-select__wrapper.is-complete .gui-select__selected-item.is-transparent {
+  @apply opacity-100;
+}
+
+.gui-select__wrapper.is-disabled {
+  @apply shadow-none cursor-not-allowed bg-primary-def-disabled border-grey-400;
+}
+.gui-select__wrapper.is-disabled:hover {
+  @apply shadow-none;
+}
+.gui-select__wrapper.is-disabled .gui-select__label {
+  @apply text-disabled-txt;
+  background: linear-gradient(180deg, transparent 40%, #eff0f2 0);
+}
+
+.gui-select__wrapper.is-disabled .gui-select__inner {
+  @apply text-disabled-txt;
+}
+
+.gui-select__wrapper.is-disabled .gui-select__selected-item {
+  @apply text-disabled-txt;
+}
+
+.gui-select.is-error .gui-select__label {
+  @apply text-error-txt !important;
+}
+
+.gui-select.is-error .gui-select__wrapper {
+  @apply border-error-bd;
+}
+
+.gui-select__selection {
+  @apply static;
+}
+.gui-select__selection.is-near {
+  @apply flex flex-wrap items-center gap-xxs m-0;
+  min-height: 1.5rem;
+}
+
+.gui-select__prefix svg {
+  @apply text-7 text-gray-500 w-5;
+}
+
+.gui-select__suffix svg {
+  @apply text-7 text-gray-500;
+}
+
+.gui-select__help {
+  @apply flex gap-xxs justify-between text-2 font-medium text-disabled-txt px-xs;
+  min-height: 18px;
+}
+
+.gui-select__help-text {
+  @apply line-clamp-2;
+}
+
+.gui-select__help-error {
+  @apply text-error-txt;
+}
+
+.gui-select__selected-item {
+  @apply text-4 text-primary-txt font-medium transition-all duration-200 ease-in w-auto flex-shrink-0;
+}
+.gui-select__selected-item.is-transparent {
+  @apply text-terciary-txt text-4 font-medium opacity-0;
+}
+
+.gui-select__input-wrapper {
+  @apply w-9/12;
+}
+
+.gui-select__placeholder {
+  @apply w-9/12;
+}
+
+.gui-select__tags-text {
+  @apply inline-block max-w-full truncate align-middle;
+}
+
+.gui-select__popper--is-light {
+  @apply bg-white !important;
+}
+
+.gui-popper.gui-select__popper.is-light.is-light {
+  @apply bg-white !important;
+}
+.gui-popper.gui-select__popper.is-light.is-light .gui-popper__arrow {
+  @apply shadow-none !important;
+}
+.gui-popper.gui-select__popper.is-light.is-light .gui-popper__arrow::before {
+  @apply bg-white !important;
+}
+
+.gui-popper__arrow {
+  @apply shadow-none !important;
+}
+.gui-popper__arrow::before {
+  @apply bg-white !important;
+}
+
+.gui-select__input-wrapper:not(.withIcon) {
+  @apply relative right-[7px] left-0;
+}
+.gui-select__input-wrapper:not(.withIcon).is-withIcon {
+  @apply right-0;
+}
+
+.gui-select-dropdown {
+  @apply my-xs;
+}
+.gui-select-dropdown__item {
+  @apply flex items-start justify-between gap-xs transition-all duration-200 px-2 ease-in !important;
+  min-height: unset !important;
+  line-height: normal !important;
+  height: unset !important;
+}
+.gui-select-dropdown__item--inner {
+  @apply flex items-center justify-between gap-xs w-full min-w-0 px-sm py-md;
+}
+.gui-select-dropdown__item--inner:hover {
+  @apply bg-everBlue-50 bg-opacity-60;
+}
+.gui-select-dropdown__item--inner:active {
+  @apply bg-everBlue-50;
+}
+
+.gui-select-dropdown__item--content {
+  @apply flex items-start justify-start flex-col flex-1 min-w-0;
+}
+
+.gui-select-dropdown__item--icon {
+  @apply text-7 text-secondary-txt mr-md shrink-0;
+}
+
+.gui-select-dropdown__item--check {
+  @apply text-everBlue-500 shrink-0;
+}
+
+.gui-select-dropdown__item--title {
+  @apply text-4 text-secondary-txt font-medium w-full whitespace-normal break-words;
+}
+
+.gui-select-dropdown__item--description {
+  @apply text-2 text-terciary-txt font-medium text-wrap;
+}
+
+.gui-select-dropdown__item.is-hovering {
+  @apply bg-transparent;
+}
+
+.gui-select-dropdown__item.is-selected {
+  @apply bg-transparent;
+}
+.gui-select-dropdown__item.is-selected::after {
+  display: none;
+}
+.gui-select-dropdown__item.is-selected .gui-select-dropdown__item--inner {
+  @apply bg-everBlue-50;
+}
+
+.gui-select-dropdown__item:active {
+  @apply bg-transparent;
+}
+.gui-select-dropdown__item.is-disabled {
+  @apply cursor-not-allowed;
+}
+.gui-select-dropdown__item.is-disabled:hover {
+  @apply bg-transparent;
+}
+.gui-select-dropdown__item.is-disabled--icon, .gui-select-dropdown__item.is-disabled--title, .gui-select-dropdown__item.is-disabled--description {
+  @apply text-grey-300;
+}
+
+.gui-select-group__title {
+  @apply text-2 text-ellipsis text-terciary-txt font-medium cursor-default pointer-events-none pb-xs pt-sm flex items-center px-xs first:pb-2 first:pt-2;
+  line-height: 1.25rem;
+  min-height: unset;
+}
+.gui-select-group__title ~ .gui-select-group__title {
+  position: relative;
+}
+.gui-select-group__title ~ .gui-select-group__title::after {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 50%;
+  transform: translateX(-50%);
+  width: calc(100% - 0.5rem);
+  height: 1px;
+  background: #eff0f2;
+  z-index: 1;
+}
+
+.gui-select-group__loading svg {
+  @apply text-7 text-gray-500;
+}
+
+.gui-select-group__empty {
+  @apply flex items-center justify-center flex-col py-md px-sm gap-xxs;
+}
+.gui-select-group__empty--title {
+  @apply text-4 text-secondary-txt font-semibold;
+}
+
+.gui-select-group__empty--description {
+  @apply text-3 text-terciary-txt font-medium text-pretty;
+}
+
+.gui-select-group__list.is-scrollbar-always-on {
+  overflow-y: scroll;
+}
+.gui-select-group__list.is-scrollbar-always-on::-webkit-scrollbar {
+  width: 6px;
+}
+.gui-select-group__list.is-scrollbar-always-on::-webkit-scrollbar-thumb {
+  @apply bg-grey-300 rounded-full;
+}

--- a/scripts/scss-parity/baseline/table-column-theme.css
+++ b/scripts/scss-parity/baseline/table-column-theme.css
@@ -1,0 +1,81 @@
+/* Element Chalk Variables */
+.gui-table-column--selection .cell {
+  padding-left: 14px;
+  padding-right: 14px;
+}
+
+.gui-table-filter {
+  border: solid 1px var(--gui-border-color-lighter);
+  border-radius: 2px;
+  background-color: #ffffff;
+  box-shadow: var(--gui-box-shadow-light);
+  box-sizing: border-box;
+  /** used for dropdown mode */
+}
+.gui-table-filter__list {
+  padding: 5px 0;
+  margin: 0;
+  list-style: none;
+  min-width: 100px;
+}
+
+.gui-table-filter__list-item {
+  line-height: 36px;
+  padding: 0 10px;
+  cursor: pointer;
+  font-size: var(--gui-font-size-base);
+}
+.gui-table-filter__list-item:hover {
+  background-color: var(--gui-color-primary-light-9);
+  color: var(--gui-color-primary);
+}
+.gui-table-filter__list-item.is-active {
+  background-color: var(--gui-color-primary);
+  color: #ffffff;
+}
+
+.gui-table-filter__content {
+  min-width: 100px;
+}
+
+.gui-table-filter__bottom {
+  border-top: 1px solid var(--gui-border-color-lighter);
+  padding: 8px;
+}
+.gui-table-filter__bottom button {
+  background: transparent;
+  border: none;
+  color: var(--gui-text-color-regular);
+  cursor: pointer;
+  font-size: var(--gui-font-size-small);
+  padding: 0 3px;
+}
+.gui-table-filter__bottom button:hover {
+  color: var(--gui-color-primary);
+}
+.gui-table-filter__bottom button:focus {
+  outline: none;
+}
+.gui-table-filter__bottom button.is-disabled {
+  color: var(--gui-disabled-text-color);
+  cursor: not-allowed;
+}
+
+.gui-table-filter__wrap {
+  max-height: 280px;
+}
+
+.gui-table-filter__checkbox-group {
+  padding: 10px;
+}
+.gui-table-filter__checkbox-group label.gui-checkbox {
+  display: flex;
+  align-items: center;
+  margin-right: 5px;
+  margin-bottom: 12px;
+  margin-left: 5px;
+  height: unset;
+}
+.gui-table-filter__checkbox-group .gui-checkbox:last-child {
+  margin-bottom: 0;
+}

--- a/scripts/scss-parity/baseline/table-theme.css
+++ b/scripts/scss-parity/baseline/table-theme.css
@@ -1,0 +1,574 @@
+/* Element Chalk Variables */
+.gui-table {
+  --gui-table-border-color: var(--gui-border-color-lighter);
+  --gui-table-border: 1px solid var(--gui-table-border-color);
+  --gui-table-text-color: var(--gui-text-color-regular);
+  --gui-table-header-text-color: var(--gui-text-color-secondary);
+  --gui-table-row-hover-bg-color: var(--gui-fill-color-light);
+  --gui-table-current-row-bg-color: var(--gui-color-primary-light-9);
+  --gui-table-header-bg-color: var(--gui-bg-color);
+  --gui-table-fixed-box-shadow: var(--gui-box-shadow-light);
+  --gui-table-bg-color: var(--gui-fill-color-blank);
+  --gui-table-tr-bg-color: var(--gui-bg-color);
+  --gui-table-expanded-cell-bg-color: var(--gui-fill-color-blank);
+  --gui-table-fixed-left-column: inset 10px 0 10px -10px rgba(0, 0, 0, 0.15);
+  --gui-table-fixed-right-column: inset -10px 0 10px -10px rgba(0, 0, 0, 0.15);
+  --gui-table-index: var(--gui-index-normal);
+}
+
+.gui-table {
+  position: relative;
+  overflow: hidden;
+  box-sizing: border-box;
+  height: fit-content;
+  width: 100%;
+  max-width: 100%;
+  background-color: var(--gui-table-bg-color);
+  font-size: var(--gui-font-size-base);
+  color: var(--gui-table-text-color);
+}
+.gui-table__inner-wrapper {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}
+.gui-table__inner-wrapper::before {
+  left: 0;
+  bottom: 0;
+  height: 1px;
+}
+
+.gui-table tbody:focus-visible {
+  outline: none;
+}
+.gui-table.has-footer.gui-table--scrollable-y tr:last-child td.gui-table__cell, .gui-table.has-footer.gui-table--fluid-height tr:last-child td.gui-table__cell {
+  border-bottom-color: transparent;
+}
+.gui-table__empty-block {
+  position: sticky;
+  left: 0;
+  min-height: 60px;
+  text-align: center;
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.gui-table__empty-text {
+  line-height: 60px;
+  width: 50%;
+  color: var(--gui-text-color-secondary);
+}
+
+.gui-table__expand-column .cell {
+  padding: 0;
+  text-align: center;
+  user-select: none;
+}
+
+.gui-table__expand-icon {
+  position: relative;
+  cursor: pointer;
+  color: var(--gui-text-color-regular);
+  font-size: 12px;
+  transition: transform var(--gui-transition-duration-fast) ease-in-out;
+  height: 20px;
+}
+.gui-table__expand-icon--expanded {
+  transform: rotate(90deg);
+}
+
+.gui-table__expand-icon > .gui-icon {
+  font-size: 12px;
+}
+
+.gui-table__expanded-cell {
+  background-color: var(--gui-table-expanded-cell-bg-color);
+}
+.gui-table__expanded-cell[class*=cell] {
+  padding: 20px 50px;
+}
+.gui-table__expanded-cell:hover {
+  background-color: transparent !important;
+}
+
+.gui-table__placeholder {
+  display: inline-block;
+  width: 20px;
+}
+
+.gui-table__append-wrapper {
+  overflow: hidden;
+}
+
+.gui-table--fit {
+  border-right: 0;
+  border-bottom: 0;
+}
+.gui-table--fit .gui-table__cell.gutter {
+  border-right-width: 1px;
+}
+.gui-table--fit .gui-table__inner-wrapper::before {
+  width: 100%;
+}
+
+.gui-table thead {
+  color: var(--gui-table-header-text-color);
+}
+.gui-table thead th {
+  font-weight: 600;
+}
+.gui-table thead.is-group th.gui-table__cell {
+  background: var(--gui-fill-color-light);
+}
+.gui-table .gui-table__cell {
+  padding: 8px 0;
+  min-width: 0;
+  box-sizing: border-box;
+  text-overflow: ellipsis;
+  vertical-align: middle;
+  position: relative;
+  text-align: left;
+  z-index: var(--gui-table-index);
+}
+.gui-table .gui-table__cell.is-center {
+  text-align: center;
+}
+
+.gui-table .gui-table__cell.is-right {
+  text-align: right;
+}
+
+.gui-table .gui-table__cell.gutter {
+  width: 15px;
+  border-right-width: 0;
+  border-bottom-width: 0;
+  padding: 0;
+}
+.gui-table .gui-table__cell.is-hidden > * {
+  visibility: hidden;
+}
+.gui-table .cell {
+  box-sizing: border-box;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: normal;
+  overflow-wrap: break-word;
+  line-height: 23px;
+  padding: 0 12px;
+}
+.gui-table .cell.gui-tooltip {
+  white-space: nowrap;
+  min-width: 50px;
+}
+.gui-table--large {
+  font-size: var(--gui-font-size-base);
+}
+.gui-table--large .gui-table__cell {
+  padding: 12px 0;
+}
+.gui-table--large .cell {
+  padding: 0 16px;
+}
+
+.gui-table--default {
+  font-size: var(--gui-font-size-base);
+}
+.gui-table--default .gui-table__cell {
+  padding: 8px 0;
+}
+.gui-table--default .cell {
+  padding: 0 12px;
+}
+
+.gui-table--small {
+  font-size: var(--gui-font-size-extra-small);
+}
+.gui-table--small .gui-table__cell {
+  padding: 4px 0;
+}
+.gui-table--small .cell {
+  padding: 0 8px;
+}
+
+.gui-table tr {
+  background-color: var(--gui-table-tr-bg-color);
+}
+.gui-table tr input[type=checkbox] {
+  margin: 0;
+}
+.gui-table th.gui-table__cell.is-leaf,
+.gui-table td.gui-table__cell {
+  border-bottom: var(--gui-table-border);
+}
+.gui-table th.gui-table__cell.is-sortable {
+  cursor: pointer;
+}
+.gui-table th.gui-table__cell {
+  background-color: var(--gui-table-header-bg-color);
+}
+.gui-table th.gui-table__cell > .cell.highlight {
+  color: var(--gui-color-primary);
+}
+.gui-table th.gui-table__cell.required > div::before {
+  display: inline-block;
+  content: "";
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: #ff4d51;
+  margin-right: 5px;
+  vertical-align: middle;
+}
+.gui-table td.gui-table__cell div {
+  box-sizing: border-box;
+}
+.gui-table td.gui-table__cell.gutter {
+  width: 0;
+}
+.gui-table--border::after, .gui-table--border::before, .gui-table--border .gui-table__inner-wrapper::after, .gui-table__inner-wrapper::before {
+  content: "";
+  position: absolute;
+  background-color: var(--gui-table-border-color);
+  z-index: calc(var(--gui-table-index) + 2);
+}
+
+.gui-table--border .gui-table__inner-wrapper::after {
+  left: 0;
+  top: 0;
+  width: 100%;
+  height: 1px;
+  z-index: calc(var(--gui-table-index) + 2);
+}
+
+.gui-table--border::before {
+  top: -1px;
+  left: 0;
+  width: 1px;
+  height: 100%;
+}
+.gui-table--border::after {
+  top: -1px;
+  right: 0;
+  width: 1px;
+  height: 100%;
+}
+.gui-table--border .gui-table__inner-wrapper {
+  border-right: none;
+  border-bottom: none;
+}
+
+.gui-table--border .gui-table__footer-wrapper {
+  position: relative;
+  flex-shrink: 0;
+}
+
+.gui-table--border .gui-table__cell {
+  border-right: var(--gui-table-border);
+}
+.gui-table--border th.gui-table__cell.gutter:last-of-type {
+  border-bottom: var(--gui-table-border);
+  border-bottom-width: 1px;
+}
+.gui-table--border th.gui-table__cell {
+  border-bottom: var(--gui-table-border);
+}
+
+.gui-table--hidden {
+  visibility: hidden;
+}
+
+.gui-table__header-wrapper, .gui-table__body-wrapper, .gui-table__footer-wrapper {
+  width: 100%;
+}
+.gui-table__header-wrapper tr td.gui-table-fixed-column--left, .gui-table__header-wrapper tr td.gui-table-fixed-column--right,
+.gui-table__header-wrapper tr th.gui-table-fixed-column--left,
+.gui-table__header-wrapper tr th.gui-table-fixed-column--right, .gui-table__body-wrapper tr td.gui-table-fixed-column--left, .gui-table__body-wrapper tr td.gui-table-fixed-column--right,
+.gui-table__body-wrapper tr th.gui-table-fixed-column--left,
+.gui-table__body-wrapper tr th.gui-table-fixed-column--right, .gui-table__footer-wrapper tr td.gui-table-fixed-column--left, .gui-table__footer-wrapper tr td.gui-table-fixed-column--right,
+.gui-table__footer-wrapper tr th.gui-table-fixed-column--left,
+.gui-table__footer-wrapper tr th.gui-table-fixed-column--right {
+  position: sticky !important;
+  background: inherit;
+  z-index: calc(var(--gui-table-index) + 1);
+}
+.gui-table__header-wrapper tr td.gui-table-fixed-column--left.is-last-column::before, .gui-table__header-wrapper tr td.gui-table-fixed-column--left.is-first-column::before, .gui-table__header-wrapper tr td.gui-table-fixed-column--right.is-last-column::before, .gui-table__header-wrapper tr td.gui-table-fixed-column--right.is-first-column::before,
+.gui-table__header-wrapper tr th.gui-table-fixed-column--left.is-last-column::before,
+.gui-table__header-wrapper tr th.gui-table-fixed-column--left.is-first-column::before,
+.gui-table__header-wrapper tr th.gui-table-fixed-column--right.is-last-column::before,
+.gui-table__header-wrapper tr th.gui-table-fixed-column--right.is-first-column::before, .gui-table__body-wrapper tr td.gui-table-fixed-column--left.is-last-column::before, .gui-table__body-wrapper tr td.gui-table-fixed-column--left.is-first-column::before, .gui-table__body-wrapper tr td.gui-table-fixed-column--right.is-last-column::before, .gui-table__body-wrapper tr td.gui-table-fixed-column--right.is-first-column::before,
+.gui-table__body-wrapper tr th.gui-table-fixed-column--left.is-last-column::before,
+.gui-table__body-wrapper tr th.gui-table-fixed-column--left.is-first-column::before,
+.gui-table__body-wrapper tr th.gui-table-fixed-column--right.is-last-column::before,
+.gui-table__body-wrapper tr th.gui-table-fixed-column--right.is-first-column::before, .gui-table__footer-wrapper tr td.gui-table-fixed-column--left.is-last-column::before, .gui-table__footer-wrapper tr td.gui-table-fixed-column--left.is-first-column::before, .gui-table__footer-wrapper tr td.gui-table-fixed-column--right.is-last-column::before, .gui-table__footer-wrapper tr td.gui-table-fixed-column--right.is-first-column::before,
+.gui-table__footer-wrapper tr th.gui-table-fixed-column--left.is-last-column::before,
+.gui-table__footer-wrapper tr th.gui-table-fixed-column--left.is-first-column::before,
+.gui-table__footer-wrapper tr th.gui-table-fixed-column--right.is-last-column::before,
+.gui-table__footer-wrapper tr th.gui-table-fixed-column--right.is-first-column::before {
+  content: "";
+  position: absolute;
+  top: 0px;
+  width: 10px;
+  bottom: -1px;
+  overflow-x: hidden;
+  overflow-y: hidden;
+  box-shadow: none;
+  touch-action: none;
+  pointer-events: none;
+}
+.gui-table__header-wrapper tr td.gui-table-fixed-column--left.is-first-column::before, .gui-table__header-wrapper tr td.gui-table-fixed-column--right.is-first-column::before,
+.gui-table__header-wrapper tr th.gui-table-fixed-column--left.is-first-column::before,
+.gui-table__header-wrapper tr th.gui-table-fixed-column--right.is-first-column::before, .gui-table__body-wrapper tr td.gui-table-fixed-column--left.is-first-column::before, .gui-table__body-wrapper tr td.gui-table-fixed-column--right.is-first-column::before,
+.gui-table__body-wrapper tr th.gui-table-fixed-column--left.is-first-column::before,
+.gui-table__body-wrapper tr th.gui-table-fixed-column--right.is-first-column::before, .gui-table__footer-wrapper tr td.gui-table-fixed-column--left.is-first-column::before, .gui-table__footer-wrapper tr td.gui-table-fixed-column--right.is-first-column::before,
+.gui-table__footer-wrapper tr th.gui-table-fixed-column--left.is-first-column::before,
+.gui-table__footer-wrapper tr th.gui-table-fixed-column--right.is-first-column::before {
+  left: -10px;
+}
+.gui-table__header-wrapper tr td.gui-table-fixed-column--left.is-last-column::before, .gui-table__header-wrapper tr td.gui-table-fixed-column--right.is-last-column::before,
+.gui-table__header-wrapper tr th.gui-table-fixed-column--left.is-last-column::before,
+.gui-table__header-wrapper tr th.gui-table-fixed-column--right.is-last-column::before, .gui-table__body-wrapper tr td.gui-table-fixed-column--left.is-last-column::before, .gui-table__body-wrapper tr td.gui-table-fixed-column--right.is-last-column::before,
+.gui-table__body-wrapper tr th.gui-table-fixed-column--left.is-last-column::before,
+.gui-table__body-wrapper tr th.gui-table-fixed-column--right.is-last-column::before, .gui-table__footer-wrapper tr td.gui-table-fixed-column--left.is-last-column::before, .gui-table__footer-wrapper tr td.gui-table-fixed-column--right.is-last-column::before,
+.gui-table__footer-wrapper tr th.gui-table-fixed-column--left.is-last-column::before,
+.gui-table__footer-wrapper tr th.gui-table-fixed-column--right.is-last-column::before {
+  right: -10px;
+  box-shadow: none;
+}
+.gui-table__header-wrapper tr td.gui-table__fixed-right-patch,
+.gui-table__header-wrapper tr th.gui-table__fixed-right-patch, .gui-table__body-wrapper tr td.gui-table__fixed-right-patch,
+.gui-table__body-wrapper tr th.gui-table__fixed-right-patch, .gui-table__footer-wrapper tr td.gui-table__fixed-right-patch,
+.gui-table__footer-wrapper tr th.gui-table__fixed-right-patch {
+  position: sticky !important;
+  z-index: calc(var(--gui-table-index) + 1);
+  background: #fff;
+  right: 0;
+}
+
+.gui-table__header-wrapper {
+  flex-shrink: 0;
+}
+.gui-table__header-wrapper tr th.gui-table-fixed-column--left, .gui-table__header-wrapper tr th.gui-table-fixed-column--right {
+  background-color: var(--gui-table-header-bg-color);
+}
+
+.gui-table__header, .gui-table__body, .gui-table__footer {
+  table-layout: fixed;
+  border-collapse: separate;
+}
+
+.gui-table__header-wrapper {
+  overflow: hidden;
+}
+.gui-table__header-wrapper tbody td.gui-table__cell {
+  background-color: var(--gui-table-row-hover-bg-color);
+  color: var(--gui-table-text-color);
+}
+
+.gui-table__footer-wrapper {
+  overflow: hidden;
+  flex-shrink: 0;
+}
+.gui-table__footer-wrapper tfoot td.gui-table__cell {
+  background-color: var(--gui-table-row-hover-bg-color);
+  color: var(--gui-table-text-color);
+}
+
+.gui-table__header-wrapper .gui-table-column--selection > .cell, .gui-table__body-wrapper .gui-table-column--selection > .cell {
+  display: inline-flex;
+  align-items: center;
+  height: 23px;
+}
+.gui-table__header-wrapper .gui-table-column--selection .gui-checkbox, .gui-table__body-wrapper .gui-table-column--selection .gui-checkbox {
+  height: unset;
+}
+
+.gui-table.is-scrolling-left .gui-table-fixed-column--right.is-first-column::before {
+  box-shadow: var(--gui-table-fixed-right-column);
+}
+.gui-table.is-scrolling-left.gui-table--border .gui-table-fixed-column--left.is-last-column.gui-table__cell {
+  border-right: var(--gui-table-border);
+}
+.gui-table.is-scrolling-left th.gui-table-fixed-column--left {
+  background-color: var(--gui-table-header-bg-color);
+}
+
+.gui-table.is-scrolling-right .gui-table-fixed-column--left.is-last-column::before {
+  box-shadow: var(--gui-table-fixed-left-column);
+}
+.gui-table.is-scrolling-right .gui-table-fixed-column--left.is-last-column.gui-table__cell {
+  border-right: none;
+}
+.gui-table.is-scrolling-right th.gui-table-fixed-column--right {
+  background-color: var(--gui-table-header-bg-color);
+}
+
+.gui-table.is-scrolling-middle .gui-table-fixed-column--left.is-last-column.gui-table__cell {
+  border-right: none;
+}
+.gui-table.is-scrolling-middle .gui-table-fixed-column--right.is-first-column::before {
+  box-shadow: var(--gui-table-fixed-right-column);
+}
+.gui-table.is-scrolling-middle .gui-table-fixed-column--left.is-last-column::before {
+  box-shadow: var(--gui-table-fixed-left-column);
+}
+
+.gui-table.is-scrolling-none .gui-table-fixed-column--left.is-first-column::before, .gui-table.is-scrolling-none .gui-table-fixed-column--left.is-last-column::before,
+.gui-table.is-scrolling-none .gui-table-fixed-column--right.is-first-column::before,
+.gui-table.is-scrolling-none .gui-table-fixed-column--right.is-last-column::before {
+  box-shadow: none;
+}
+.gui-table.is-scrolling-none th.gui-table-fixed-column--left,
+.gui-table.is-scrolling-none th.gui-table-fixed-column--right {
+  background-color: var(--gui-table-header-bg-color);
+}
+
+.gui-table__body-wrapper {
+  overflow: hidden;
+  position: relative;
+  flex: 1;
+}
+.gui-table__body-wrapper .gui-scrollbar__bar {
+  z-index: calc(var(--gui-table-index) + 2);
+}
+
+.gui-table .caret-wrapper {
+  display: inline-flex;
+  flex-direction: column;
+  align-items: center;
+  height: 14px;
+  width: 24px;
+  vertical-align: middle;
+  cursor: pointer;
+  overflow: initial;
+  position: relative;
+}
+.gui-table .sort-caret {
+  width: 0;
+  height: 0;
+  border: solid 5px transparent;
+  position: absolute;
+  left: 7px;
+}
+.gui-table .sort-caret.ascending {
+  border-bottom-color: var(--gui-text-color-placeholder);
+  top: -5px;
+}
+.gui-table .sort-caret.descending {
+  border-top-color: var(--gui-text-color-placeholder);
+  bottom: -3px;
+}
+.gui-table .ascending .sort-caret.ascending {
+  border-bottom-color: var(--gui-color-primary);
+}
+.gui-table .descending .sort-caret.descending {
+  border-top-color: var(--gui-color-primary);
+}
+.gui-table .hidden-columns {
+  visibility: hidden;
+  position: absolute;
+  z-index: -1;
+}
+.gui-table--striped .gui-table__body tr.gui-table__row--striped td.gui-table__cell {
+  background: var(--gui-fill-color-lighter);
+}
+.gui-table--striped .gui-table__body tr.gui-table__row--striped.current-row td.gui-table__cell {
+  background-color: var(--gui-table-current-row-bg-color);
+}
+
+.gui-table__body tr.hover-row > td.gui-table__cell, .gui-table__body tr.hover-row.current-row > td.gui-table__cell, .gui-table__body tr.hover-row.gui-table__row--striped > td.gui-table__cell, .gui-table__body tr.hover-row.gui-table__row--striped.current-row > td.gui-table__cell {
+  background-color: var(--gui-table-row-hover-bg-color);
+}
+.gui-table__body tr > td.hover-cell {
+  background-color: var(--gui-table-row-hover-bg-color);
+}
+.gui-table__body tr.current-row > td.gui-table__cell {
+  background-color: var(--gui-table-current-row-bg-color);
+}
+
+.gui-table.gui-table--scrollable-y .gui-table__body-header {
+  position: sticky;
+  top: 0;
+  z-index: calc(var(--gui-table-index) + 2);
+}
+
+.gui-table.gui-table--scrollable-y .gui-table__body-footer {
+  position: sticky;
+  bottom: 0;
+  z-index: calc(var(--gui-table-index) + 2);
+}
+
+.gui-table__column-resize-proxy {
+  position: absolute;
+  left: 200px;
+  top: 0;
+  bottom: 0;
+  width: 0;
+  border-left: var(--gui-table-border);
+  z-index: calc(var(--gui-table-index) + 9);
+}
+
+.gui-table__column-filter-trigger {
+  display: inline-block;
+  cursor: pointer;
+}
+.gui-table__column-filter-trigger i {
+  color: var(--gui-color-info);
+  font-size: 14px;
+  vertical-align: middle;
+}
+
+.gui-table__border-left-patch {
+  top: 0;
+  left: 0;
+  width: 1px;
+  height: 100%;
+  z-index: calc(var(--gui-table-index) + 2);
+  position: absolute;
+  background-color: var(--gui-table-border-color);
+}
+
+.gui-table__border-bottom-patch {
+  left: 0;
+  height: 1px;
+  z-index: calc(var(--gui-table-index) + 2);
+  position: absolute;
+  background-color: var(--gui-table-border-color);
+}
+
+.gui-table__border-right-patch {
+  top: 0;
+  height: 100%;
+  width: 1px;
+  z-index: calc(var(--gui-table-index) + 2);
+  position: absolute;
+  background-color: var(--gui-table-border-color);
+}
+
+.gui-table--enable-row-transition .gui-table__body td.gui-table__cell {
+  transition: background-color 0.25s ease;
+}
+
+.gui-table--enable-row-hover .gui-table__body tr:hover > td.gui-table__cell {
+  background-color: var(--gui-table-row-hover-bg-color);
+}
+
+.gui-table [class*=gui-table__row--level] .gui-table__expand-icon {
+  display: inline-block;
+  width: 12px;
+  line-height: 12px;
+  height: 12px;
+  text-align: center;
+  margin-right: 8px;
+}
+.gui-table .gui-table.gui-table--border .gui-table__cell {
+  border-right: var(--gui-table-border);
+}
+.gui-table:not(.gui-table--border) .gui-table__cell {
+  border-right: none;
+}
+.gui-table:not(.gui-table--border) > .gui-table__inner-wrapper::after {
+  content: none;
+}

--- a/scripts/scss-parity/baseline/table.css
+++ b/scripts/scss-parity/baseline/table.css
@@ -1,0 +1,1344 @@
+/* Element Chalk Variables */
+.gui-table {
+  --gui-table-border-color: var(--gui-border-color-lighter);
+  --gui-table-border: 1px solid var(--gui-table-border-color);
+  --gui-table-text-color: var(--gui-text-color-regular);
+  --gui-table-header-text-color: var(--gui-text-color-secondary);
+  --gui-table-row-hover-bg-color: var(--gui-fill-color-light);
+  --gui-table-current-row-bg-color: var(--gui-color-primary-light-9);
+  --gui-table-header-bg-color: var(--gui-bg-color);
+  --gui-table-fixed-box-shadow: var(--gui-box-shadow-light);
+  --gui-table-bg-color: var(--gui-fill-color-blank);
+  --gui-table-tr-bg-color: var(--gui-bg-color);
+  --gui-table-expanded-cell-bg-color: var(--gui-fill-color-blank);
+  --gui-table-fixed-left-column: inset 10px 0 10px -10px rgba(0, 0, 0, 0.15);
+  --gui-table-fixed-right-column: inset -10px 0 10px -10px rgba(0, 0, 0, 0.15);
+  --gui-table-index: var(--gui-index-normal);
+}
+
+.gui-table {
+  position: relative;
+  overflow: hidden;
+  box-sizing: border-box;
+  height: fit-content;
+  width: 100%;
+  max-width: 100%;
+  background-color: var(--gui-table-bg-color);
+  font-size: var(--gui-font-size-base);
+  color: var(--gui-table-text-color);
+}
+.gui-table__inner-wrapper {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}
+.gui-table__inner-wrapper::before {
+  left: 0;
+  bottom: 0;
+  height: 1px;
+}
+
+.gui-table tbody:focus-visible {
+  outline: none;
+}
+.gui-table.has-footer.gui-table--scrollable-y tr:last-child td.gui-table__cell, .gui-table.has-footer.gui-table--fluid-height tr:last-child td.gui-table__cell {
+  border-bottom-color: transparent;
+}
+.gui-table__empty-block {
+  position: sticky;
+  left: 0;
+  min-height: 60px;
+  text-align: center;
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.gui-table__empty-text {
+  line-height: 60px;
+  width: 50%;
+  color: var(--gui-text-color-secondary);
+}
+
+.gui-table__expand-column .cell {
+  padding: 0;
+  text-align: center;
+  user-select: none;
+}
+
+.gui-table__expand-icon {
+  position: relative;
+  cursor: pointer;
+  color: var(--gui-text-color-regular);
+  font-size: 12px;
+  transition: transform var(--gui-transition-duration-fast) ease-in-out;
+  height: 20px;
+}
+.gui-table__expand-icon--expanded {
+  transform: rotate(90deg);
+}
+
+.gui-table__expand-icon > .gui-icon {
+  font-size: 12px;
+}
+
+.gui-table__expanded-cell {
+  background-color: var(--gui-table-expanded-cell-bg-color);
+}
+.gui-table__expanded-cell[class*=cell] {
+  padding: 20px 50px;
+}
+.gui-table__expanded-cell:hover {
+  background-color: transparent !important;
+}
+
+.gui-table__placeholder {
+  display: inline-block;
+  width: 20px;
+}
+
+.gui-table__append-wrapper {
+  overflow: hidden;
+}
+
+.gui-table--fit {
+  border-right: 0;
+  border-bottom: 0;
+}
+.gui-table--fit .gui-table__cell.gutter {
+  border-right-width: 1px;
+}
+.gui-table--fit .gui-table__inner-wrapper::before {
+  width: 100%;
+}
+
+.gui-table thead {
+  color: var(--gui-table-header-text-color);
+}
+.gui-table thead th {
+  font-weight: 600;
+}
+.gui-table thead.is-group th.gui-table__cell {
+  background: var(--gui-fill-color-light);
+}
+.gui-table .gui-table__cell {
+  padding: 8px 0;
+  min-width: 0;
+  box-sizing: border-box;
+  text-overflow: ellipsis;
+  vertical-align: middle;
+  position: relative;
+  text-align: left;
+  z-index: var(--gui-table-index);
+}
+.gui-table .gui-table__cell.is-center {
+  text-align: center;
+}
+
+.gui-table .gui-table__cell.is-right {
+  text-align: right;
+}
+
+.gui-table .gui-table__cell.gutter {
+  width: 15px;
+  border-right-width: 0;
+  border-bottom-width: 0;
+  padding: 0;
+}
+.gui-table .gui-table__cell.is-hidden > * {
+  visibility: hidden;
+}
+.gui-table .cell {
+  box-sizing: border-box;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: normal;
+  overflow-wrap: break-word;
+  line-height: 23px;
+  padding: 0 12px;
+}
+.gui-table .cell.gui-tooltip {
+  white-space: nowrap;
+  min-width: 50px;
+}
+.gui-table--large {
+  font-size: var(--gui-font-size-base);
+}
+.gui-table--large .gui-table__cell {
+  padding: 12px 0;
+}
+.gui-table--large .cell {
+  padding: 0 16px;
+}
+
+.gui-table--default {
+  font-size: var(--gui-font-size-base);
+}
+.gui-table--default .gui-table__cell {
+  padding: 8px 0;
+}
+.gui-table--default .cell {
+  padding: 0 12px;
+}
+
+.gui-table--small {
+  font-size: var(--gui-font-size-extra-small);
+}
+.gui-table--small .gui-table__cell {
+  padding: 4px 0;
+}
+.gui-table--small .cell {
+  padding: 0 8px;
+}
+
+.gui-table tr {
+  background-color: var(--gui-table-tr-bg-color);
+}
+.gui-table tr input[type=checkbox] {
+  margin: 0;
+}
+.gui-table th.gui-table__cell.is-leaf,
+.gui-table td.gui-table__cell {
+  border-bottom: var(--gui-table-border);
+}
+.gui-table th.gui-table__cell.is-sortable {
+  cursor: pointer;
+}
+.gui-table th.gui-table__cell {
+  background-color: var(--gui-table-header-bg-color);
+}
+.gui-table th.gui-table__cell > .cell.highlight {
+  color: var(--gui-color-primary);
+}
+.gui-table th.gui-table__cell.required > div::before {
+  display: inline-block;
+  content: "";
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: #ff4d51;
+  margin-right: 5px;
+  vertical-align: middle;
+}
+.gui-table td.gui-table__cell div {
+  box-sizing: border-box;
+}
+.gui-table td.gui-table__cell.gutter {
+  width: 0;
+}
+.gui-table--border::after, .gui-table--border::before, .gui-table--border .gui-table__inner-wrapper::after, .gui-table__inner-wrapper::before {
+  content: "";
+  position: absolute;
+  background-color: var(--gui-table-border-color);
+  z-index: calc(var(--gui-table-index) + 2);
+}
+
+.gui-table--border .gui-table__inner-wrapper::after {
+  left: 0;
+  top: 0;
+  width: 100%;
+  height: 1px;
+  z-index: calc(var(--gui-table-index) + 2);
+}
+
+.gui-table--border::before {
+  top: -1px;
+  left: 0;
+  width: 1px;
+  height: 100%;
+}
+.gui-table--border::after {
+  top: -1px;
+  right: 0;
+  width: 1px;
+  height: 100%;
+}
+.gui-table--border .gui-table__inner-wrapper {
+  border-right: none;
+  border-bottom: none;
+}
+
+.gui-table--border .gui-table__footer-wrapper {
+  position: relative;
+  flex-shrink: 0;
+}
+
+.gui-table--border .gui-table__cell {
+  border-right: var(--gui-table-border);
+}
+.gui-table--border th.gui-table__cell.gutter:last-of-type {
+  border-bottom: var(--gui-table-border);
+  border-bottom-width: 1px;
+}
+.gui-table--border th.gui-table__cell {
+  border-bottom: var(--gui-table-border);
+}
+
+.gui-table--hidden {
+  visibility: hidden;
+}
+
+.gui-table__header-wrapper, .gui-table__body-wrapper, .gui-table__footer-wrapper {
+  width: 100%;
+}
+.gui-table__header-wrapper tr td.gui-table-fixed-column--left, .gui-table__header-wrapper tr td.gui-table-fixed-column--right,
+.gui-table__header-wrapper tr th.gui-table-fixed-column--left,
+.gui-table__header-wrapper tr th.gui-table-fixed-column--right, .gui-table__body-wrapper tr td.gui-table-fixed-column--left, .gui-table__body-wrapper tr td.gui-table-fixed-column--right,
+.gui-table__body-wrapper tr th.gui-table-fixed-column--left,
+.gui-table__body-wrapper tr th.gui-table-fixed-column--right, .gui-table__footer-wrapper tr td.gui-table-fixed-column--left, .gui-table__footer-wrapper tr td.gui-table-fixed-column--right,
+.gui-table__footer-wrapper tr th.gui-table-fixed-column--left,
+.gui-table__footer-wrapper tr th.gui-table-fixed-column--right {
+  position: sticky !important;
+  background: inherit;
+  z-index: calc(var(--gui-table-index) + 1);
+}
+.gui-table__header-wrapper tr td.gui-table-fixed-column--left.is-last-column::before, .gui-table__header-wrapper tr td.gui-table-fixed-column--left.is-first-column::before, .gui-table__header-wrapper tr td.gui-table-fixed-column--right.is-last-column::before, .gui-table__header-wrapper tr td.gui-table-fixed-column--right.is-first-column::before,
+.gui-table__header-wrapper tr th.gui-table-fixed-column--left.is-last-column::before,
+.gui-table__header-wrapper tr th.gui-table-fixed-column--left.is-first-column::before,
+.gui-table__header-wrapper tr th.gui-table-fixed-column--right.is-last-column::before,
+.gui-table__header-wrapper tr th.gui-table-fixed-column--right.is-first-column::before, .gui-table__body-wrapper tr td.gui-table-fixed-column--left.is-last-column::before, .gui-table__body-wrapper tr td.gui-table-fixed-column--left.is-first-column::before, .gui-table__body-wrapper tr td.gui-table-fixed-column--right.is-last-column::before, .gui-table__body-wrapper tr td.gui-table-fixed-column--right.is-first-column::before,
+.gui-table__body-wrapper tr th.gui-table-fixed-column--left.is-last-column::before,
+.gui-table__body-wrapper tr th.gui-table-fixed-column--left.is-first-column::before,
+.gui-table__body-wrapper tr th.gui-table-fixed-column--right.is-last-column::before,
+.gui-table__body-wrapper tr th.gui-table-fixed-column--right.is-first-column::before, .gui-table__footer-wrapper tr td.gui-table-fixed-column--left.is-last-column::before, .gui-table__footer-wrapper tr td.gui-table-fixed-column--left.is-first-column::before, .gui-table__footer-wrapper tr td.gui-table-fixed-column--right.is-last-column::before, .gui-table__footer-wrapper tr td.gui-table-fixed-column--right.is-first-column::before,
+.gui-table__footer-wrapper tr th.gui-table-fixed-column--left.is-last-column::before,
+.gui-table__footer-wrapper tr th.gui-table-fixed-column--left.is-first-column::before,
+.gui-table__footer-wrapper tr th.gui-table-fixed-column--right.is-last-column::before,
+.gui-table__footer-wrapper tr th.gui-table-fixed-column--right.is-first-column::before {
+  content: "";
+  position: absolute;
+  top: 0px;
+  width: 10px;
+  bottom: -1px;
+  overflow-x: hidden;
+  overflow-y: hidden;
+  box-shadow: none;
+  touch-action: none;
+  pointer-events: none;
+}
+.gui-table__header-wrapper tr td.gui-table-fixed-column--left.is-first-column::before, .gui-table__header-wrapper tr td.gui-table-fixed-column--right.is-first-column::before,
+.gui-table__header-wrapper tr th.gui-table-fixed-column--left.is-first-column::before,
+.gui-table__header-wrapper tr th.gui-table-fixed-column--right.is-first-column::before, .gui-table__body-wrapper tr td.gui-table-fixed-column--left.is-first-column::before, .gui-table__body-wrapper tr td.gui-table-fixed-column--right.is-first-column::before,
+.gui-table__body-wrapper tr th.gui-table-fixed-column--left.is-first-column::before,
+.gui-table__body-wrapper tr th.gui-table-fixed-column--right.is-first-column::before, .gui-table__footer-wrapper tr td.gui-table-fixed-column--left.is-first-column::before, .gui-table__footer-wrapper tr td.gui-table-fixed-column--right.is-first-column::before,
+.gui-table__footer-wrapper tr th.gui-table-fixed-column--left.is-first-column::before,
+.gui-table__footer-wrapper tr th.gui-table-fixed-column--right.is-first-column::before {
+  left: -10px;
+}
+.gui-table__header-wrapper tr td.gui-table-fixed-column--left.is-last-column::before, .gui-table__header-wrapper tr td.gui-table-fixed-column--right.is-last-column::before,
+.gui-table__header-wrapper tr th.gui-table-fixed-column--left.is-last-column::before,
+.gui-table__header-wrapper tr th.gui-table-fixed-column--right.is-last-column::before, .gui-table__body-wrapper tr td.gui-table-fixed-column--left.is-last-column::before, .gui-table__body-wrapper tr td.gui-table-fixed-column--right.is-last-column::before,
+.gui-table__body-wrapper tr th.gui-table-fixed-column--left.is-last-column::before,
+.gui-table__body-wrapper tr th.gui-table-fixed-column--right.is-last-column::before, .gui-table__footer-wrapper tr td.gui-table-fixed-column--left.is-last-column::before, .gui-table__footer-wrapper tr td.gui-table-fixed-column--right.is-last-column::before,
+.gui-table__footer-wrapper tr th.gui-table-fixed-column--left.is-last-column::before,
+.gui-table__footer-wrapper tr th.gui-table-fixed-column--right.is-last-column::before {
+  right: -10px;
+  box-shadow: none;
+}
+.gui-table__header-wrapper tr td.gui-table__fixed-right-patch,
+.gui-table__header-wrapper tr th.gui-table__fixed-right-patch, .gui-table__body-wrapper tr td.gui-table__fixed-right-patch,
+.gui-table__body-wrapper tr th.gui-table__fixed-right-patch, .gui-table__footer-wrapper tr td.gui-table__fixed-right-patch,
+.gui-table__footer-wrapper tr th.gui-table__fixed-right-patch {
+  position: sticky !important;
+  z-index: calc(var(--gui-table-index) + 1);
+  background: #fff;
+  right: 0;
+}
+
+.gui-table__header-wrapper {
+  flex-shrink: 0;
+}
+.gui-table__header-wrapper tr th.gui-table-fixed-column--left, .gui-table__header-wrapper tr th.gui-table-fixed-column--right {
+  background-color: var(--gui-table-header-bg-color);
+}
+
+.gui-table__header, .gui-table__body, .gui-table__footer {
+  table-layout: fixed;
+  border-collapse: separate;
+}
+
+.gui-table__header-wrapper {
+  overflow: hidden;
+}
+.gui-table__header-wrapper tbody td.gui-table__cell {
+  background-color: var(--gui-table-row-hover-bg-color);
+  color: var(--gui-table-text-color);
+}
+
+.gui-table__footer-wrapper {
+  overflow: hidden;
+  flex-shrink: 0;
+}
+.gui-table__footer-wrapper tfoot td.gui-table__cell {
+  background-color: var(--gui-table-row-hover-bg-color);
+  color: var(--gui-table-text-color);
+}
+
+.gui-table__header-wrapper .gui-table-column--selection > .cell, .gui-table__body-wrapper .gui-table-column--selection > .cell {
+  display: inline-flex;
+  align-items: center;
+  height: 23px;
+}
+.gui-table__header-wrapper .gui-table-column--selection .gui-checkbox, .gui-table__body-wrapper .gui-table-column--selection .gui-checkbox {
+  height: unset;
+}
+
+.gui-table.is-scrolling-left .gui-table-fixed-column--right.is-first-column::before {
+  box-shadow: var(--gui-table-fixed-right-column);
+}
+.gui-table.is-scrolling-left.gui-table--border .gui-table-fixed-column--left.is-last-column.gui-table__cell {
+  border-right: var(--gui-table-border);
+}
+.gui-table.is-scrolling-left th.gui-table-fixed-column--left {
+  background-color: var(--gui-table-header-bg-color);
+}
+
+.gui-table.is-scrolling-right .gui-table-fixed-column--left.is-last-column::before {
+  box-shadow: var(--gui-table-fixed-left-column);
+}
+.gui-table.is-scrolling-right .gui-table-fixed-column--left.is-last-column.gui-table__cell {
+  border-right: none;
+}
+.gui-table.is-scrolling-right th.gui-table-fixed-column--right {
+  background-color: var(--gui-table-header-bg-color);
+}
+
+.gui-table.is-scrolling-middle .gui-table-fixed-column--left.is-last-column.gui-table__cell {
+  border-right: none;
+}
+.gui-table.is-scrolling-middle .gui-table-fixed-column--right.is-first-column::before {
+  box-shadow: var(--gui-table-fixed-right-column);
+}
+.gui-table.is-scrolling-middle .gui-table-fixed-column--left.is-last-column::before {
+  box-shadow: var(--gui-table-fixed-left-column);
+}
+
+.gui-table.is-scrolling-none .gui-table-fixed-column--left.is-first-column::before, .gui-table.is-scrolling-none .gui-table-fixed-column--left.is-last-column::before,
+.gui-table.is-scrolling-none .gui-table-fixed-column--right.is-first-column::before,
+.gui-table.is-scrolling-none .gui-table-fixed-column--right.is-last-column::before {
+  box-shadow: none;
+}
+.gui-table.is-scrolling-none th.gui-table-fixed-column--left,
+.gui-table.is-scrolling-none th.gui-table-fixed-column--right {
+  background-color: var(--gui-table-header-bg-color);
+}
+
+.gui-table__body-wrapper {
+  overflow: hidden;
+  position: relative;
+  flex: 1;
+}
+.gui-table__body-wrapper .gui-scrollbar__bar {
+  z-index: calc(var(--gui-table-index) + 2);
+}
+
+.gui-table .caret-wrapper {
+  display: inline-flex;
+  flex-direction: column;
+  align-items: center;
+  height: 14px;
+  width: 24px;
+  vertical-align: middle;
+  cursor: pointer;
+  overflow: initial;
+  position: relative;
+}
+.gui-table .sort-caret {
+  width: 0;
+  height: 0;
+  border: solid 5px transparent;
+  position: absolute;
+  left: 7px;
+}
+.gui-table .sort-caret.ascending {
+  border-bottom-color: var(--gui-text-color-placeholder);
+  top: -5px;
+}
+.gui-table .sort-caret.descending {
+  border-top-color: var(--gui-text-color-placeholder);
+  bottom: -3px;
+}
+.gui-table .ascending .sort-caret.ascending {
+  border-bottom-color: var(--gui-color-primary);
+}
+.gui-table .descending .sort-caret.descending {
+  border-top-color: var(--gui-color-primary);
+}
+.gui-table .hidden-columns {
+  visibility: hidden;
+  position: absolute;
+  z-index: -1;
+}
+.gui-table--striped .gui-table__body tr.gui-table__row--striped td.gui-table__cell {
+  background: var(--gui-fill-color-lighter);
+}
+.gui-table--striped .gui-table__body tr.gui-table__row--striped.current-row td.gui-table__cell {
+  background-color: var(--gui-table-current-row-bg-color);
+}
+
+.gui-table__body tr.hover-row > td.gui-table__cell, .gui-table__body tr.hover-row.current-row > td.gui-table__cell, .gui-table__body tr.hover-row.gui-table__row--striped > td.gui-table__cell, .gui-table__body tr.hover-row.gui-table__row--striped.current-row > td.gui-table__cell {
+  background-color: var(--gui-table-row-hover-bg-color);
+}
+.gui-table__body tr > td.hover-cell {
+  background-color: var(--gui-table-row-hover-bg-color);
+}
+.gui-table__body tr.current-row > td.gui-table__cell {
+  background-color: var(--gui-table-current-row-bg-color);
+}
+
+.gui-table.gui-table--scrollable-y .gui-table__body-header {
+  position: sticky;
+  top: 0;
+  z-index: calc(var(--gui-table-index) + 2);
+}
+
+.gui-table.gui-table--scrollable-y .gui-table__body-footer {
+  position: sticky;
+  bottom: 0;
+  z-index: calc(var(--gui-table-index) + 2);
+}
+
+.gui-table__column-resize-proxy {
+  position: absolute;
+  left: 200px;
+  top: 0;
+  bottom: 0;
+  width: 0;
+  border-left: var(--gui-table-border);
+  z-index: calc(var(--gui-table-index) + 9);
+}
+
+.gui-table__column-filter-trigger {
+  display: inline-block;
+  cursor: pointer;
+}
+.gui-table__column-filter-trigger i {
+  color: var(--gui-color-info);
+  font-size: 14px;
+  vertical-align: middle;
+}
+
+.gui-table__border-left-patch {
+  top: 0;
+  left: 0;
+  width: 1px;
+  height: 100%;
+  z-index: calc(var(--gui-table-index) + 2);
+  position: absolute;
+  background-color: var(--gui-table-border-color);
+}
+
+.gui-table__border-bottom-patch {
+  left: 0;
+  height: 1px;
+  z-index: calc(var(--gui-table-index) + 2);
+  position: absolute;
+  background-color: var(--gui-table-border-color);
+}
+
+.gui-table__border-right-patch {
+  top: 0;
+  height: 100%;
+  width: 1px;
+  z-index: calc(var(--gui-table-index) + 2);
+  position: absolute;
+  background-color: var(--gui-table-border-color);
+}
+
+.gui-table--enable-row-transition .gui-table__body td.gui-table__cell {
+  transition: background-color 0.25s ease;
+}
+
+.gui-table--enable-row-hover .gui-table__body tr:hover > td.gui-table__cell {
+  background-color: var(--gui-table-row-hover-bg-color);
+}
+
+.gui-table [class*=gui-table__row--level] .gui-table__expand-icon {
+  display: inline-block;
+  width: 12px;
+  line-height: 12px;
+  height: 12px;
+  text-align: center;
+  margin-right: 8px;
+}
+.gui-table .gui-table.gui-table--border .gui-table__cell {
+  border-right: var(--gui-table-border);
+}
+.gui-table:not(.gui-table--border) .gui-table__cell {
+  border-right: none;
+}
+.gui-table:not(.gui-table--border) > .gui-table__inner-wrapper::after {
+  content: none;
+}
+
+.gui-table-column--selection .cell {
+  padding-left: 14px;
+  padding-right: 14px;
+}
+
+.gui-table-filter {
+  border: solid 1px var(--gui-border-color-lighter);
+  border-radius: 2px;
+  background-color: #ffffff;
+  box-shadow: var(--gui-box-shadow-light);
+  box-sizing: border-box;
+  /** used for dropdown mode */
+}
+.gui-table-filter__list {
+  padding: 5px 0;
+  margin: 0;
+  list-style: none;
+  min-width: 100px;
+}
+
+.gui-table-filter__list-item {
+  line-height: 36px;
+  padding: 0 10px;
+  cursor: pointer;
+  font-size: var(--gui-font-size-base);
+}
+.gui-table-filter__list-item:hover {
+  background-color: var(--gui-color-primary-light-9);
+  color: var(--gui-color-primary);
+}
+.gui-table-filter__list-item.is-active {
+  background-color: var(--gui-color-primary);
+  color: #ffffff;
+}
+
+.gui-table-filter__content {
+  min-width: 100px;
+}
+
+.gui-table-filter__bottom {
+  border-top: 1px solid var(--gui-border-color-lighter);
+  padding: 8px;
+}
+.gui-table-filter__bottom button {
+  background: transparent;
+  border: none;
+  color: var(--gui-text-color-regular);
+  cursor: pointer;
+  font-size: var(--gui-font-size-small);
+  padding: 0 3px;
+}
+.gui-table-filter__bottom button:hover {
+  color: var(--gui-color-primary);
+}
+.gui-table-filter__bottom button:focus {
+  outline: none;
+}
+.gui-table-filter__bottom button.is-disabled {
+  color: var(--gui-disabled-text-color);
+  cursor: not-allowed;
+}
+
+.gui-table-filter__wrap {
+  max-height: 280px;
+}
+
+.gui-table-filter__checkbox-group {
+  padding: 10px;
+}
+.gui-table-filter__checkbox-group label.gui-checkbox {
+  display: flex;
+  align-items: center;
+  margin-right: 5px;
+  margin-bottom: 12px;
+  margin-left: 5px;
+  height: unset;
+}
+.gui-table-filter__checkbox-group .gui-checkbox:last-child {
+  margin-bottom: 0;
+}
+
+.gui-tooltip-v2__content {
+  --gui-tooltip-v2-padding: 5px 10px;
+  --gui-tooltip-v2-border-radius: 4px;
+  --gui-tooltip-v2-border-color: var(--gui-border-color);
+  border-radius: var(--gui-tooltip-v2-border-radius);
+  color: var(--gui-color-black);
+  background-color: var(--gui-color-white);
+  padding: var(--gui-tooltip-v2-padding);
+  border: 1px solid var(--gui-border-color);
+}
+.gui-tooltip-v2__arrow {
+  position: absolute;
+  color: var(--gui-color-white);
+  width: var(--gui-tooltip-v2-arrow-width);
+  height: var(--gui-tooltip-v2-arrow-height);
+  pointer-events: none;
+  left: var(--gui-tooltip-v2-arrow-x);
+  top: var(--gui-tooltip-v2-arrow-y);
+}
+.gui-tooltip-v2__arrow::before {
+  content: "";
+  width: 0;
+  height: 0;
+  border: var(--gui-tooltip-v2-arrow-border-width) solid transparent;
+  position: absolute;
+}
+.gui-tooltip-v2__arrow::after {
+  content: "";
+  width: 0;
+  height: 0;
+  border: var(--gui-tooltip-v2-arrow-border-width) solid transparent;
+  position: absolute;
+}
+.gui-tooltip-v2__content[data-side^=top] .gui-tooltip-v2__arrow {
+  bottom: 0;
+}
+.gui-tooltip-v2__content[data-side^=top] .gui-tooltip-v2__arrow::before {
+  border-top-color: var(--gui-color-white);
+  border-top-width: var(--gui-tooltip-v2-arrow-border-width);
+  border-bottom: 0;
+  top: calc(100% - 1px);
+}
+.gui-tooltip-v2__content[data-side^=top] .gui-tooltip-v2__arrow::after {
+  border-top-color: var(--gui-border-color);
+  border-top-width: var(--gui-tooltip-v2-arrow-border-width);
+  border-bottom: 0;
+  top: 100%;
+  z-index: -1;
+}
+.gui-tooltip-v2__content[data-side^=bottom] .gui-tooltip-v2__arrow {
+  top: 0;
+}
+.gui-tooltip-v2__content[data-side^=bottom] .gui-tooltip-v2__arrow::before {
+  border-bottom-color: var(--gui-color-white);
+  border-bottom-width: var(--gui-tooltip-v2-arrow-border-width);
+  border-top: 0;
+  bottom: calc(100% - 1px);
+}
+.gui-tooltip-v2__content[data-side^=bottom] .gui-tooltip-v2__arrow::after {
+  border-bottom-color: var(--gui-border-color);
+  border-bottom-width: var(--gui-tooltip-v2-arrow-border-width);
+  border-top: 0;
+  bottom: 100%;
+  z-index: -1;
+}
+.gui-tooltip-v2__content[data-side^=left] .gui-tooltip-v2__arrow {
+  right: 0;
+}
+.gui-tooltip-v2__content[data-side^=left] .gui-tooltip-v2__arrow::before {
+  border-left-color: var(--gui-color-white);
+  border-left-width: var(--gui-tooltip-v2-arrow-border-width);
+  border-right: 0;
+  left: calc(100% - 1px);
+}
+.gui-tooltip-v2__content[data-side^=left] .gui-tooltip-v2__arrow::after {
+  border-left-color: var(--gui-border-color);
+  border-left-width: var(--gui-tooltip-v2-arrow-border-width);
+  border-right: 0;
+  left: 100%;
+  z-index: -1;
+}
+.gui-tooltip-v2__content[data-side^=right] .gui-tooltip-v2__arrow {
+  left: 0;
+}
+.gui-tooltip-v2__content[data-side^=right] .gui-tooltip-v2__arrow::before {
+  border-right-color: var(--gui-color-white);
+  border-right-width: var(--gui-tooltip-v2-arrow-border-width);
+  border-left: 0;
+  right: calc(100% - 1px);
+}
+.gui-tooltip-v2__content[data-side^=right] .gui-tooltip-v2__arrow::after {
+  border-right-color: var(--gui-border-color);
+  border-right-width: var(--gui-tooltip-v2-arrow-border-width);
+  border-left: 0;
+  right: 100%;
+  z-index: -1;
+}
+
+.gui-tooltip-v2__content.is-dark {
+  --gui-tooltip-v2-border-color: transparent;
+  background-color: var(--gui-color-black);
+  color: var(--gui-color-white);
+  border-color: transparent;
+}
+.gui-tooltip-v2__content.is-dark .gui-tooltip-v2__arrow {
+  background-color: var(--gui-color-black);
+  border-color: transparent;
+}
+
+.gui-popper {
+  --gui-popper-border-radius: var(--gui-popover-border-radius, 4px);
+}
+
+.gui-popper {
+  position: absolute;
+  border-radius: var(--gui-popper-border-radius);
+  padding: 5px 11px;
+  z-index: 2000;
+  font-size: 12px;
+  line-height: 20px;
+  min-width: 10px;
+  overflow-wrap: break-word;
+  visibility: visible;
+}
+.gui-popper.is-dark {
+  color: var(--gui-bg-color);
+  background: var(--gui-text-color-primary);
+  border: 1px solid var(--gui-text-color-primary);
+}
+.gui-popper.is-dark > .gui-popper__arrow::before {
+  border: 1px solid var(--gui-text-color-primary);
+  background: var(--gui-text-color-primary);
+  right: 0;
+}
+
+.gui-popper.is-light {
+  background: var(--gui-bg-color-overlay);
+  border: 1px solid var(--gui-border-color-light);
+}
+.gui-popper.is-light > .gui-popper__arrow::before {
+  border: 1px solid var(--gui-border-color-light);
+  background: var(--gui-bg-color-overlay);
+  right: 0;
+}
+
+.gui-popper.is-pure {
+  padding: 0;
+}
+
+.gui-popper__arrow {
+  position: absolute;
+  width: 10px;
+  height: 10px;
+  z-index: -1;
+}
+.gui-popper__arrow::before {
+  position: absolute;
+  width: 10px;
+  height: 10px;
+  z-index: -1;
+  content: " ";
+  transform: rotate(45deg);
+  background: var(--gui-text-color-primary);
+  box-sizing: border-box;
+}
+
+.gui-popper[data-popper-placement^=top] > .gui-popper__arrow {
+  bottom: -5px;
+}
+.gui-popper[data-popper-placement^=top] > .gui-popper__arrow::before {
+  border-bottom-right-radius: 2px;
+}
+.gui-popper[data-popper-placement^=bottom] > .gui-popper__arrow {
+  top: -5px;
+}
+.gui-popper[data-popper-placement^=bottom] > .gui-popper__arrow::before {
+  border-top-left-radius: 2px;
+}
+.gui-popper[data-popper-placement^=left] > .gui-popper__arrow {
+  right: -5px;
+}
+.gui-popper[data-popper-placement^=left] > .gui-popper__arrow::before {
+  border-top-right-radius: 2px;
+}
+.gui-popper[data-popper-placement^=right] > .gui-popper__arrow {
+  left: -5px;
+}
+.gui-popper[data-popper-placement^=right] > .gui-popper__arrow::before {
+  border-bottom-left-radius: 2px;
+}
+.gui-popper[data-popper-placement^=top] > .gui-popper__arrow::before {
+  border-top-color: transparent !important;
+  border-left-color: transparent !important;
+}
+.gui-popper[data-popper-placement^=bottom] > .gui-popper__arrow::before {
+  border-bottom-color: transparent !important;
+  border-right-color: transparent !important;
+}
+.gui-popper[data-popper-placement^=left] > .gui-popper__arrow::before {
+  border-left-color: transparent !important;
+  border-bottom-color: transparent !important;
+}
+.gui-popper[data-popper-placement^=right] > .gui-popper__arrow::before {
+  border-right-color: transparent !important;
+  border-top-color: transparent !important;
+}
+
+.gui-checkbox {
+  --gui-checkbox-font-size: 14px;
+  --gui-checkbox-font-weight: var(--gui-font-weight-primary);
+  --gui-checkbox-text-color: var(--gui-text-color-regular);
+  --gui-checkbox-input-height: 14px;
+  --gui-checkbox-input-width: 14px;
+  --gui-checkbox-border-radius: var(--gui-border-radius-small);
+  --gui-checkbox-bg-color: var(--gui-fill-color-blank);
+  --gui-checkbox-input-border: var(--gui-border);
+  --gui-checkbox-disabled-border-color: var(--gui-border-color);
+  --gui-checkbox-disabled-input-fill: var(--gui-fill-color-light);
+  --gui-checkbox-disabled-icon-color: var(--gui-text-color-placeholder);
+  --gui-checkbox-disabled-checked-input-fill: var(--gui-border-color-extra-light);
+  --gui-checkbox-disabled-checked-input-border-color: var(--gui-border-color);
+  --gui-checkbox-disabled-checked-icon-color: var(--gui-text-color-placeholder);
+  --gui-checkbox-checked-text-color: var(--gui-color-primary);
+  --gui-checkbox-checked-input-border-color: var(--gui-color-primary);
+  --gui-checkbox-checked-bg-color: var(--gui-color-primary);
+  --gui-checkbox-checked-icon-color: var(--gui-color-white);
+  --gui-checkbox-input-border-color-hover: var(--gui-color-primary);
+}
+
+.gui-checkbox {
+  color: var(--gui-checkbox-text-color);
+  font-weight: var(--gui-checkbox-font-weight);
+  font-size: var(--gui-font-size-base);
+  position: relative;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  white-space: nowrap;
+  user-select: none;
+  margin-right: 30px;
+  height: var(--gui-checkbox-height, 32px);
+}
+.gui-checkbox.is-disabled {
+  cursor: not-allowed;
+}
+
+.gui-checkbox.is-bordered {
+  padding: 0 15px 0 9px;
+  border-radius: var(--gui-border-radius-base);
+  border: var(--gui-border);
+  box-sizing: border-box;
+}
+.gui-checkbox.is-bordered.is-checked {
+  border-color: var(--gui-color-primary);
+}
+.gui-checkbox.is-bordered.is-disabled {
+  border-color: var(--gui-border-color-lighter);
+}
+.gui-checkbox.is-bordered.gui-checkbox--large {
+  padding: 0 19px 0 11px;
+  border-radius: var(--gui-border-radius-base);
+}
+.gui-checkbox.is-bordered.gui-checkbox--large .gui-checkbox__label {
+  font-size: var(--gui-font-size-base);
+}
+.gui-checkbox.is-bordered.gui-checkbox--large .gui-checkbox__inner {
+  height: 14px;
+  width: 14px;
+}
+.gui-checkbox.is-bordered.gui-checkbox--small {
+  padding: 0 11px 0 7px;
+  border-radius: calc(var(--gui-border-radius-base) - 1px);
+}
+.gui-checkbox.is-bordered.gui-checkbox--small .gui-checkbox__label {
+  font-size: 12px;
+}
+.gui-checkbox.is-bordered.gui-checkbox--small .gui-checkbox__inner {
+  height: 12px;
+  width: 12px;
+}
+.gui-checkbox.is-bordered.gui-checkbox--small .gui-checkbox__inner::after {
+  height: 6px;
+  width: 2px;
+}
+
+.gui-checkbox input:focus-visible + .gui-checkbox__inner {
+  outline: 2px solid var(--gui-checkbox-input-border-color-hover);
+  outline-offset: 1px;
+  border-radius: var(--gui-checkbox-border-radius);
+}
+.gui-checkbox__input {
+  white-space: nowrap;
+  cursor: pointer;
+  outline: none;
+  display: inline-flex;
+  position: relative;
+}
+.gui-checkbox__input.is-disabled .gui-checkbox__inner {
+  background-color: var(--gui-checkbox-disabled-input-fill);
+  border-color: var(--gui-checkbox-disabled-border-color);
+  cursor: not-allowed;
+}
+.gui-checkbox__input.is-disabled .gui-checkbox__inner::after {
+  cursor: not-allowed;
+  border-color: var(--gui-checkbox-disabled-icon-color);
+}
+.gui-checkbox__input.is-disabled.is-checked .gui-checkbox__inner {
+  background-color: var(--gui-checkbox-disabled-checked-input-fill);
+  border-color: var(--gui-checkbox-disabled-checked-input-border-color);
+}
+.gui-checkbox__input.is-disabled.is-checked .gui-checkbox__inner::after {
+  border-color: var(--gui-checkbox-disabled-checked-icon-color);
+}
+.gui-checkbox__input.is-disabled.is-indeterminate .gui-checkbox__inner {
+  background-color: var(--gui-checkbox-disabled-checked-input-fill);
+  border-color: var(--gui-checkbox-disabled-checked-input-border-color);
+}
+.gui-checkbox__input.is-disabled.is-indeterminate .gui-checkbox__inner::before {
+  background-color: var(--gui-checkbox-disabled-checked-icon-color);
+  border-color: var(--gui-checkbox-disabled-checked-icon-color);
+}
+.gui-checkbox__input.is-disabled + span.gui-checkbox__label {
+  color: var(--gui-disabled-text-color);
+  cursor: not-allowed;
+}
+
+.gui-checkbox__input.is-checked .gui-checkbox__inner {
+  background-color: var(--gui-checkbox-checked-bg-color);
+  border-color: var(--gui-checkbox-checked-input-border-color);
+}
+.gui-checkbox__input.is-checked .gui-checkbox__inner::after {
+  transform: rotate(45deg) scaleY(1);
+  border-color: var(--gui-checkbox-checked-icon-color);
+}
+.gui-checkbox__input.is-checked + .gui-checkbox__label {
+  color: var(--gui-checkbox-checked-text-color);
+}
+
+.gui-checkbox__input.is-focus:not(.is-checked) .gui-checkbox__original:not(:focus-visible) {
+  border-color: var(--gui-checkbox-input-border-color-hover);
+}
+
+.gui-checkbox__input.is-indeterminate .gui-checkbox__inner {
+  background-color: var(--gui-checkbox-checked-bg-color);
+  border-color: var(--gui-checkbox-checked-input-border-color);
+}
+.gui-checkbox__input.is-indeterminate .gui-checkbox__inner::before {
+  content: "";
+  position: absolute;
+  display: block;
+  background-color: var(--gui-checkbox-checked-icon-color);
+  height: 2px;
+  transform: scale(0.5);
+  left: 0;
+  right: 0;
+  top: 5px;
+}
+.gui-checkbox__input.is-indeterminate .gui-checkbox__inner::after {
+  display: none;
+}
+
+.gui-checkbox__inner {
+  display: inline-block;
+  position: relative;
+  border: var(--gui-checkbox-input-border);
+  border-radius: var(--gui-checkbox-border-radius);
+  box-sizing: border-box;
+  width: var(--gui-checkbox-input-width);
+  height: var(--gui-checkbox-input-height);
+  background-color: var(--gui-checkbox-bg-color);
+  z-index: var(--gui-index-normal);
+  transition: border-color 0.25s cubic-bezier(0.71, -0.46, 0.29, 1.46), background-color 0.25s cubic-bezier(0.71, -0.46, 0.29, 1.46), outline 0.25s cubic-bezier(0.71, -0.46, 0.29, 1.46);
+}
+.gui-checkbox__inner:hover {
+  border-color: var(--gui-checkbox-input-border-color-hover);
+}
+.gui-checkbox__inner::after {
+  box-sizing: content-box;
+  content: "";
+  border: 1px solid transparent;
+  border-left: 0;
+  border-top: 0;
+  height: 7px;
+  left: 4px;
+  position: absolute;
+  top: 1px;
+  transform: rotate(45deg) scaleY(0);
+  width: 3px;
+  transition: transform 0.15s ease-in 0.05s;
+  transform-origin: center;
+}
+
+.gui-checkbox__original {
+  opacity: 0;
+  outline: none;
+  position: absolute;
+  margin: 0;
+  width: 0;
+  height: 0;
+  z-index: -1;
+}
+
+.gui-checkbox__label {
+  display: inline-block;
+  padding-left: 8px;
+  line-height: 1;
+  font-size: var(--gui-checkbox-font-size);
+}
+
+.gui-checkbox.gui-checkbox--large {
+  height: 40px;
+}
+.gui-checkbox.gui-checkbox--large .gui-checkbox__label {
+  font-size: 14px;
+}
+
+.gui-checkbox.gui-checkbox--large .gui-checkbox__inner {
+  width: 14px;
+  height: 14px;
+}
+
+.gui-checkbox.gui-checkbox--small {
+  height: 24px;
+}
+.gui-checkbox.gui-checkbox--small .gui-checkbox__label {
+  font-size: 12px;
+}
+
+.gui-checkbox.gui-checkbox--small .gui-checkbox__inner {
+  width: 12px;
+  height: 12px;
+}
+
+.gui-checkbox.gui-checkbox--small .gui-checkbox__input.is-indeterminate .gui-checkbox__inner::before {
+  top: 4px;
+}
+
+.gui-checkbox.gui-checkbox--small .gui-checkbox__inner::after {
+  width: 2px;
+  height: 6px;
+}
+
+.gui-checkbox:last-of-type {
+  margin-right: 0;
+}
+
+.gui-table tbody:has(.gui-table-cell-input-editing), .gui-table tbody:has(.gui-table-cell-select-editing) {
+  overflow: visible !important;
+}
+.gui-table__header thead.is-group .gui-table__cell {
+  @apply bg-everBlue-50 border-everBlue-100 !important;
+}
+
+.gui-table__header tr th .cell {
+  @apply text-primary-txt font-semibold !important;
+}
+
+.gui-table--group::after {
+  @apply w-0;
+}
+.gui-table--group .gui-table__header-wrapper {
+  @apply border-t border-l-0 border-everBlue-100;
+}
+.gui-table--group .gui-table__header {
+  @apply relative;
+}
+.gui-table--group .gui-table__header::before {
+  @apply content-[''] absolute top-0 left-0 w-[1px] h-full bg-everBlue-100;
+}
+.gui-table--group.gui-table--border .gui-table__inner-wrapper::after {
+  @apply h-0;
+}
+.gui-table--group.gui-table--border::before {
+  @apply w-0;
+}
+
+.gui-table tr {
+  @apply bg-sec-def-bg;
+}
+.gui-table__cell {
+  @apply border-b border-gray-100 !important;
+  position: relative;
+}
+.gui-table__cell:has(.gui-table-cell-edit-wrapper), .gui-table__cell:has(.gui-table-cell-input-wrapper) {
+  @apply p-0 !important;
+}
+.gui-table__cell:has(.gui-table-cell-edit-wrapper) .cell, .gui-table__cell:has(.gui-table-cell-input-wrapper) .cell {
+  position: static !important;
+}
+.gui-table__cell:has(.gui-table-cell-input-reading):hover {
+  @apply bg-everBlue-100 bg-opacity-30;
+}
+.gui-table__cell:has(.gui-table-cell-input-editing), .gui-table__cell:has(.gui-table-cell-select-editing) {
+  overflow: visible !important;
+}
+.gui-table__cell:has(.gui-table-cell-input-editing) .cell, .gui-table__cell:has(.gui-table-cell-select-editing) .cell {
+  overflow: visible !important;
+}
+.gui-table__cell:has(.gui-table-cell-input-editing) .gui-table-cell-edit-wrapper, .gui-table__cell:has(.gui-table-cell-select-editing) .gui-table-cell-edit-wrapper {
+  @apply bg-white;
+}
+.gui-table__cell .cell {
+  @apply text-primary-txt font-medium text-3 !important;
+  position: relative;
+  min-height: 3.8rem;
+  display: flex;
+  align-items: center;
+}
+.gui-table__cell .cell:not(:has(.gui-table-cell-edit-wrapper)):not(:has(.gui-table-cell-input-wrapper)) {
+  @apply px-xs;
+}
+.gui-table__cell:has(.absolute.items-start) {
+  height: auto;
+}
+.gui-table__cell:has(.absolute.items-start) .cell {
+  height: auto;
+  min-height: auto;
+}
+.gui-table__cell .gui-table-cell-select {
+  @apply w-full min-w-0 py-xxs px-xs text-3 border border-transparent rounded bg-transparent outline-none;
+  min-height: 3.8rem;
+}
+.gui-table__cell .gui-table-cell-select:focus {
+  @apply border-everBlue-200;
+}
+.gui-table__cell .gui-table-cell-select-read {
+  @apply w-full h-full min-h-0 max-w-full flex items-center justify-start cursor-pointer outline-none py-0 px-xs rounded;
+}
+.gui-table__cell .gui-table-cell-select-read:focus {
+  @apply ring-1 ring-everBlue-200 ring-offset-0;
+}
+.gui-table__cell .gui-table-cell-select-inner {
+  @apply min-w-0 w-full h-full flex items-center justify-start;
+}
+.gui-table__cell .gui-table-cell-edit-wrapper:has(.gui-table-cell-select-inner) {
+  justify-content: flex-start;
+}
+.gui-table__cell.is-center:has(.gui-table-cell-select-inner) {
+  text-align: left;
+}
+.gui-table__cell.is-center:has(.gui-table-cell-select-inner) .cell {
+  justify-content: flex-start;
+}
+.gui-table__cell .gui-table-cell-input {
+  @apply w-full min-w-0 py-xxs px-xs text-3 border border-transparent rounded bg-transparent outline-none;
+  min-height: 3.8rem;
+}
+.gui-table__cell .gui-table-cell-input:focus {
+  @apply border-everBlue-200;
+}
+.gui-table__cell .gui-table-cell-input-read {
+  @apply w-full flex items-center justify-center cursor-pointer outline-none py-xxs px-xs rounded;
+  min-height: 3.8rem;
+}
+.gui-table__cell .gui-table-cell-input-read:focus {
+  @apply ring-1 ring-everBlue-200 ring-offset-0;
+}
+.gui-table__cell .gui-table-cell-edit-wrapper {
+  @apply w-full flex items-center bg-white;
+  min-height: 3.8rem;
+}
+.gui-table__cell .gui-table-cell-edit-wrapper:hover {
+  @apply bg-everBlue-100 !important;
+}
+.gui-table__cell .gui-table-cell-edit-wrapper.has-textarea {
+  @apply items-start;
+  align-items: flex-start;
+  min-height: auto;
+  height: auto;
+}
+.gui-table__cell .gui-table-cell-input-textarea-wrapper {
+  @apply w-full flex flex-col gap-xxs;
+  min-width: 0;
+  width: 100%;
+  position: relative;
+}
+.gui-table__cell .gui-table-cell-input-label {
+  @apply text-3 font-medium text-primary-txt mb-xxs;
+}
+.gui-table__cell .gui-table-cell-input-textarea {
+  @apply w-full min-w-0 py-xxs px-xs text-3 border border-transparent rounded bg-transparent outline-none resize-none;
+  font-family: inherit;
+  line-height: 1.5;
+  min-height: auto;
+}
+.gui-table__cell .gui-table-cell-input-textarea:focus {
+  @apply border-everBlue-200;
+}
+.gui-table__cell .gui-table-cell-input-textarea::placeholder {
+  @apply text-terciary-txt;
+}
+.gui-table__cell .gui-table-cell-input-error {
+  @apply text-2 text-error-def mt-xxs;
+}
+.gui-table__cell .gui-table-cell-input-textarea--error {
+  border-color: var(--color-error);
+}
+.gui-table__cell .gui-table-cell-input-textarea--error:focus {
+  border-color: var(--color-error);
+  box-shadow: 0 0 0 1px var(--color-error);
+}
+.gui-table__cell .gui-table-cell-input-textarea--validating {
+  opacity: 0.6;
+  pointer-events: none;
+}
+.gui-table__cell .gui-table-cell-input-textarea-loading {
+  position: absolute;
+  top: 6px;
+  right: 8px;
+  width: 14px;
+  height: 14px;
+  border: 2px solid transparent;
+  border-top-color: var(--color-everBlue-200, #60a5fa);
+  border-radius: 50%;
+  animation: gui-table-cell-textarea-spin 0.6s linear infinite;
+  pointer-events: none;
+  z-index: 1;
+}
+@keyframes gui-table-cell-textarea-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+.gui-table__cell .gui-table-cell-edit-enter-active {
+  transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+}
+.gui-table__cell .gui-table-cell-edit-enter-from {
+  opacity: 0;
+  transform: translateX(-8px);
+}
+.gui-table__cell .gui-table-cell-edit-enter-to {
+  opacity: 1;
+  transform: translateX(0);
+}
+.gui-table__cell .gui-table-cell-edit-leave-active {
+  transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1);
+}
+.gui-table__cell .gui-table-cell-edit-leave-from {
+  opacity: 1;
+  transform: translateX(0);
+}
+.gui-table__cell .gui-table-cell-edit-leave-to {
+  opacity: 0;
+  transform: translateX(8px);
+}
+
+.gui-table__expanded-cell.gui-table__cell {
+  @apply p-7 !important;
+}
+
+.gui-table__row {
+  @apply transition-colors duration-200 ease-in;
+  /* &:has(.is-checked) {
+    @apply bg-everBlue-50 border-everBlue-100 !important;
+  } */
+}
+.gui-table__row:hover .gui-table__cell {
+  @apply bg-everBlue-50 !important;
+}
+.gui-table__row:hover .gui-table-cell-edit-wrapper {
+  @apply bg-everBlue-50;
+}
+.gui-table__row--striped .gui-table__cell {
+  @apply bg-everBlue-50 bg-opacity-50 !important;
+}
+
+.gui-table .gui-table-column--selection .cell {
+  @apply flex items-center justify-center h-9;
+}
+.gui-table__body-wrapper .gui-scrollbar__wrap {
+  scroll-behavior: auto;
+}
+
+.gui-table__header-wrapper tr td.gui-table-fixed-column--left.is-last-column::before, .gui-table__header-wrapper tr td.gui-table-fixed-column--left.is-first-column::before, .gui-table__header-wrapper tr td.gui-table-fixed-column--right.is-last-column::before, .gui-table__header-wrapper tr td.gui-table-fixed-column--right.is-first-column::before,
+.gui-table__header-wrapper tr th.gui-table-fixed-column--left.is-last-column::before,
+.gui-table__header-wrapper tr th.gui-table-fixed-column--left.is-first-column::before,
+.gui-table__header-wrapper tr th.gui-table-fixed-column--right.is-last-column::before,
+.gui-table__header-wrapper tr th.gui-table-fixed-column--right.is-first-column::before, .gui-table__body-wrapper tr td.gui-table-fixed-column--left.is-last-column::before, .gui-table__body-wrapper tr td.gui-table-fixed-column--left.is-first-column::before, .gui-table__body-wrapper tr td.gui-table-fixed-column--right.is-last-column::before, .gui-table__body-wrapper tr td.gui-table-fixed-column--right.is-first-column::before,
+.gui-table__body-wrapper tr th.gui-table-fixed-column--left.is-last-column::before,
+.gui-table__body-wrapper tr th.gui-table-fixed-column--left.is-first-column::before,
+.gui-table__body-wrapper tr th.gui-table-fixed-column--right.is-last-column::before,
+.gui-table__body-wrapper tr th.gui-table-fixed-column--right.is-first-column::before, .gui-table__footer-wrapper tr td.gui-table-fixed-column--left.is-last-column::before, .gui-table__footer-wrapper tr td.gui-table-fixed-column--left.is-first-column::before, .gui-table__footer-wrapper tr td.gui-table-fixed-column--right.is-last-column::before, .gui-table__footer-wrapper tr td.gui-table-fixed-column--right.is-first-column::before,
+.gui-table__footer-wrapper tr th.gui-table-fixed-column--left.is-last-column::before,
+.gui-table__footer-wrapper tr th.gui-table-fixed-column--left.is-first-column::before,
+.gui-table__footer-wrapper tr th.gui-table-fixed-column--right.is-last-column::before,
+.gui-table__footer-wrapper tr th.gui-table-fixed-column--right.is-first-column::before {
+  transition: none;
+}

--- a/scripts/scss-parity/targets.json
+++ b/scripts/scss-parity/targets.json
@@ -50,5 +50,10 @@
   "input-tag-theme": "components/input-tag/src/styles/input-tag.scss",
   "input-tag": "components/input-tag/src/input-tag.styles.scss",
   "g-utils-button-mixins": "common/g-utils/styles/button-mixins.scss",
-  "g-utils-radio-group": "common/g-utils/styles/radio-group.scss"
+  "g-utils-radio-group": "common/g-utils/styles/radio-group.scss",
+  "select-v2-theme": "components/select/src/styles/select-v2.scss",
+  "select": "components/select/src/select.styles.scss",
+  "table-theme": "components/table/src/styles/table.scss",
+  "table-column-theme": "components/table/src/styles/table-column.scss",
+  "table": "components/table/src/table.styles.scss"
 }


### PR DESCRIPTION
## Qué

Quinta slice de WU4 — los dos themes más grandes que quedaban. Porta byte-exacto el árbol de theme de `select` (`select-v2`, `select`, `select-dropdown`, `select-dropdown-v2`, `option-group`) y de `table` (`table`, `table-column`) a archivos locales `src/styles/`, repuntando las hojas de entrada.

Ambos ya tenían la mayoría de sus dependencias de EP portadas en slices anteriores:
- `select` reutiliza `g-utils/scrollbar`, `virtual-list`, `option`, `tooltip-v2`, `popper` (S1/S2).
- `table` reutiliza `g-utils/tooltip-v2`, `popper` (S1/S2) y **referencia cruzada** el theme de `checkbox` ya portado en S4 (`@flash-global66/g-checkbox/src/styles/checkbox.scss`) en vez de duplicar ese puerto.

## Verificación

- Byte-exacto directo (sin artefactos de reordenamiento): `select` 24527b, `table` 43180b, idénticos a element-plus en namespace `gui`.
- **Parity harness**: 57/57 OK.
- Tests pre-push ✅.
- Validación en b2b vía yarn link: pendiente antes del merge.

## Alcance

Sin cambios de API pública. Con esta slice, todos los componentes "no-isla" quedan repuntados salvo los pickers (date-picker, time-picker — S6).