### PR TITLE
chore(deps): drop stale element-plus peerDependency from 32 migrated components

### DIFF
--- a/components/attach-file/package.json
+++ b/components/attach-file/package.json
@@ -36,7 +36,6 @@
     "@flash-global66/g-icon-button": "0.2.2",
     "@flash-global66/g-icon-font": "0.6.0",
     "@flash-global66/g-progress": "0.2.0",
-    "element-plus": "2.9.0",
     "vue": "3.2.0"
   }
 }

--- a/components/checkbox/package.json
+++ b/components/checkbox/package.json
@@ -31,7 +31,6 @@
   "peerDependencies": {
     "@flash-global66/g-form": "^0.2.0",
     "@vueuse/core": "^12.4.0",
-    "element-plus": "^2.9.0",
     "lodash-unified": "^1.0.3",
     "vue": "^3.2.0"
   },

--- a/components/chip/package.json
+++ b/components/chip/package.json
@@ -29,7 +29,6 @@
     "@flash-global66/g-dropdown": "^0.1.0",
     "@flash-global66/g-icon-font": "^0.11.0",
     "@flash-global66/g-popover": "^0.0.7",
-    "element-plus": "^2.9.0",
     "vue": "^3.2.0"
   },
   "publishConfig": {

--- a/components/collapse/package.json
+++ b/components/collapse/package.json
@@ -35,7 +35,6 @@
     "@flash-global66/g-utils": "^0.15.5"
   },
   "peerDependencies": {
-    "element-plus": "^2.9.0",
     "vue": "^3.2.0"
   },
   "gitHead": "581df2757ad066a5cdd5a2e64500ab33a68279ad"

--- a/components/country-flag/package.json
+++ b/components/country-flag/package.json
@@ -36,7 +36,6 @@
   },
   "peerDependencies": {
     "@vueuse/core": "^13.0.0",
-    "element-plus": "^2.0.0",
     "vue": "^3.2.0"
   }
 }

--- a/components/date-picker/package.json
+++ b/components/date-picker/package.json
@@ -39,7 +39,6 @@
   },
   "peerDependencies": {
     "dayjs": "^1.11.13",
-    "element-plus": "^2.9.0",
     "vue": "^3.2.0"
   },
   "gitHead": "581df2757ad066a5cdd5a2e64500ab33a68279ad"

--- a/components/dialog-alert/package.json
+++ b/components/dialog-alert/package.json
@@ -30,7 +30,6 @@
     "@flash-global66/g-config-provider": "0.0.8",
     "@flash-global66/g-dialog": "0.0.8",
     "@flash-global66/g-image": "0.0.3",
-    "element-plus": "^2.9.7",
     "vue": "^3.2.0"
   },
   "publishConfig": {

--- a/components/dialog/package.json
+++ b/components/dialog/package.json
@@ -32,7 +32,6 @@
     "@flash-global66/g-utils": "^0.15.5"
   },
   "peerDependencies": {
-    "element-plus": "^2.9.7",
     "vue": "^3.2.0"
   },
   "publishConfig": {

--- a/components/drawer/package.json
+++ b/components/drawer/package.json
@@ -32,7 +32,6 @@
     "@flash-global66/g-icon-font": "^0.0.8",
     "@flash-global66/g-overlay": "^0.0.7",
     "@flash-global66/g-teleport": "^0.0.6",
-    "element-plus": "^2.9.0",
     "vue": "^3.2.0"
   },
   "publishConfig": {

--- a/components/dropdown/package.json
+++ b/components/dropdown/package.json
@@ -36,7 +36,6 @@
   },
   "peerDependencies": {
     "@popperjs/core": "^2.11.6",
-    "element-plus": "^2.9.0",
     "vue": "^3.2.0"
   },
   "publishConfig": {

--- a/components/form/package.json
+++ b/components/form/package.json
@@ -33,7 +33,6 @@
     "@flash-global66/g-utils": "^0.15.5"
   },
   "peerDependencies": {
-    "element-plus": "^2.9.0",
     "vue": "^3.2.0"
   },
   "gitHead": "581df2757ad066a5cdd5a2e64500ab33a68279ad"

--- a/components/icon-button/package.json
+++ b/components/icon-button/package.json
@@ -25,7 +25,6 @@
   "peerDependencies": {
     "@flash-global66/g-form": "^0.1.0",
     "@flash-global66/g-icon-font": "^0.24.0",
-    "element-plus": "^2.9.0",
     "vue": "^3.2.0"
   },
   "files": [

--- a/components/inline/package.json
+++ b/components/inline/package.json
@@ -35,7 +35,6 @@
     "@flash-global66/g-utils": "^0.15.5"
   },
   "peerDependencies": {
-    "element-plus": "^2.9.0",
     "vue": "^3.2.0"
   },
   "gitHead": "581df2757ad066a5cdd5a2e64500ab33a68279ad"

