### PR TITLE
refactor(badge): migrate off element-plus (ep-extraction-v6 WU1)

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -26,12 +26,19 @@ module.exports = {
       // never re-introduce a direct dependency on it. Covers nested-layout
       // implementations (components/*/src/**, common/*/src/**) AND flat-layout
       // package roots + barrels (components/*/*.ts, e.g. overlay/overlay.ts,
-      // overlay/index.ts). The flat-layout glob is required because packages
-      // like `overlay` ship implementation at the package root, not under src/.
-      files: ['components/*/src/**', 'common/*/src/**', 'components/*/*.ts'],
+      // overlay/index.ts; components/*/*.vue, e.g. badge/Badge.vue,
+      // config-provider/ConfigProvider.vue). The flat-layout globs are
+      // required because packages like `overlay`, `badge`, and
+      // `config-provider` ship implementation at the package root, not
+      // under src/.
+      files: [
+        'components/*/src/**',
+        'common/*/src/**',
+        'components/*/*.ts',
+        'components/*/*.vue',
+      ],
       excludedFiles: [
         // Islands: intentionally wrap/re-export a real element-plus component.
-        'components/badge/**',
         'components/menu/**',
         'components/config-provider/**',
         'components/popover/**',

--- a/components/badge/Badge.vue
+++ b/components/badge/Badge.vue
@@ -1,22 +1,30 @@
 <template>
-  <el-badge v-bind="filteredAttrs">
+  <div :class="ns.b()">
     <slot />
-  </el-badge>
+    <transition :name="`${ns.namespace.value}-zoom-in-center`">
+      <sup
+        v-show="!hidden && (content || isDot || !!$slots.content)"
+        :class="contentClasses"
+        :style="contentStyle"
+      >
+        <slot name="content" :value="content">{{ content }}</slot>
+      </sup>
+    </transition>
+  </div>
 </template>
 
 <script lang="ts">
 import { defineComponent, PropType, computed, StyleValue } from 'vue';
-import { ElBadge } from 'element-plus';
+import { useNamespace } from '@flash-global66/g-utils';
 
 // TYPES
 import { BadgeType } from './badge.type';
 
+const addUnit = (value: number, defaultUnit = 'px'): string =>
+  value ? `${value}${defaultUnit}` : '';
 
 export default defineComponent({
   name: 'GBadge',
-  components: {
-    ElBadge,
-  },
   props: {
     /**
      * @description display value.
@@ -63,14 +71,14 @@ export default defineComponent({
      */
     badgeStyle: {
       type: [String, Object, Array] as PropType<StyleValue>,
-      default: () => ({})
+      default: () => ({}),
     },
     /**
      * @description set offset of the badge
      */
     offset: {
       type: Array as unknown as PropType<[number, number]>,
-      default: () => [0, 0]
+      default: () => [0, 0],
     },
     /**
      * @description custom class name of badge
@@ -90,18 +98,51 @@ export default defineComponent({
     'blur',
     'focus',
   ],
-  setup(props, { emit, slots, attrs }) {
-    const filteredAttrs = computed(() => {
-      const result = { ...props, ...attrs } as Record<string, unknown>;
-      const excludeKeys = [];
+  setup(props, { slots }) {
+    const ns = useNamespace('badge');
 
-      excludeKeys.forEach(key => delete result[key]);
+    const content = computed(() => {
+      if (props.isDot) return '';
 
-      return result;
+      const { value, max } = props;
+      const isNumericValue = typeof value === 'number';
+      const isNumericMax = typeof max === 'number';
+
+      if (isNumericValue && isNumericMax) {
+        return max < value ? `${max}+` : `${value}`;
+      }
+
+      return `${value}`;
+    });
+
+    const contentClasses = computed(() => [
+      ns.e('content'),
+      ns.em('content', props.type),
+      ns.is('fixed', !!slots.default),
+      ns.is('dot', props.isDot),
+      ns.is('hide-zero', !props.showZero && props.value === 0),
+      props.badgeClass,
+    ]);
+
+    const contentStyle = computed(() => {
+      const [offsetX, offsetY] = props.offset;
+
+      return [
+        {
+          backgroundColor: props.color,
+          marginRight: addUnit(-offsetX),
+          marginTop: addUnit(offsetY),
+        },
+        props.badgeStyle ?? {},
+      ];
     });
 
     return {
-      filteredAttrs,
-    }
-  }
-});</script>
+      ns,
+      content,
+      contentClasses,
+      contentStyle,
+    };
+  },
+});
+</script>

--- a/components/badge/badge.styles.scss
+++ b/components/badge/badge.styles.scss
@@ -1,4 +1,66 @@
-@use "element-plus/theme-chalk/src/badge.scss" as *;
+// Port byte-exact de element-plus/theme-chalk/src/badge.scss
+// Único cambio respecto al original: los `@use` internos se reenrutan a los
+// módulos planos ya portados de @flash-global66/g-utils (mixins, var-mixins,
+// tokens), en lugar de los mixins/vars propios de element-plus. El resto del
+// contenido (selectores, mapa `$badge`, valores) se preserva byte a byte.
+@use '@flash-global66/g-utils/mixins' as *;
+@use '@flash-global66/g-utils/var-mixins' as *;
+@use '@flash-global66/g-utils/tokens' as *;
+
+@include b(badge) {
+  @include set-component-css-var('badge', $badge);
+
+  position: relative;
+  vertical-align: middle;
+  display: inline-block;
+  width: fit-content;
+
+  @include e(content) {
+    background-color: getCssVar('badge', 'bg-color');
+    border-radius: getCssVar('badge', 'radius');
+    color: getCssVar('color', 'white');
+
+    display: inline-flex;
+    justify-content: center;
+    align-items: center;
+
+    font-size: getCssVar('badge', 'font-size');
+    height: getCssVar('badge', 'size');
+    padding: 0 getCssVar('badge', 'padding');
+    white-space: nowrap;
+    border: 1px solid getCssVar('bg-color');
+
+    @include when(fixed) {
+      position: absolute;
+      top: 0;
+      right: calc(1px + #{getCssVar('badge', 'size')} / 2);
+      transform: translateY(-50%) translateX(100%);
+      z-index: getCssVar('index', 'normal');
+
+      @include when(dot) {
+        right: 5px;
+      }
+    }
+
+    @include when(dot) {
+      height: 8px;
+      width: 8px;
+      padding: 0;
+      right: 0;
+      border-radius: 50%;
+    }
+
+    @include when(hide-zero) {
+      display: none;
+    }
+
+    @each $type in (primary, success, warning, info, danger) {
+      @include m($type) {
+        background-color: getCssVar('color', $type);
+      }
+    }
+  }
+}
 
 .gui-badge__content {
   font-size: 10px;

--- a/components/badge/package.json
+++ b/components/badge/package.json
@@ -7,6 +7,9 @@
     ".": "./index.ts",
     "./badge.styles.scss": "./badge.styles.scss"
   },
+  "dependencies": {
+    "@flash-global66/g-utils": "^0.15.5"
+  },
   "publishConfig": {
     "registry": "https://npm.pkg.github.com"
   },

--- a/components/badge/tests/Badge.spec.ts
+++ b/components/badge/tests/Badge.spec.ts
@@ -1,0 +1,172 @@
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/vue';
+import Badge from '../Badge.vue';
+
+describe('Badge (render nativo — sin ElBadge)', () => {
+  it('renderiza la clase base gui-badge y el slot default', () => {
+    const { container, getByText } = render(Badge, {
+      props: { value: 5 },
+      slots: { default: 'Bandeja' },
+    });
+    const root = container.firstElementChild as HTMLElement;
+    expect(root).toHaveClass('gui-badge');
+    expect(getByText('Bandeja')).toBeInTheDocument();
+  });
+
+  it('muestra el value como contenido con la clase de tipo por defecto (danger)', () => {
+    const { getByText } = render(Badge, { props: { value: 5 } });
+    const content = getByText('5');
+    expect(content).toHaveClass(
+      'gui-badge__content',
+      'gui-badge__content--danger',
+    );
+  });
+
+  it('trunca el value cuando excede max: "{max}+"', () => {
+    const { getByText } = render(Badge, { props: { value: 120, max: 99 } });
+    expect(getByText('99+')).toBeInTheDocument();
+  });
+
+  it('no trunca el value cuando es menor o igual a max', () => {
+    const { getByText } = render(Badge, { props: { value: 42, max: 99 } });
+    expect(getByText('42')).toBeInTheDocument();
+  });
+
+  it('isDot oculta el texto y aplica la clase is-dot', () => {
+    const { container } = render(Badge, { props: { value: 5, isDot: true } });
+    const content = container.querySelector(
+      '.gui-badge__content',
+    ) as HTMLElement;
+    expect(content).toHaveClass('is-dot');
+    expect(content).toHaveTextContent('');
+  });
+
+  it('hidden oculta el badge (display:none) aunque haya value', () => {
+    const { container } = render(Badge, { props: { value: 5, hidden: true } });
+    const content = container.querySelector(
+      '.gui-badge__content',
+    ) as HTMLElement;
+    expect(content).not.toBeVisible();
+  });
+
+  it('showZero=false aplica is-hide-zero cuando value es 0', () => {
+    const { container } = render(Badge, {
+      props: { value: 0, showZero: false },
+    });
+    const content = container.querySelector(
+      '.gui-badge__content',
+    ) as HTMLElement;
+    expect(content).toHaveClass('is-hide-zero');
+  });
+
+  it('showZero=true (default) NO aplica is-hide-zero cuando value es 0', () => {
+    const { container } = render(Badge, { props: { value: 0 } });
+    const content = container.querySelector(
+      '.gui-badge__content',
+    ) as HTMLElement;
+    expect(content).not.toHaveClass('is-hide-zero');
+    expect(content).toBeVisible();
+  });
+
+  it('type aplica el modificador correspondiente', () => {
+    const { container } = render(Badge, {
+      props: { value: 1, type: 'success' },
+    });
+    const content = container.querySelector(
+      '.gui-badge__content',
+    ) as HTMLElement;
+    expect(content).toHaveClass('gui-badge__content--success');
+    expect(content).not.toHaveClass('gui-badge__content--danger');
+  });
+
+  it('color customiza el background-color inline', () => {
+    const { container } = render(Badge, {
+      props: { value: 1, color: 'rgb(1, 2, 3)' },
+    });
+    const content = container.querySelector(
+      '.gui-badge__content',
+    ) as HTMLElement;
+    expect(content).toHaveStyle({ backgroundColor: 'rgb(1, 2, 3)' });
+  });
+
+  it('offset aplica margin-right invertido y margin-top en px', () => {
+    const { container } = render(Badge, {
+      props: { value: 1, offset: [10, 5] },
+    });
+    const content = container.querySelector(
+      '.gui-badge__content',
+    ) as HTMLElement;
+    expect(content).toHaveStyle({ marginRight: '-10px', marginTop: '5px' });
+  });
+
+  it('badgeStyle se combina con los estilos calculados', () => {
+    const { container } = render(Badge, {
+      props: { value: 1, badgeStyle: { fontWeight: 'bold' } },
+    });
+    const content = container.querySelector(
+      '.gui-badge__content',
+    ) as HTMLElement;
+    expect(content).toHaveStyle({ fontWeight: 'bold' });
+  });
+
+  it('badgeClass agrega una clase custom al contenido', () => {
+    const { container } = render(Badge, {
+      props: { value: 1, badgeClass: 'custom-badge' },
+    });
+    const content = container.querySelector(
+      '.gui-badge__content',
+    ) as HTMLElement;
+    expect(content).toHaveClass('custom-badge');
+  });
+
+  it('el slot "content" reemplaza el contenido usando el scope { value }', () => {
+    const { getByText } = render(Badge, {
+      props: { value: 7 },
+      slots: { content: (props: { value: string }) => `custom:${props.value}` },
+    });
+    expect(getByText('custom:7')).toBeInTheDocument();
+  });
+
+  it('aplica is-fixed cuando hay slot default (badge posicionado sobre el contenido envuelto)', () => {
+    const { container } = render(Badge, {
+      props: { value: 5 },
+      slots: { default: 'Wrapped' },
+    });
+    const content = container.querySelector(
+      '.gui-badge__content',
+    ) as HTMLElement;
+    expect(content).toHaveClass('is-fixed');
+  });
+
+  it('NO aplica is-fixed cuando no hay slot default (badge standalone)', () => {
+    const { container } = render(Badge, { props: { value: 5 } });
+    const content = container.querySelector(
+      '.gui-badge__content',
+    ) as HTMLElement;
+    expect(content).not.toHaveClass('is-fixed');
+  });
+
+  it('atributos extra (class, id) hacen fallthrough sobre el div raíz', () => {
+    const { container } = render(Badge, {
+      props: { value: 1 },
+      attrs: { class: 'foo', id: 'my-badge' },
+    });
+    const root = container.firstElementChild as HTMLElement;
+    expect(root).toHaveClass('gui-badge', 'foo');
+    expect(root).toHaveAttribute('id', 'my-badge');
+  });
+
+  it('resuelve el namespace gui-badge sin necesitar un ConfigProvider ancestro (contrato nuevo, ya no cae a el-badge*)', () => {
+    const { container } = render(Badge, {
+      props: { value: 5 },
+    });
+    const root = container.firstElementChild as HTMLElement;
+    const content = container.querySelector(
+      '.gui-badge__content',
+    ) as HTMLElement;
+    expect(root).toHaveClass('gui-badge');
+    expect(root).not.toHaveClass('el-badge');
+    expect(content).toHaveClass('gui-badge__content');
+    expect(content).not.toHaveClass('el-badge__content');
+  });
+});

--- a/openspec/changes/ep-extraction-v6/design.md
+++ b/openspec/changes/ep-extraction-v6/design.md
@@ -1,0 +1,67 @@
+# Design: EP Extraction v6 — Close out the element-plus removal
+
+## Technical Approach
+
+Fifth JS-migration in the `ep-extraction-vN` series; follow the **v4/v5 pattern verbatim**: port EP's own component/directive source into the DS package, re-point every EP import to an already-DS-owned package (`@flash-global66/g-*`) or a DS hook, keep behavior byte-faithful, validate live in front-b2b via `yarn-link` before "done", and drop each package from `.eslintrc.cjs` excludedFiles as it lands. No new architecture is invented. Delivery is stacked work-unit PRs inside one change; each DS unit is Lerna-published before the front-b2b units consume it. Strict TDD (`yarn test:run`).
+
+## Migration technique per island
+
+| Island                   | Technique                                                                                            | EP source removed                    | Re-point / target                                                                                                                                                              |
+| ------------------------ | ---------------------------------------------------------------------------------------------------- | ------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| badge                    | Native `GBadge` render + ported `badge.scss`                                                         | `ElBadge`                            | none (self-contained template)                                                                                                                                                 |
+| radio-group              | Native `<div role=radiogroup>` + provide/inject (value/size/disabled)                                | `ElRadioGroup`                       | own context key; **fix latent bug** (see Decision 4)                                                                                                                           |
+| skeleton + skeleton-item | Ported template + SCSS animation states                                                              | `ElSkeleton/Item`                    | none                                                                                                                                                                           |
+| infinite-scroll          | From-scratch Vue directive (port EP `v-infinite-scroll`) replacing bare re-export                    | `ElInfiniteScroll`                   | export DS directive from `index.ts`                                                                                                                                            |
+| form-item                | Ported `ElFormItem` template over DS `g-form` validation core                                        | `ElFormItem`                         | DS `formContextKey`/`formItemContextKey` (g-form)                                                                                                                              |
+| popover                  | Port EP `popover.vue`, render `<g-tooltip>` internally                                               | `ElPopover` + 3 composables          | `useTooltipTriggerProps`/`useTooltipContentProps` → `@flash-global66/g-tooltip`; `dropdownProps` → `@flash-global66/g-dropdown`                                                |
+| menu (×4)                | Port EP menu family preserving shared provide/inject state machine                                   | `ElMenu/Item/Sub/ItemGroup`          | one shared context module (see Decision 1)                                                                                                                                     |
+| time-picker              | Default `clearIcon` to `true` (boolean); drop `CircleClose` import                                   | `@element-plus/icons-vue`            | none — `picker.vue` already renders `<g-icon-font name="regular times">` unconditionally; `clearIcon` is only ever used as a truthy `v-if` gate, never rendered as a component |
+| config-provider (LAST)   | Replace EP `provideGlobalConfig` with DS `provideGlobalConfig` from g-hooks; own brand SCSS emission | `element-plus` `provideGlobalConfig` | g-hooks `provideGlobalConfig`; keep `provide(namespaceContextKey,'gui')`                                                                                                       |
+
+## Architecture Decisions
+
+### Decision 1 — Menu shared state = ONE context module
+
+**Choice**: Port `menuContextKey`/`subMenuContextKey` into a single shared module both parent and descendants import; migrate all 4 components in one WU, done LAST among islands.
+**Alternatives**: per-file keys; split WUs.
+**Rationale**: v4's forward-ref lesson — split provide/inject symbols create two distinct `Symbol()`s and break the handshake. Prove the provide/inject technique first on radio-group + badge, then apply to the highest-risk unit.
+
+### Decision 2 — config-provider consumer safety (enumerated, zero behavioral change)
+
+**Choice**: config-provider calls DS `provideGlobalConfig({ namespace: 'gui' })` and keeps `namespaceContextKey`.
+**Consumers verified**: `useGlobalConfig` → **dialog only** (reads `namespace`, default `'gui'` — `use-dialog.ts:60`). `useEmptyValues` → select + time-picker, which already inject the DS `gEmptyValuesContextKey` that the current EP island never provides, so they already fall back to default. Retiring EP `provideGlobalConfig` therefore keeps dialog resolving `'gui'` and leaves emptyValues consumers untouched.
+**Rationale**: The MED risk dissolves once the full consumer set is enumerated — no hidden EP-context reader exists.
+
+### Decision 3 — clearIcon is a dead-weight prop, not an icon swap
+
+**Choice**: `clearIcon`'s type stays `string | Component` (no breaking prop-type change), but its default becomes `true` and the `CircleClose` import is deleted. Verified in `common/picker.vue:77` and `:129` — the prop is only ever read as `v-if="clearIcon"` (a truthy check); the actual glyph is already hardcoded as `<g-icon-font name="regular times">`, unconditionally rendered, unrelated to this prop's value. There is no component to swap.
+**Sequencing**: still done BEFORE the root EP-removal WU — root removal also drops transitive `@element-plus/icons-vue`; a live `CircleClose` import would break the build. Root WU asserts zero live imports of BOTH `element-plus` and `@element-plus/icons-vue`.
+
+### Decision 4 — fix the radio-group latent bug in-WU
+
+**Choice**: `RadioGroup.vue:15` imports `TypeRadioSize/EnumRadioSize` from non-existent `../radio/radio.type`; create/inline that types module during the radio-group WU.
+**Rationale**: v6 removes radio-group from ESLint excludedFiles (`--max-warnings 0`); the island mask that hid this defect is gone, so it must be resolved now.
+
+## Work-unit sequencing (WHY)
+
+1. badge → 2. radio-group → 3. skeleton → 4. infinite-scroll (small, independent, prove provide/inject) → 5. form-item → 6. popover → 7. **menu** (highest, pattern proven) → 8. time-picker icon → 9. **config-provider (LAST DS unit)** → 10. root `package.json`/`yarn.lock` removal + g-hooks EP test-import cleanup → 11. front-b2b 8× g-\* version bumps → 12. front-b2b EP removal (`package.json:110`, `vite.config.ts:102`).
+
+- **config-provider last** on the DS side: it gates root removal — once it stops importing EP, nothing in `components/` imports EP; it also satisfies scss-token-foundation **task 4.5** (DS-owned brand emission), which lets time-picker drop `@use "element-plus/theme-chalk/src/base.scss"`. This design formally **reverses** scss-token-foundation's "Entangled Islands Remain Deferred" for config-provider only.
+- **front-b2b bumps last of all**: they pin post-migration versions that only exist after each DS package is Lerna-published; bumping earlier points at unpublished versions.
+- **front-b2b EP removal final**: safe only once every consumed g-\* package is EP-free.
+
+## Testing Strategy
+
+| Layer       | What                                                                                                                     | How                                                                 |
+| ----------- | ------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------- |
+| Unit        | render, props, emits, provide/inject handshake per WU (menu open/close/select/collapse; radio-group value/size/disabled) | `yarn test:run`, strict TDD (test first)                            |
+| Integration | live render in front-b2b                                                                                                 | mandatory `yarn-link` validation before each unit is "done"         |
+| Lint        | zero EP imports                                                                                                          | ESLint `--max-warnings 0`; remove package from excludedFiles per WU |
+
+## Migration / Rollout
+
+Per-unit PRs; revert the offending PR to roll back. Root removal and both front-b2b units are separate final PRs, revertable without touching migrated islands (restore the two b2b lines / the root dep).
+
+## Open Questions
+
+- None blocking. Popover's native path assumes EP's popover→tooltip composition maps cleanly onto `g-tooltip`; confirm slot/reference forwarding during the popover WU.

--- a/openspec/changes/ep-extraction-v6/proposal.md
+++ b/openspec/changes/ep-extraction-v6/proposal.md
@@ -1,0 +1,81 @@
+# Proposal: EP Extraction v6 — Close out the element-plus removal initiative
+
+## Intent
+
+Final chapter of the ep-extraction-vN initiative (v2–v5 + scss-token-foundation archived). Nine DS packages still import `element-plus` at runtime, forcing the sole remaining root `"element-plus": "2.9.7"` (package.json line 62) to stay. Migrating them off EP lets us delete that dependency (and its transitive `@element-plus/icons-vue`), and lets consumer `front-b2b` drop its own EP workaround. This reverses the "permanent islands" classification from v4 — these are now in scope.
+
+## Scope
+
+### In Scope (DS-side island migrations, then downstream cleanup)
+
+- `badge` — replace `ElBadge` render with native `GBadge` + ported SCSS
+- `menu` family (Menu, MenuItem, MenuSub, MenuItemGroup) — largest unit; shared provide/inject state machine
+- `popover` — native render reusing already-DS `g-popper`/`g-tooltip`; own prop/composable surface
+- `radio-group` — provide/inject value/size/disabled context
+- `form-item` — presentational wrapper over already-DS `g-form` validation core
+- `skeleton` + `skeleton-item` — presentational animation states
+- `infinite-scroll` — from-scratch Vue directive replacing bare `ElInfiniteScroll` re-export
+- `time-picker` — swap `CircleClose` from `@element-plus/icons-vue` to `g-icon-font` (input.ts precedent)
+- `config-provider` (LAST) — retire `provideGlobalConfig` bridge + EP SCSS forward chain; unblocks scss-token-foundation task 4.5
+- Remove root `element-plus` dependency + prune yarn.lock; drop g-hooks test-only EP imports
+- **front-b2b (final, separate units):** (a) bump 8 declared `@flash-global66/g-*` deps to post-migration versions; (b) remove `element-plus` from `package.json` line 110 and `vite.config.ts` optimizeDeps.include line 102
+
+### Out of Scope
+
+- g-utils `styles/*.scss` EP `@forward`/`@use` — intentional permanent namespace/token bridge from scss-token-foundation; NOT a leftover
+- Re-litigating archived specs (scss-token-foundation, v2–v5)
+- front-admin (no EP dependency)
+- CHANGELOG/comment historical EP mentions
+
+## Capabilities
+
+### New Capabilities
+
+- None (continues existing migration capabilities)
+
+### Modified Capabilities
+
+- `eslint-ep-import-guard`: remove the 9 packages from `.eslintrc.cjs` excludedFiles as each migrates
+- `scss-token-foundation`: config-provider migration satisfies deferred task 4.5 (DS-owned brand emission)
+
+## Approach
+
+Chained/stacked work-unit PRs within one SDD change, exactly as v4/v5 delivered. Order: small independent islands (badge, radio-group, skeleton, infinite-scroll) → form-item → popover → menu → time-picker icon → config-provider (LAST, gates root EP removal) → root package.json/yarn.lock removal + test cleanup → front-b2b version bumps → front-b2b EP removal. Each DS unit validated live in front-b2b via local yarn-link before it is considered done (mandatory carried-forward convention). Strict TDD active.
+
+## Affected Areas
+
+| Area                                                                                             | Impact   | Description                           |
+| ------------------------------------------------------------------------------------------------ | -------- | ------------------------------------- |
+| `components/{badge,menu,popover,radio-group,form-item,skeleton,infinite-scroll,config-provider}` | Modified | Native render + ported SCSS           |
+| `components/time-picker/src/common/props.ts`                                                     | Modified | Icon swap to g-icon-font              |
+| `common/g-hooks/tests/composables/{useGlobalConfig,useLocale}.spec.ts`                           | Modified | Drop EP negative-assertion imports    |
+| root `package.json` / `yarn.lock`                                                                | Modified | Remove element-plus 2.9.7             |
+| `../front-b2b/package.json`                                                                      | Modified | Bump 8 g-\* deps; remove element-plus |
+| `../front-b2b/vite.config.ts`                                                                    | Modified | Remove optimizeDeps.include EP entry  |
+
+## Risks
+
+| Risk                                                               | Likelihood | Mitigation                                                                               |
+| ------------------------------------------------------------------ | ---------- | ---------------------------------------------------------------------------------------- |
+| Menu family under-sized (4 sub-components, shared state)           | High       | Dedicated last-among-islands unit; prove pattern on radio-group/badge first              |
+| Retiring `provideGlobalConfig` breaks a hidden EP-context consumer | Med        | Design MUST enumerate every remaining consumer of EP config-context shape before removal |
+| Dropping root EP breaks time-picker icon                           | Med        | Sequence icon swap as precondition, not afterthought                                     |
+| front-b2b bump uses unpublished versions                           | Med        | Bump only after each DS package is Lerna-published; b2b real-copy validation             |
+
+## Rollback Plan
+
+Per-unit: each work unit is its own PR; revert the offending PR. Root EP removal and front-b2b changes are separate final PRs — revert independently without touching migrated islands. front-b2b EP removal is reversible by restoring the two lines.
+
+## Dependencies
+
+- Published post-migration versions of all 9 DS packages (front-b2b units depend on these)
+- config-provider migration must land before root EP removal
+
+## Success Criteria
+
+- [ ] Zero live `element-plus` / `@element-plus/icons-vue` imports across `components/` and `common/`
+- [ ] Root `package.json` has no `element-plus`; yarn.lock pruned
+- [ ] Each DS unit validated live in front-b2b via yarn-link before merge
+- [ ] front-b2b `package.json` + `vite.config.ts` element-plus-free; 8 g-\* deps bumped
+- [ ] scss-token-foundation task 4.5 satisfied (config-provider owns brand emission)
+- [ ] ESLint `--max-warnings 0` green; migrated packages removed from excludedFiles

--- a/openspec/changes/ep-extraction-v6/specs/element-plus-independence/spec.md
+++ b/openspec/changes/ep-extraction-v6/specs/element-plus-independence/spec.md
@@ -1,0 +1,145 @@
+# Spec: element-plus-independence
+
+> Artifact store: hybrid. Change: `ep-extraction-v6`. New capability — closes the
+> final 9 element-plus-coupled DS packages (the former "permanent islands") plus
+> root and consumer cleanup, completing the `ep-extraction-vN` initiative
+> (v2-v5 + `scss-token-foundation` already archived).
+
+## Purpose
+
+Migrate the last DS packages still importing `element-plus` at runtime — badge,
+menu family (Menu/MenuItem/MenuSub/MenuItemGroup), popover, radio-group,
+form-item, skeleton family (Skeleton/SkeletonItem), infinite-scroll,
+time-picker's icon prop, and config-provider's JS bridge — off `element-plus`,
+then remove the root `element-plus` dependency and close the two front-b2b
+cleanup units, with zero public API or visual regression.
+
+## Requirements
+
+### Requirement: Zero EP Imports Per Island
+
+For each in-scope package (`badge`, `menu`, `popover`, `radio-group`,
+`form-item`, `skeleton`, `infinite-scroll`, `time-picker`, `config-provider`),
+no file under `components/<pkg>/src/**` or `components/<pkg>/index.ts` MUST
+import any specifier starting with `element-plus` or
+`@element-plus/icons-vue`.
+
+#### Scenario: Grep audit passes per island
+
+- GIVEN a migrated package from the in-scope list
+- WHEN `grep -rE "from ['\"](element-plus|@element-plus/icons-vue)"
+components/<pkg>/src/ components/<pkg>/index.ts` runs
+- THEN zero matches are returned
+
+#### Scenario: Time-picker icon swap verified
+
+- GIVEN `time-picker`'s icon prop definitions
+- WHEN inspected after migration
+- THEN `CircleClose` is sourced from `g-icon-font`, not
+  `@element-plus/icons-vue`, following the `components/input/src/input.ts`
+  precedent
+
+### Requirement: Public API and Visual Parity Preserved
+
+Each migrated package's props, emits, slots, and exported types MUST be
+identical before and after migration, and rendered visual output MUST be
+unchanged.
+
+#### Scenario: Consumer usage compiles and renders unchanged
+
+- GIVEN a fixed set of props/emits/slots usage for one in-scope package,
+  exercised before and after migration
+- WHEN compared
+- THEN no prop/emit/slot/exported type is added, removed, renamed, or
+  retyped, and rendered output/styles are unchanged
+
+#### Scenario: Menu family shared state preserved
+
+- GIVEN Menu/MenuItem/MenuSub/MenuItemGroup's provide/inject state machine
+- WHEN migrated off element-plus internals
+- THEN descendants read the identical provided keys/shape as before migration
+
+### Requirement: Config-Provider Context Shape Preserved
+
+config-provider's retirement of `provideGlobalConfig` MUST preserve the exact
+context shape (injection keys, provided value structure) consumed by every
+downstream component currently reading the EP/DS config context, and MUST NOT
+regress `scss-token-foundation`'s already-shipped guarantees.
+
+#### Scenario: Every remaining consumer enumerated before removal
+
+- GIVEN the set of components injecting the EP config context today
+- WHEN `provideGlobalConfig` is retired
+- THEN each enumerated consumer resolves the same locale/size/zIndex/namespace
+  defaults via the DS-native replacement
+
+#### Scenario: scss-token-foundation guarantees not regressed
+
+- GIVEN `scss-token-foundation`'s shipped requirements (Byte-Exact CSS Parity,
+  DS-Owned Token Generation, Config-Provider Is DS-Native)
+- WHEN config-provider's remaining JS bridge is retired in this change
+- THEN those requirements continue to hold with no diff in generated CSS or
+  namespace resolution
+
+### Requirement: Root EP Removal Is Gated
+
+Removing `"element-plus"` (and `@element-plus/icons-vue`) from the root
+`package.json` MUST be gated on all 9 in-scope packages passing the zero
+EP imports check AND on `config-provider` migrating last (sequenced after
+every other island).
+
+#### Scenario: Root removal blocked until gate clears
+
+- GIVEN one or more of the 9 packages still importing element-plus
+- WHEN root `package.json`/`yarn.lock` removal is attempted
+- THEN it MUST NOT proceed
+
+#### Scenario: Root removal succeeds after gate clears
+
+- GIVEN all 9 packages pass the grep audit and `config-provider` is migrated
+- WHEN root `element-plus`/`@element-plus/icons-vue` are removed from
+  `package.json` and `yarn.lock` is pruned
+- THEN `yarn install` and `yarn build` succeed with zero `element-plus`
+  resolution anywhere in the workspace
+
+### Requirement: front-b2b Version Bump and Cleanup
+
+front-b2b's `package.json` MUST bump the 8 affected `@flash-global66/g-*`
+deps (`g-badge`, `g-config-provider`, `g-form-item`, `g-infinite-scroll`,
+`g-menu`, `g-popover`, `g-skeleton`, `g-time-picker` — NOT `g-radio-group`,
+not a direct b2b dep) to their published post-migration versions, and MUST
+remove its own `element-plus` dependency (`package.json:110`) and the
+`vite.config.ts:102` `optimizeDeps.include` EP workaround entry, only after
+each bumped package is Lerna-published and yarn-link validated.
+
+#### Scenario: Version bump uses published versions only
+
+- GIVEN a DS package pending front-b2b bump
+- WHEN front-b2b's `package.json` is edited
+- THEN the pinned version matches an already-published Lerna release, not an
+  in-progress local build
+
+#### Scenario: front-b2b builds and runs EP-free
+
+- GIVEN the 8 version bumps applied and the `element-plus`/`optimizeDeps`
+  workaround removed
+- WHEN front-b2b is built
+- THEN the build succeeds with no `element-plus` resolution and no
+  regression in the migrated components' consuming screens
+
+## Non-Goals
+
+- `g-utils` `styles/*.scss` EP `@forward`/`@use` bridge (intentional
+  `scss-token-foundation` namespace substrate — not removed)
+- Re-litigating archived specs (`scss-token-foundation`, v2-v5)
+- front-admin changes (no EP dependency)
+- CHANGELOG/comment historical EP mentions
+
+## References
+
+- Depends on: `openspec/specs/eslint-ep-import-guard/spec.md`,
+  `openspec/specs/scss-token-foundation/spec.md`,
+  `openspec/specs/popper-overlay-migration/spec.md` (precedent),
+  `openspec/specs/form-control-migration/spec.md` (precedent)
+- Change: `ep-extraction-v6` (proposal obs #328 /
+  `openspec/changes/ep-extraction-v6/proposal.md`)

--- a/openspec/changes/ep-extraction-v6/specs/eslint-ep-import-guard/spec.md
+++ b/openspec/changes/ep-extraction-v6/specs/eslint-ep-import-guard/spec.md
@@ -1,0 +1,69 @@
+# Delta for eslint-ep-import-guard
+
+> Artifact store: hybrid. Change: `ep-extraction-v6`. Base spec:
+> `openspec/specs/eslint-ep-import-guard/spec.md`.
+
+## MODIFIED Requirements
+
+### Requirement: island-override-exclusion
+
+The rule MUST include exclusions only for packages not yet migrated off
+element-plus internals, so their legitimate element-plus imports are not
+blocked. As of `ep-extraction-v4`, `focus-trap`, `slot`, `overlay`,
+`scrollbar`, `popper`, `tooltip`, `select`, `dropdown`, `dialog`,
+`date-picker`, `time-picker`, `input-tag`, and `inline` are migrated and
+MUST NOT appear in `excludedFiles`. As of `ep-extraction-v6`, the former
+"8 permanent islands" — `badge`, `menu`, `config-provider`, `popover`,
+`radio-group`, `form-item`, `skeleton`, `infinite-scroll` — are ALSO migrated
+and MUST NO LONGER appear in `excludedFiles`; no package retains a
+"permanent island" classification after this change. `toast`, `table`,
+`pagination`, `collapse`, and `input-number` remain excluded (still
+deferred, out of scope for `ep-extraction-v6`).
+(Previously: classified those 8 packages as permanent islands exempt from
+the guard forever; v6 reverses that and migrates all 8.)
+
+#### Scenario: v4-migrated packages are no longer excluded
+
+- GIVEN the 13 v4 packages removed from `excludedFiles`
+- WHEN a file under `components/dropdown/src/**` (or any of the other 12)
+  imports `from 'element-plus'`
+- THEN ESLint reports error `'element-plus' import is restricted`
+
+#### Scenario: v6-migrated packages are no longer excluded
+
+- GIVEN the 8 former "permanent island" packages removed from `excludedFiles`
+- WHEN a file under `components/badge/src/**` (or any of the other 7)
+  imports `from 'element-plus'`
+- THEN ESLint reports error `'element-plus' import is restricted`
+
+#### Scenario: remaining deferred packages stay excluded
+
+- GIVEN `table`, `pagination`, `collapse`, `input-number`, and `toast`
+  remain deferred
+- WHEN a file under any of their `src/**` imports `from 'element-plus'`
+- THEN ESLint reports no error
+
+## ADDED Requirements
+
+### Requirement: v6-exclude-removed-per-work-unit
+
+Each of the 8 v6-migrated packages' `excludedFiles` entries MUST be removed
+individually, at that package's own migration work unit boundary, not
+batched. `config-provider`'s entry MUST be the last one removed, after every
+other v6 island's entry, matching the proposal's sequencing (config-provider
+gates root EP removal).
+
+#### Scenario: lint passes at each package's guard update
+
+- GIVEN one of the 8 v6 packages finishes migration and its unit tests are
+  green
+- WHEN `.eslintrc.cjs` is updated to remove that package's exclude
+- THEN `yarn lint --max-warnings 0` passes immediately after that update,
+  before the next package's work unit starts
+
+#### Scenario: config-provider exclude removed last
+
+- GIVEN the other 7 v6 packages already removed from `excludedFiles`
+- WHEN `config-provider`'s exclude entry is removed
+- THEN it is the final `excludedFiles` edit among the 8, immediately
+  preceding root `element-plus` removal

--- a/openspec/changes/ep-extraction-v6/specs/scss-token-foundation/spec.md
+++ b/openspec/changes/ep-extraction-v6/specs/scss-token-foundation/spec.md
@@ -1,0 +1,42 @@
+# Delta for scss-token-foundation
+
+> Artifact store: hybrid. Change: `ep-extraction-v6`. Base spec:
+> `openspec/specs/scss-token-foundation/spec.md`.
+
+## MODIFIED Requirements
+
+### Requirement: Entangled Islands Remain Deferred
+
+The 6 previously-deferred entangled islands (`badge`, `menu`, `popover`,
+`radio-group`, `form-item`, `skeleton`) are migrated off `element-plus` in
+`ep-extraction-v6`. Their full-component stylesheets MUST now be DS-owned
+(no `element-plus` `@use`/`@forward` reference), and MUST preserve
+byte-exact CSS parity per this spec's Byte-Exact CSS Parity requirement.
+(Previously: deferred these 6 islands' full stylesheets, only allowing their
+shared-mixin dependency to be repointed when byte-exact.)
+
+#### Scenario: Previously-deferred island stylesheet fully migrated
+
+- GIVEN one of the 6 previously-deferred islands
+- WHEN its `.scss` is migrated in `ep-extraction-v6`
+- THEN it contains no `element-plus` reference and compiles to byte-identical
+  CSS versus its pre-migration output
+
+## ADDED Requirements
+
+### Requirement: Config-Provider Owns Brand Emission (Closes Task 4.5)
+
+config-provider's JS bridge retirement (`provideGlobalConfig`) in
+`ep-extraction-v6` MUST complete this spec's deferred brand-color emission
+task: DS-owned code MUST be the sole source of brand-color `--gui-*` custom
+properties, with no `element-plus` fallback path remaining anywhere in the
+emission chain.
+
+#### Scenario: Deferred brand-emission task closed
+
+- GIVEN config-provider fully migrated off element-plus in
+  `ep-extraction-v6`
+- WHEN brand-color `--gui-*` custom properties are generated
+- THEN they are emitted entirely by DS-owned code, with zero element-plus
+  involvement, satisfying the task deferred at `scss-token-foundation`
+  archival

--- a/openspec/changes/ep-extraction-v6/tasks.md
+++ b/openspec/changes/ep-extraction-v6/tasks.md
@@ -1,0 +1,131 @@
+# Tasks: ep-extraction-v6 — Close out the element-plus removal
+
+## Review Workload Forecast
+
+| Field                   | Value                                                                    |
+| ----------------------- | ------------------------------------------------------------------------ |
+| Estimated changed lines | ~2,150–3,600 total across 12 units (see per-unit table)                  |
+| 400-line budget risk    | High                                                                     |
+| Chained PRs recommended | Yes                                                                      |
+| Suggested split         | WU1 → WU2 → ... → WU12, one PR per work unit, in design order            |
+| Delivery strategy       | ask-on-risk (orchestrator asks user before apply)                        |
+| Chain strategy          | pending — user decision needed (stacked-to-main vs feature-branch-chain) |
+
+Decision needed before apply: Yes
+Chained PRs recommended: Yes
+Chain strategy: pending
+400-line budget risk: High
+
+### Per-Unit Estimate
+
+| WU  | Unit                                                        | Est. lines | Risk     | Notes                              |
+| --- | ----------------------------------------------------------- | ---------- | -------- | ---------------------------------- |
+| 1   | badge                                                       | 150–250    | Low      | self-contained                     |
+| 2   | radio-group                                                 | 200–350    | Low-Med  | + latent bug fix                   |
+| 3   | skeleton + skeleton-item                                    | 250–400    | Med      | 2 components, near budget          |
+| 4   | infinite-scroll                                             | 150–250    | Low      | new directive, isolated            |
+| 5   | form-item                                                   | 250–400    | Med      | validation core coupling           |
+| 6   | popover                                                     | 300–450    | Med-High | 3 composables re-pointed           |
+| 7   | menu (×4)                                                   | 500–800    | **High** | exceeds 400 alone — see flag below |
+| 8   | time-picker clearIcon default                               | 20–50      | Low      | 2-line prop change only            |
+| 9   | config-provider (+ SCSS task 4.5 + time-picker `@use` drop) | 200–350    | Med      | gates root removal                 |
+| 10  | root removal + g-hooks test cleanup + eslintrc final entry  | 50–150     | Low      |                                    |
+| 11  | front-b2b 8× version bumps                                  | 20–60      | Low      | mechanical                         |
+| 12  | front-b2b EP removal                                        | 10–30      | Low      | mechanical                         |
+
+**Flag**: WU7 (menu family) is estimated at 500–800 changed lines even as its own isolated PR, above the 400-line budget by design (one shared context module + 4 components + provide/inject tests cannot be safely split without breaking the symbol-identity handshake, per Design Decision 1). Options for the user to decide: (a) accept `size:exception` for WU7 only, (b) split WU7 into parent (Menu + context module) then children (MenuItem/MenuSub/MenuItemGroup) as two chained sub-PRs sharing the WU7 branch, or (c) proceed as-is and rely on reviewer discretion. This is flagged, not decided, per `ask-on-risk`.
+
+Every WU below includes, per unit convention (do not skip for any unit 1–9): strict-TDD test-first implementation, `yarn test:run` green, ESLint `excludedFiles` removal for that package, byte/behavior parity check, and mandatory live `yarn-link` validation in `../front-b2b` before marking the unit done.
+
+## WU1: badge (PR 1)
+
+- [x] 1.1 Write failing tests in `components/badge/tests/Badge.spec.ts` for native render (props/slots/emits parity vs current `ElBadge` usage) — 17 tests, RED confirmed against old EL-wrapped Badge.vue (revealed a pre-existing gap: outside a ConfigProvider it rendered `el-badge*`, not `gui-badge*`)
+- [x] 1.2 Rewrite `components/badge/Badge.vue` as native `GBadge` template (remove `ElBadge` import) — uses `useNamespace('badge')` from `@flash-global66/g-utils`
+- [x] 1.3 Port `components/badge/badge.styles.scss` to DS-owned styles (byte-exact parity vs current compiled CSS) — re-pointed `@use` to `@flash-global66/g-utils/{mixins,var-mixins,tokens}`, selectors/values preserved byte-exact; `$badge` token map already existed in g-utils/styles/tokens.scss from ep-extraction-scss
+- [x] 1.4 Remove `components/badge/**` from `.eslintrc.cjs` excludedFiles; `yarn lint --max-warnings 0` green — also widened the guard's `files` glob to include `components/*/*.vue` (flat-layout root .vue files were not previously matched, so the exclude removal alone would have been a no-op for badge)
+- [x] 1.5 `yarn test:run` green (17/17 badge, 362/362 full suite); yarn-link validate live in `../front-b2b` deferred — human-in-the-loop step per orchestrator scope for this isolated worktree, pending before PR merge
+
+## WU2: radio-group (PR 2)
+
+- [ ] 2.1 Write failing tests in `components/radio-group/tests/RadioGroup.spec.ts` for provide/inject (value/size/disabled) + native `role=radiogroup` render
+- [ ] 2.2 Create `components/radio-group/radio.type.ts` (or inline) defining `TypeRadioSize`/`EnumRadioSize` — fixes latent missing-file bug from `RadioGroup.vue:15`
+- [ ] 2.3 Rewrite `components/radio-group/RadioGroup.vue` as native `<div role="radiogroup">` + own context key (remove `ElRadioGroup`)
+- [ ] 2.4 Remove `components/radio-group/**` from `.eslintrc.cjs` excludedFiles; `yarn lint --max-warnings 0` green
+- [ ] 2.5 `yarn test:run` green; yarn-link validate live in `../front-b2b`
+
+## WU3: skeleton + skeleton-item (PR 3)
+
+- [ ] 3.1 Write failing tests in `components/skeleton/tests/Skeleton.spec.ts` and `SkeletonItem.spec.ts` for template/animation-state parity
+- [ ] 3.2 Rewrite `components/skeleton/Skeleton.vue` and `SkeletonItem.vue` as native templates (remove `ElSkeleton`/`ElSkeletonItem`)
+- [ ] 3.3 Port `components/skeleton/skeleton.styles.scss` and `skeleton-item.styles.scss` (byte-exact animation-state parity)
+- [ ] 3.4 Remove `components/skeleton/**` from `.eslintrc.cjs` excludedFiles; `yarn lint --max-warnings 0` green
+- [ ] 3.5 `yarn test:run` green; yarn-link validate live in `../front-b2b`
+
+## WU4: infinite-scroll (PR 4)
+
+- [ ] 4.1 Write failing tests for the ported directive's scroll-trigger/disabled/distance behavior
+- [ ] 4.2 Port EP's `v-infinite-scroll` directive from scratch into `components/infinite-scroll` (replace bare `ElInfiniteScroll` re-export)
+- [ ] 4.3 Export the DS directive from `components/infinite-scroll/index.ts`
+- [ ] 4.4 Remove `components/infinite-scroll/**` from `.eslintrc.cjs` excludedFiles; `yarn lint --max-warnings 0` green
+- [ ] 4.5 `yarn test:run` green; yarn-link validate live in `../front-b2b`
+
+## WU5: form-item (PR 5)
+
+- [ ] 5.1 Write failing tests in `components/form-item/tests/FormItem.spec.ts` for validation wiring via DS `g-form` context
+- [ ] 5.2 Rewrite `components/form-item/FormItem.vue` as ported `ElFormItem` template over DS `g-form` validation core (remove `ElFormItem`)
+- [ ] 5.3 Re-point to DS `formContextKey`/`formItemContextKey` (g-form)
+- [ ] 5.4 Remove `components/form-item/**` from `.eslintrc.cjs` excludedFiles; `yarn lint --max-warnings 0` green
+- [ ] 5.5 `yarn test:run` green; yarn-link validate live in `../front-b2b`
+
+## WU6: popover (PR 6)
+
+- [ ] 6.1 Write failing tests in `components/popover/tests/Popover.spec.ts` for slot/reference-forwarding parity onto `g-tooltip`
+- [ ] 6.2 Port `components/popover/Popover.vue` from EP `popover.vue`, rendering `<g-tooltip>` internally (remove `ElPopover`)
+- [ ] 6.3 Re-point `useTooltipTriggerProps`/`useTooltipContentProps` to `@flash-global66/g-tooltip`; `dropdownProps` to `@flash-global66/g-dropdown`
+- [ ] 6.4 Remove `components/popover/**` from `.eslintrc.cjs` excludedFiles; `yarn lint --max-warnings 0` green
+- [ ] 6.5 `yarn test:run` green; yarn-link validate live in `../front-b2b`
+
+## WU7: menu family — Menu/MenuItem/MenuSub/MenuItemGroup (PR 7)
+
+- [ ] 7.1 Write failing tests for provide/inject handshake (open/close/select/collapse) across all 4 components
+- [ ] 7.2 Create one shared context module (`menuContextKey`/`subMenuContextKey`) imported by parent and descendants (Design Decision 1 — do not split symbols)
+- [ ] 7.3 Port `components/menu/Menu.vue` off `ElMenu` onto the shared context module
+- [ ] 7.4 Port `components/menu/MenuItem.vue`, `MenuSub.vue`, `MenuItemGroup.vue` off `ElMenuItem`/`ElMenuSub`/`ElMenuItemGroup`
+- [ ] 7.5 Remove `components/menu/**` from `.eslintrc.cjs` excludedFiles; `yarn lint --max-warnings 0` green
+- [ ] 7.6 `yarn test:run` green; yarn-link validate live in `../front-b2b` (exercise nested submenu + item-group scenarios)
+
+## WU8: time-picker clearIcon default fix (PR 8)
+
+- [ ] 8.1 Write failing test asserting `clearIcon` defaults to `true` in `components/time-picker/src/common/props.ts`
+- [ ] 8.2 Edit `components/time-picker/src/common/props.ts:4` — delete `import { CircleClose } from '@element-plus/icons-vue'`
+- [ ] 8.3 Edit `components/time-picker/src/common/props.ts:88-91` — `clearIcon` default becomes `true` (boolean); keep type `string | Component` (no breaking prop-type change); leave `picker.vue` untouched
+- [ ] 8.4 `yarn test:run` green; yarn-link validate live in `../front-b2b`
+
+## WU9: config-provider — LAST DS unit (PR 9)
+
+- [ ] 9.1 Write failing tests for `provideGlobalConfig`-from-g-hooks context shape parity (dialog `namespace='gui'`; `emptyValues` consumers untouched — Design Decision 2)
+- [ ] 9.2 Edit `components/config-provider/ConfigProvider.vue` — call DS `provideGlobalConfig({ namespace: 'gui' })` from g-hooks; keep `provide(namespaceContextKey, 'gui')`; remove EP `provideGlobalConfig` import
+- [ ] 9.3 Switch `components/config-provider/config.styles.scss` to DS-owned brand-color `--gui-*` emission (closes scss-token-foundation task 4.5); zero element-plus involvement
+- [ ] 9.4 Drop `@use "element-plus/theme-chalk/src/base.scss"` from `components/time-picker/src/common/time-picker.styles.scss` (now safe — config-provider owns brand emission)
+- [ ] 9.5 Remove `components/config-provider/**` from `.eslintrc.cjs` excludedFiles — MUST be the last of the 8 v6 exclude removals
+- [ ] 9.6 `yarn test:run` green; yarn-link validate live in `../front-b2b`; confirm dialog and time-picker rendering unchanged
+
+## WU10: root element-plus removal + g-hooks cleanup (PR 10)
+
+- [ ] 10.1 Gate check: `grep -rE "from ['\"](element-plus|@element-plus/icons-vue)"` across `components/**/src` and `components/**/index.ts` returns zero matches
+- [ ] 10.2 Remove `"element-plus": "2.9.7"` from root `package.json:62`; prune `yarn.lock`
+- [ ] 10.3 Edit `common/g-hooks/tests/composables/useGlobalConfig.spec.ts:5` — remove `import { configProviderContextKey } from 'element-plus'`; adjust the "no coupling" assertion to compare against the DS key only
+- [ ] 10.4 Confirm `.eslintrc.cjs` excludedFiles no longer lists any of the 8 v6 packages
+- [ ] 10.5 `yarn install` and `yarn build` succeed with zero `element-plus` resolution workspace-wide; `yarn test:run` green
+
+## WU11: front-b2b version bumps (PR 11)
+
+- [ ] 11.1 Bump `../front-b2b/package.json` deps to published Lerna versions: `g-badge`, `g-config-provider`, `g-form-item`, `g-infinite-scroll`, `g-menu`, `g-popover`, `g-skeleton`, `g-time-picker` (NOT `g-radio-group`)
+- [ ] 11.2 `yarn install` in `../front-b2b`; confirm no unpublished/local-only version is pinned
+- [ ] 11.3 Build `../front-b2b`; confirm no regression in the 8 migrated components' consuming screens
+
+## WU12: front-b2b element-plus removal (PR 12)
+
+- [ ] 12.1 Remove `"element-plus": "2.9.7"` from `../front-b2b/package.json:110`
+- [ ] 12.2 Remove the `element-plus` entry from `../front-b2b/vite.config.ts:102` `optimizeDeps.include`
+- [ ] 12.3 `yarn install` and build `../front-b2b`; confirm zero `element-plus` resolution and no regressions


### PR DESCRIPTION
## Summary
Work Unit 1 of 12 for `ep-extraction-v6` — the closing chapter of the element-plus removal initiative (v2–v5 + ep-extraction-scss already archived). This unit migrates `badge` off `element-plus`, the smallest/lowest-risk island, establishing the pattern for the remaining 11 units.

- `Badge.vue` rewritten as a native template (no `ElBadge`/`element-plus` import), byte-faithful to the original prop/slot/emit contract (value, max, isDot, hidden, type, showZero, color, badgeStyle, offset, badgeClass).
- `badge.styles.scss` ported byte-exact off `element-plus/theme-chalk`, re-pointed to `@flash-global66/g-utils` (mixins/var-mixins/tokens) — the `$badge` token map already existed there from the earlier SCSS migration.
- `badge` removed from `.eslintrc.cjs`'s element-plus-import-guard `excludedFiles`; widened the guard's `files` glob to also cover `components/*/*.vue` (previously only matched `.ts`, so flat-layout `.vue` files were never actually enforced).
- Behavior note: Badge now always resolves the `gui-` namespace via `useNamespace`, regardless of `ConfigProvider` ancestor (previously fell back to `el-` outside one) — verified this doesn't affect any known consumer (front-b2b always wraps in `ConfigProvider`; front-admin doesn't use `GBadge`) and added an explicit test locking in the new contract.
- Fixed a real compile-time bug surfaced during review: a duplicate `persisted` attribute on the `<transition>` (Vue auto-injects it due to the internal `v-show`; the literal attribute caused a `vue-tsc` TS1117 error, invisible today only because `badge` isn't yet marked `buildable` in its package.json).

Reviewed by two independent adversarial passes (judgment-day) before this PR — both confirmed no functional regressions; the findings above were folded in.

## Test plan
- [x] `yarn vitest run components/badge/tests/Badge.spec.ts` — 18/18 passing
- [x] Full suite — no regressions
- [x] `npx vue-tsc --noEmit -p .` — clean on Badge.vue
- [x] `eslint --max-warnings 0` on changed files
- [ ] Manual `yarn link` validation in `front-b2b` (pending — will validate live render before merge, per project convention)