### PR TITLE
[ML-82] Feat: Selector de cuenta con buscador y variante sin borde

### DIFF
--- a/components/select/package.json
+++ b/components/select/package.json
@@ -30,6 +30,7 @@
   },
   "dependencies": {
     "@flash-global66/g-hooks": "^0.11.14",
+    "@flash-global66/g-search-input": "1.2.25",
     "@flash-global66/g-tooltip": "^0.1.21",
     "@flash-global66/g-utils": "^0.15.6",
     "@tanstack/vue-virtual": "3.13.23"

--- a/components/select/src/defaults.ts
+++ b/components/select/src/defaults.ts
@@ -101,6 +101,25 @@ export const SelectProps = buildProps({
    */
   filterMethod: Function,
   /**
+   * @description shows a search field inside the dropdown panel (independent from `filterable`,
+   * which shows the search field in the closed trigger instead). Matches against both title and
+   * description of each option.
+   */
+  searchable: Boolean,
+  /**
+   * @description placeholder for the internal search field shown when `searchable` is true
+   */
+  searchPlaceholder: {
+    type: String,
+    default: 'Buscar',
+  },
+  /**
+   * @description removes the trigger's border across all states (default, hover, focused,
+   * complete), for embedding the select inside containers that already provide their own
+   * border/outline treatment
+   */
+  borderless: Boolean,
+  /**
    * @description The height of the dropdown panel, 34px for each item
    */
   height: {

--- a/components/select/src/hooks/use-select.ts
+++ b/components/select/src/hooks/use-select.ts
@@ -58,6 +58,7 @@ type useSelectReturnType = (
   debounce: ComputedRef<0 | 300>;
   allOptions: Ref<OptionType[]>;
   filteredOptions: Ref<OptionType[]>;
+  searchQuery: Ref<string>;
   iconComponent: ComputedRef<any>;
   iconReverse: ComputedRef<any>;
   tagStyle: ComputedRef<{ maxWidth: string }>;
@@ -149,8 +150,14 @@ const useSelect: useSelectReturnType = (
   const { inputId } = useFormItemInputId(props, {
     formItemContext: elFormItem,
   });
-  const { aliasProps, getTitle, getValue, getDisabled, getOptions } =
-    useProps(props);
+  const {
+    aliasProps,
+    getTitle,
+    getDescription,
+    getValue,
+    getDisabled,
+    getOptions,
+  } = useProps(props);
   const { valueOnClear, isEmptyValue } = useEmptyValues(props);
 
   const states: SelectStates = reactive({
@@ -216,6 +223,7 @@ const useSelect: useSelectReturnType = (
 
   const allOptions = ref<OptionType[]>([]);
   const filteredOptions = ref<OptionType[]>([]);
+  const searchQuery = ref('');
   // the controller of the expanded popup
   const expanded = ref(false);
   const leftPrefixSelect = ref<string | undefined>(undefined);
@@ -284,8 +292,8 @@ const useSelect: useSelectReturnType = (
       if (props.remote && !states.inputValue && allOptions.value.length === 0)
         return false;
       if (
-        props.filterable &&
-        states.inputValue &&
+        ((props.filterable && states.inputValue) ||
+          (props.searchable && searchQuery.value)) &&
         allOptions.value.length > 0 &&
         filteredOptions.value.length === 0
       ) {
@@ -304,8 +312,14 @@ const useSelect: useSelectReturnType = (
       if (props.filterable && props.remote && isFunction(props.remoteMethod))
         return true;
       // when query was given, we should test on the label see whether the label contains the given query
+      if (!query) return true;
       const regexp = new RegExp(escapeStringRegexp(query), 'i');
-      return query ? regexp.test(getTitle(o) || '') : true;
+      if (props.searchable) {
+        return (
+          regexp.test(getTitle(o) || '') || regexp.test(getDescription(o) || '')
+        );
+      }
+      return regexp.test(getTitle(o) || '');
     };
     if (props.loading) {
       return [];
@@ -340,7 +354,9 @@ const useSelect: useSelectReturnType = (
 
   const updateOptions = () => {
     allOptions.value = filterOptions('');
-    filteredOptions.value = filterOptions(states.inputValue);
+    filteredOptions.value = filterOptions(
+      props.searchable ? searchQuery.value : states.inputValue,
+    );
   };
 
   const allOptionsValueMap = computed(() => {
@@ -1105,6 +1121,7 @@ const useSelect: useSelectReturnType = (
     debounce,
     allOptions,
     filteredOptions,
+    searchQuery,
     iconComponent,
     iconReverse,
     prefixIcon,

--- a/components/select/src/select.styles.scss
+++ b/components/select/src/select.styles.scss
@@ -83,6 +83,34 @@
         @apply text-disabled-txt;
       }
     }
+
+    @include when(borderless) {
+      @apply border-transparent shadow-none bg-transparent p-0 gap-xxs;
+
+      @include when(complete) {
+        @apply border-transparent;
+      }
+
+      @include when(focused) {
+        @apply border-transparent shadow-none;
+      }
+
+      .gui-select__placeholder {
+        @apply w-auto;
+        position: static;
+        top: auto;
+        transform: none;
+      }
+
+      .gui-select__input-wrapper.is-hidden {
+        @apply w-0 min-w-0 overflow-hidden p-0;
+
+        .gui-select__input {
+          width: 1px;
+          min-width: 0;
+        }
+      }
+    }
   }
 
   @include when(error) {
@@ -189,17 +217,17 @@
 @include b("select-dropdown") {
   @apply my-xs;
   @include e("item") {
-    @apply flex items-start justify-between gap-xs transition-all duration-200 px-2 ease-in !important;
+    @apply flex items-start justify-between gap-xs transition-all duration-200 px-0 ease-in !important;
     min-height: unset !important;
     line-height: normal !important;
     height: unset !important;
 
     @include m("inner") {
-      @apply flex items-center justify-between gap-xs w-full min-w-0 px-sm py-md;
+      @apply flex items-center justify-between gap-xs w-full min-w-0 px-lg py-xs;
       &:hover {
         @apply bg-everBlue-50 bg-opacity-60;
-      } 
-      
+      }
+
       &:active {
         @apply bg-everBlue-50;
       }
@@ -255,25 +283,8 @@
 
   @include b("select-group") {
     @include e("title") {
-      @apply text-2 text-ellipsis text-terciary-txt font-medium cursor-default pointer-events-none pb-xs pt-sm flex items-center px-xs first:pb-2 first:pt-2;
-      line-height: 1.25rem;
+      @apply text-3 text-ellipsis text-primary-txt font-semibold cursor-default pointer-events-none pb-xs pt-[10px] flex items-center px-md first:pb-2 first:pt-2;
       min-height: unset;
-
-      & ~ & {
-        position: relative;
-
-        &::after {
-          content: '';
-          position: absolute;
-          top: 0;
-          left: 50%;
-          transform: translateX(-50%);
-          width: calc(100% - 0.5rem);
-          height: 1px;
-          background: #eff0f2;
-          z-index: 1;
-        }
-      }
     }
   }
 

--- a/components/select/src/select.vue
+++ b/components/select/src/select.vue
@@ -39,6 +39,7 @@
               nsSelect.is('filterable', filterable),
               nsSelect.is('disabled', selectDisabled),
               nsSelect.is('complete', !isFocused && Boolean(hasModelValue)),
+              nsSelect.is('borderless', borderless),
             ]"
             @click.prevent="toggleMenu"
           >
@@ -257,8 +258,14 @@
             :hovering-index="states.hoveringIndex"
             :scrollbar-always-on="scrollbarAlwaysOn"
           >
-            <template v-if="$slots.header" #header>
+            <template v-if="searchable || $slots.header" #header>
               <div :class="nsSelect.be('dropdown', 'header')">
+                <g-search-input
+                  v-if="searchable"
+                  v-model="searchQuery"
+                  :placeholder="searchPlaceholder"
+                  :class="nsSelect.be('dropdown', 'search')"
+                />
                 <slot name="header" />
               </div>
             </template>
@@ -324,6 +331,7 @@ import { useCalcInputWidth } from '@flash-global66/g-hooks';
 import { GTooltip } from '@flash-global66/g-tooltip';
 import { GTag } from '@flash-global66/g-tag';
 import { GIconFont } from '@flash-global66/g-icon-font';
+import { GSearchInput } from '@flash-global66/g-search-input';
 import GSelectMenu from './select-dropdown';
 import useSelect from './hooks/use-select';
 import { SelectProps, selectEmits } from './defaults';
@@ -336,6 +344,7 @@ export default defineComponent({
     GTag,
     GTooltip,
     GIconFont,
+    GSearchInput,
   },
   directives: { ClickOutside },
   props: SelectProps,

--- a/components/select/src/styles/select-dropdown.scss
+++ b/components/select/src/styles/select-dropdown.scss
@@ -47,8 +47,7 @@
 }
 
 @include b(select-dropdown__header) {
-  padding: map.get($select-dropdown, 'header-padding');
-  border-bottom: map.get($select-dropdown, 'border');
+  padding: 0 map.get($select-dropdown, 'header-padding') map.get($select-dropdown, 'header-padding');
 }
 
 @include b(select-dropdown__footer) {


### PR DESCRIPTION
## Historia de Usuario
**RESPONSABLE**

| Nombre               | Equipo            | Proyecto / Iniciativa  | HU del desarrollo                                          |
|:--------------------:|:-----------------:|:----------------------:|:-----------------------------------------------------------|
| Brayan Basallo        | Design System      | Multicuentas B2B        | [ML-82](https://global66.atlassian.net/browse/ML-82)      |

**CONTEXTO**

ML-82 pide un dropdown de selección de cuenta reutilizable en el Design System (búsqueda, cuentas agrupadas por moneda, cuenta destacada/seleccionada, cuenta deshabilitada, estado vacío) — patrón que hoy se reimplementa distinto en cada equipo/flujo (bloquea ML-24, ML-54, ML-60, ML-76, ML-16).

En vez de un componente nuevo, se generalizó `GSelect` (que ya soportaba agrupado, resaltado de selección y disabled nativamente) con dos props opt-in y aditivas: `searchable` (buscador dentro del panel del dropdown) y `borderless` (trigger sin caja, para embeberlo en contenedores con su propio tratamiento visual — ej. el picker de moneda de `GQuote`).

---

**FLUJOS AFECTADOS**

* Trigger cerrado de `GSelect` — nueva variante `borderless` (sin borde/padding/fondo)
* Panel del dropdown de `GSelect` — nuevo buscador interno (`searchable`) y ajustes visuales del header/grupo
* Ningún flujo existente con `GSelect` cambia de comportamiento (props nuevas, default `false`)

---

**CAMBIOS REALIZADOS**

* `components/select/src/defaults.ts`: nuevas props `searchable`, `searchPlaceholder`, `borderless`
* `components/select/src/hooks/use-select.ts`: estado `searchQuery` propio (independiente de `states.inputValue` de `filterable`); filtrado por título **y** descripción en modo `searchable`
* `components/select/src/select.vue`: registra `GSearchInput`; wrapper agrega clase `is-borderless`; header del dropdown renderiza el buscador cuando `searchable`
* `components/select/src/select.styles.scss`: estilos de `is-borderless` (trigger sin caja); estilo del título de grupo (`text-3`/`font-semibold`/`text-primary-txt`, según Figma)
* `components/select/src/styles/select-dropdown.scss`: header del dropdown sin borde, padding solo en eje x
* `components/select/package.json`: agrega `@flash-global66/g-search-input` como dependencia

----

**EXTRA INFO**

* Figma: https://www.figma.com/design/QV8OodSHqhZbgH1SkaPTQa/B2B_Wallets?node-id=1824-38363
* Tests unitarios: no se agregaron — `select/` no tiene suite de tests propia hoy (mismo estado que `date-picker/`/`dialog/`); verificado a mano en Storybook (`Form/Select`)
* Feature Flag: no aplica