--- a/components/input-number/package.json
+++ b/components/input-number/package.json
@@ -37,7 +37,6 @@
     "@flash-global66/g-utils": "^0.15.5"
   },
   "peerDependencies": {
-    "element-plus": "^2.9.0",
     "lodash-unified": "^1.0.3",
     "vue": "^3.2.0"
   },

--- a/components/input-tag/package.json
+++ b/components/input-tag/package.json
@@ -39,7 +39,6 @@
   },
   "peerDependencies": {
     "@vueuse/core": "^13.0.0",
-    "element-plus": "^2.9.0",
     "lodash-unified": "^1.0.3",
     "vue": "^3.2.0"
   },

--- a/components/input/package.json
+++ b/components/input/package.json
@@ -32,7 +32,6 @@
     "@flash-global66/g-form": "^0.2.0",
     "@flash-global66/g-icon-font": "^0.0.8",
     "@vueuse/core": "^12.4.0",
-    "element-plus": "^2.9.0",
     "lodash-unified": "^1.0.3",
     "vue": "^3.2.0"
   },

--- a/components/logo/package.json
+++ b/components/logo/package.json
@@ -36,7 +36,6 @@
   },
   "peerDependencies": {
     "@vueuse/core": "^13.0.0",
-    "element-plus": "^2.0.0",
     "vue": "^3.2.0"
   }
 }

--- a/components/overlay/package.json
+++ b/components/overlay/package.json
@@ -14,7 +14,6 @@
     "url": "https://github.com/Flash-Global66/global-design-system.git"
   },
   "peerDependencies": {
-    "element-plus": "^2.9.0",
     "vue": "^3.2.0"
   },
   "dependencies": {

--- a/components/pagination/package.json
+++ b/components/pagination/package.json
@@ -33,7 +33,6 @@
     "@flash-global66/g-utils": "^0.15.5"
   },
   "peerDependencies": {
-    "element-plus": "^2.9.0",
     "vue": "^3.2.0"
   },
   "gitHead": "581df2757ad066a5cdd5a2e64500ab33a68279ad"

--- a/components/popper/package.json
+++ b/components/popper/package.json
@@ -38,7 +38,6 @@
     "@flash-global66/g-slot": "^0.0.2",
     "@popperjs/core": "^2.11.6",
     "@vueuse/core": "^12.4.0",
-    "element-plus": "^2.9.0",
     "lodash-unified": "^1.0.3",
     "vue": "^3.2.0"
   },

--- a/components/progress/package.json
+++ b/components/progress/package.json
@@ -33,7 +33,6 @@
   },
   "peerDependencies": {
     "@flash-global66/g-icon-font": "^0.5.8",
-    "element-plus": "^2.9.7",
     "vue": "^3.2.0"
   }
 }

--- a/components/radio/package.json
+++ b/components/radio/package.json
@@ -31,7 +31,6 @@
   "peerDependencies": {
     "@flash-global66/g-form": "^0.2.0",
     "@vueuse/core": "^12.4.0",
-    "element-plus": "^2.9.0",
     "vue": "^3.2.0"
   },
   "gitHead": "581df2757ad066a5cdd5a2e64500ab33a68279ad",

--- a/components/scrollbar/package.json
+++ b/components/scrollbar/package.json
@@ -30,7 +30,6 @@
   },
   "peerDependencies": {
     "@vueuse/core": "^12.4.0",
-    "element-plus": "^2.9.0",
     "vue": "^3.2.0"
   },
   "dependencies": {

--- a/components/search-input/package.json
+++ b/components/search-input/package.json
@@ -32,7 +32,6 @@
     "@flash-global66/g-input": "0.3.0",
     "@flash-global66/g-skeleton": "0.0.7",
     "@vueuse/core": "^12.4.0",
-    "element-plus": "^2.9.7",
     "vue": "^3.2.0"
   },
   "publishConfig": {

--- a/components/segmented/package.json
+++ b/components/segmented/package.json
@@ -30,7 +30,6 @@
   },
   "peerDependencies": {
     "@flash-global66/g-form": "^0.2.0",
-    "element-plus": "^2.9.0",
     "vue": "^3.2.0"
   },
   "gitHead": "581df2757ad066a5cdd5a2e64500ab33a68279ad",

--- a/components/select/package.json
+++ b/components/select/package.json
@@ -40,7 +40,6 @@
     "@flash-global66/g-tag": "^0.1.2",
     "@popperjs/core": "^2.11.6",
     "@vueuse/core": "^13.0.0",
-    "element-plus": "^2.9.0",
     "vue": "^3.2.0"
   },
   "gitHead": "581df2757ad066a5cdd5a2e64500ab33a68279ad"

--- a/components/switch/package.json
+++ b/components/switch/package.json
@@ -25,7 +25,6 @@
   "peerDependencies": {
     "@flash-global66/g-form": "^0.2.0",
     "@flash-global66/g-icon-font": "^0.10.0",
-    "element-plus": "^2.9.0",
     "vue": "^3.2.0"
   },
   "publishConfig": {

--- a/components/table/package.json
+++ b/components/table/package.json
@@ -41,7 +41,6 @@
   },
   "peerDependencies": {
     "async-validator": "^4.2.5",
-    "element-plus": "^2.9.0",
     "lodash-unified": "^1.0.3",
     "vue": "^3.2.0"
   },

--- a/components/tag/package.json
+++ b/components/tag/package.json
@@ -33,7 +33,6 @@
   },
   "peerDependencies": {
     "@flash-global66/g-icon-font": "^0.0.8",
-    "element-plus": "^2.9.0",
     "vue": "^3.2.0"
   },
   "gitHead": "581df2757ad066a5cdd5a2e64500ab33a68279ad"

--- a/components/time-picker/package.json
+++ b/components/time-picker/package.json
@@ -40,7 +40,6 @@
   },
   "peerDependencies": {
     "dayjs": "^1.11.13",
-    "element-plus": "^2.9.0",
     "vue": "^3.2.0"
   },
   "gitHead": "581df2757ad066a5cdd5a2e64500ab33a68279ad"

--- a/components/toast/package.json
+++ b/components/toast/package.json
@@ -36,7 +36,6 @@
   },
   "peerDependencies": {
     "@vueuse/core": "^12.4.0",
-    "element-plus": "^2.9.0",
     "vue": "^3.2.0"
   }
 }

--- a/components/tooltip/package.json
+++ b/components/tooltip/package.json
@@ -38,7 +38,6 @@
     "@flash-global66/g-utils": "^0.15.5"
   },
   "peerDependencies": {
-    "element-plus": "^2.9.0",
     "vue": "^3.2.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -945,7 +945,6 @@ __metadata:
     "@flash-global66/g-icon-button": 0.2.2
     "@flash-global66/g-icon-font": 0.6.0
     "@flash-global66/g-progress": 0.2.0
-    element-plus: 2.9.0
     vue: 3.2.0
   languageName: unknown
   linkType: soft
@@ -991,7 +990,6 @@ __metadata:
   peerDependencies:
     "@flash-global66/g-form": ^0.2.0
     "@vueuse/core": ^12.4.0
-    element-plus: ^2.9.0
     lodash-unified: ^1.0.3
     vue: ^3.2.0
   languageName: unknown
@@ -1006,7 +1004,6 @@ __metadata:
     "@flash-global66/g-dropdown": ^0.1.0
     "@flash-global66/g-icon-font": ^0.11.0
     "@flash-global66/g-popover": ^0.0.7
-    element-plus: ^2.9.0
     vue: ^3.2.0
   languageName: unknown
   linkType: soft
@@ -1030,7 +1027,6 @@ __metadata:
     "@flash-global66/g-icon-font": "npm:^0.25.24"
     "@flash-global66/g-utils": "npm:^0.15.5"
   peerDependencies:
-    element-plus: ^2.9.0
     vue: ^3.2.0
   languageName: unknown
   linkType: soft
@@ -1060,7 +1056,6 @@ __metadata:
     "@flash-global66/g-utils": "npm:^0.15.5"
   peerDependencies:
     "@vueuse/core": ^13.0.0
-    element-plus: ^2.0.0
     vue: ^3.2.0
   languageName: unknown
   linkType: soft
@@ -1078,7 +1073,6 @@ __metadata:
     "@flash-global66/g-utils": "npm:^0.15.5"
   peerDependencies:
     dayjs: ^1.11.13
-    element-plus: ^2.9.0
     vue: ^3.2.0
   languageName: unknown
   linkType: soft
@@ -1093,7 +1087,6 @@ __metadata:
     "@flash-global66/g-config-provider": 0.0.8
     "@flash-global66/g-dialog": 0.0.8
     "@flash-global66/g-image": 0.0.3
-    element-plus: ^2.9.7
     vue: ^3.2.0
   languageName: unknown
   linkType: soft
@@ -1110,7 +1103,6 @@ __metadata:
     "@flash-global66/g-teleport": "npm:^0.0.29"
     "@flash-global66/g-utils": "npm:^0.15.5"
   peerDependencies:
-    element-plus: ^2.9.7
     vue: ^3.2.0
   languageName: unknown
   linkType: soft
@@ -1127,7 +1119,6 @@ __metadata:
     "@flash-global66/g-icon-font": ^0.0.8
     "@flash-global66/g-overlay": ^0.0.7
     "@flash-global66/g-teleport": ^0.0.6
-    element-plus: ^2.9.0
     vue: ^3.2.0
   languageName: unknown
   linkType: soft
@@ -1148,7 +1139,6 @@ __metadata:
     "@flash-global66/g-utils": "npm:^0.15.5"
   peerDependencies:
     "@popperjs/core": ^2.11.6
-    element-plus: ^2.9.0
     vue: ^3.2.0
   languageName: unknown
   linkType: soft
@@ -1178,7 +1168,6 @@ __metadata:
     "@flash-global66/g-hooks": "npm:^0.11.13"
     "@flash-global66/g-utils": "npm:^0.15.5"
   peerDependencies:
-    element-plus: ^2.9.0
     vue: ^3.2.0
   languageName: unknown
   linkType: soft
@@ -1204,7 +1193,6 @@ __metadata:
   peerDependencies:
     "@flash-global66/g-form": ^0.1.0
     "@flash-global66/g-icon-font": ^0.24.0
-    element-plus: ^2.9.0
     vue: ^3.2.0
   languageName: unknown
   linkType: soft
@@ -1254,7 +1242,6 @@ __metadata:
     "@flash-global66/g-icon-font": "npm:^0.25.24"
     "@flash-global66/g-utils": "npm:^0.15.5"
   peerDependencies:
-    element-plus: ^2.9.0
     vue: ^3.2.0
   languageName: unknown
   linkType: soft
@@ -1278,7 +1265,6 @@ __metadata:
     "@flash-global66/g-input": "npm:^0.3.30"
     "@flash-global66/g-utils": "npm:^0.15.5"
   peerDependencies:
-    element-plus: ^2.9.0
     lodash-unified: ^1.0.3
     vue: ^3.2.0
   languageName: unknown
@@ -1297,7 +1283,6 @@ __metadata:
     "@flash-global66/g-utils": "npm:^0.15.5"
   peerDependencies:
     "@vueuse/core": ^13.0.0
-    element-plus: ^2.9.0
     lodash-unified: ^1.0.3
     vue: ^3.2.0
   languageName: unknown
@@ -1313,7 +1298,6 @@ __metadata:
     "@flash-global66/g-form": ^0.2.0
     "@flash-global66/g-icon-font": ^0.0.8
     "@vueuse/core": ^12.4.0
-    element-plus: ^2.9.0
     lodash-unified: ^1.0.3
     vue: ^3.2.0
   languageName: unknown
@@ -1342,7 +1326,6 @@ __metadata:
     "@flash-global66/g-utils": "npm:^0.15.5"
   peerDependencies:
     "@vueuse/core": ^13.0.0
-    element-plus: ^2.0.0
     vue: ^3.2.0
   languageName: unknown
   linkType: soft
@@ -1360,7 +1343,6 @@ __metadata:
     "@flash-global66/g-hooks": "npm:^0.11.13"
     "@flash-global66/g-utils": "npm:^0.15.5"
   peerDependencies:
-    element-plus: ^2.9.0
     vue: ^3.2.0
   languageName: unknown
   linkType: soft
@@ -1372,7 +1354,6 @@ __metadata:
     "@flash-global66/g-icon-font": "npm:^0.25.24"
     "@flash-global66/g-utils": "npm:^0.15.5"
   peerDependencies:
-    element-plus: ^2.9.0
     vue: ^3.2.0
   languageName: unknown
   linkType: soft
@@ -1395,7 +1376,6 @@ __metadata:
     "@flash-global66/g-slot": ^0.0.2
     "@popperjs/core": ^2.11.6
     "@vueuse/core": ^12.4.0
-    element-plus: ^2.9.0
     lodash-unified: ^1.0.3
     vue: ^3.2.0
   languageName: unknown
@@ -1408,7 +1388,6 @@ __metadata:
     "@flash-global66/g-utils": "npm:^0.15.5"
   peerDependencies:
     "@flash-global66/g-icon-font": ^0.5.8
-    element-plus: ^2.9.7
     vue: ^3.2.0
   languageName: unknown
   linkType: soft
@@ -1442,7 +1421,6 @@ __metadata:
   peerDependencies:
     "@flash-global66/g-form": ^0.2.0
     "@vueuse/core": ^12.4.0
-    element-plus: ^2.9.0
     vue: ^3.2.0
   languageName: unknown
   linkType: soft
@@ -1468,7 +1446,6 @@ __metadata:
     "@flash-global66/g-utils": "npm:^0.15.5"
   peerDependencies:
     "@vueuse/core": ^12.4.0
-    element-plus: ^2.9.0
     vue: ^3.2.0
   languageName: unknown
   linkType: soft
@@ -1484,7 +1461,6 @@ __metadata:
     "@flash-global66/g-input": 0.3.0
     "@flash-global66/g-skeleton": 0.0.7
     "@vueuse/core": ^12.4.0
-    element-plus: ^2.9.7
     vue: ^3.2.0
   languageName: unknown
   linkType: soft
@@ -1497,7 +1473,6 @@ __metadata:
     "@flash-global66/g-utils": "npm:^0.15.5"
   peerDependencies:
     "@flash-global66/g-form": ^0.2.0
-    element-plus: ^2.9.0
     vue: ^3.2.0
   languageName: unknown
   linkType: soft
@@ -1516,7 +1491,6 @@ __metadata:
     "@flash-global66/g-tag": ^0.1.2
     "@popperjs/core": ^2.11.6
     "@vueuse/core": ^13.0.0
-    element-plus: ^2.9.0
     vue: ^3.2.0
   languageName: unknown
   linkType: soft
@@ -1547,7 +1521,6 @@ __metadata:
   peerDependencies:
     "@flash-global66/g-form": ^0.2.0
     "@flash-global66/g-icon-font": ^0.10.0
-    element-plus: ^2.9.0
     vue: ^3.2.0
   languageName: unknown
   linkType: soft
@@ -1567,7 +1540,6 @@ __metadata:
     "@flash-global66/g-utils": "npm:^0.15.5"
   peerDependencies:
     async-validator: ^4.2.5
-    element-plus: ^2.9.0
     lodash-unified: ^1.0.3
     vue: ^3.2.0
   languageName: unknown
@@ -1580,7 +1552,6 @@ __metadata:
     "@flash-global66/g-utils": "npm:^0.15.5"
   peerDependencies:
     "@flash-global66/g-icon-font": ^0.0.8
-    element-plus: ^2.9.0
     vue: ^3.2.0
   languageName: unknown
   linkType: soft
@@ -1607,7 +1578,6 @@ __metadata:
     "@flash-global66/g-utils": "npm:^0.15.5"
   peerDependencies:
     dayjs: ^1.11.13
-    element-plus: ^2.9.0
     vue: ^3.2.0
   languageName: unknown
   linkType: soft
@@ -1622,7 +1592,6 @@ __metadata:
     "@flash-global66/g-utils": "npm:^0.15.5"
   peerDependencies:
     "@vueuse/core": ^12.4.0
-    element-plus: ^2.9.0
     vue: ^3.2.0
   languageName: unknown
   linkType: soft
@@ -1639,7 +1608,6 @@ __metadata:
     "@flash-global66/g-teleport": "npm:^0.0.29"
     "@flash-global66/g-utils": "npm:^0.15.5"
   peerDependencies:
-    element-plus: ^2.9.0
     vue: ^3.2.0
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
## Qué

Los 32 componentes ya migrados en `ep-extraction-scss` (WU1-WU4) tenían `element-plus` declarado como `peerDependency` pero **ya no lo usan** — ni en SCSS ni en JS/TS. Era cruft dejado de antes de la migración.

Verificado con grep en todo el repo: cero `@use`/`@forward` de rutas de element-plus SCSS y cero `from 'element-plus'` real en estos 32 paquetes.

## No tocado (a propósito)

Las **8 islas JS** (badge, menu+3 subcomponentes, popover, radio-group, form-item, skeleton+item, infinite-scroll) + `config-provider` sí siguen necesitando `element-plus` de verdad — renderizan componentes Vue reales de EP o hacen bootstrap de config. Esas quedan intactas.

## Verificación

- `yarn build` (41 paquetes) ✅
- `yarn test:run` (51 archivos, 345 tests) ✅
- `yarn install` sin warnings relacionados a element-plus
- `yarn.lock`: -32 líneas (entradas redundantes de las peerDeps removidas)

## Alcance

Puro housekeeping de dependencias declaradas. Sin cambios de código ni de API pública.